### PR TITLE
Apply filter to the whole value instead of just the start

### DIFF
--- a/src/WinUI.TableView/TableViewColumnHeader.cs
+++ b/src/WinUI.TableView/TableViewColumnHeader.cs
@@ -226,7 +226,7 @@ public partial class TableViewColumnHeader : ContentControl
 
 
                 return string.IsNullOrEmpty(_filterText)
-                      || value?.ToString()?.StartsWith(_filterText, StringComparison.OrdinalIgnoreCase) == true
+                      || value?.ToString()?.Contains(_filterText, StringComparison.OrdinalIgnoreCase) == true
                       ? new FilterItem(isSelected, value, _optionsFlyoutViewModel)
                       : null;
 


### PR DESCRIPTION
I assume that in many cases it may be more useful to filter using 'Contains' then using 'StartWith".

![TableView_Filter](https://github.com/w-ahmad/WinUI.TableView/assets/9828352/5e761908-5218-4bb7-a41b-cae2f5b2123e)
