### PR TITLE
Use built-in APIs for file picker HWND interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Developers also have the flexibility to implement their own export functionality
 - [CommunityToolkit.WinUI.Converters](https://www.nuget.org/packages/CommunityToolkit.WinUI.Converters/)
 - [CommunityToolkit.WinUI.Helpers](https://www.nuget.org/packages/CommunityToolkit.WinUI.Helpers/)
 - [Microsoft.WindowsAppSDK](https://www.nuget.org/packages/Microsoft.WindowsAppSDK/)
-- [WinUIEx](https://www.nuget.org/packages/WinUIEx/)
 
 ### Contributing
 We welcome contributions from the community! If you find any issues or have suggestions for improvements, please submit them through the GitHub issue tracker or consider making a pull request.

--- a/src/WinUI.TableView/TableView.cs
+++ b/src/WinUI.TableView/TableView.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Animations.Expressions;
 using CommunityToolkit.WinUI.Collections;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
@@ -20,7 +21,6 @@ using Windows.Storage;
 using Windows.Storage.Pickers;
 using WinRT.Interop;
 using WinUI.TableView.Extensions;
-using WinUIEx;
 
 namespace WinUI.TableView;
 public class TableView : ListView
@@ -270,7 +270,7 @@ public class TableView : ListView
 
         try
         {
-            var hWnd = HwndExtensions.GetActiveWindow();
+            var hWnd = Win32Interop.GetWindowFromWindowId(XamlRoot.ContentIslandEnvironment.AppWindowId);
             if (await GetStorageFile(hWnd) is not { } file)
             {
                 return;
@@ -303,7 +303,7 @@ public class TableView : ListView
 
         try
         {
-            var hWnd = HwndExtensions.GetActiveWindow();
+            var hWnd = Win32Interop.GetWindowFromWindowId(XamlRoot.ContentIslandEnvironment.AppWindowId);
             if (await GetStorageFile(hWnd) is not { } file)
             {
                 return;

--- a/src/WinUI.TableView/WinUI.TableView.csproj
+++ b/src/WinUI.TableView/WinUI.TableView.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.0.240109" />
     <PackageReference Include="CommunityToolkit.WinUI.Helpers" Version="8.0.240109" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
-    <PackageReference Include="WinUIEx" Version="2.3.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This replaces the call to WinUIEx’s `GetActiveWindow` with the content island environment API in WinUI 3. This increases correctness by ensuring the window handle is the window associated with the table view (in case that window is not focused when this call is made). It also reduces complexity by removing a dependency, as WinUIEx is not needed for anything with this change.