### PR TITLE
Replace filter list ScrollView with ScrollViewer

### DIFF
--- a/src/WinUI.TableView/Themes/Generic.xaml
+++ b/src/WinUI.TableView/Themes/Generic.xaml
@@ -183,8 +183,9 @@
                                                                       IsThreeState="True"
                                                                       Content="(Select All)" />
                                                         </Border>
-                                                        <ScrollView Grid.Row="2"
-                                                                    Padding="12,0">
+                                                        <ScrollViewer Grid.Row="2"
+                                                                      Padding="12,0"
+                                                                      VerticalScrollMode="Enabled">
                                                             <ItemsControl ItemsSource="{Binding FilterItems}">
                                                                 <ItemsControl.ItemTemplate>
                                                                     <DataTemplate>
@@ -195,7 +196,7 @@
                                                                     </DataTemplate>
                                                                 </ItemsControl.ItemTemplate>
                                                             </ItemsControl>
-                                                        </ScrollView>
+                                                        </ScrollViewer>
                                                     </Grid>
                                                 </ControlTemplate>
                                             </MenuFlyoutItem.Template>


### PR DESCRIPTION
The filter list uses a `ScrollView` control to scroll its items. As the `ScrollView` control is quite new and has some known issues (blurry text and inconsistent speed), I suggest using the more mature `ScrollViewer` as none of the new features from `ScrollView` are required here.