### PR TITLE
Avoid negative MaxWidth values

### DIFF
--- a/src/WinUI.TableView/TableViewCell.cs
+++ b/src/WinUI.TableView/TableViewCell.cs
@@ -40,7 +40,10 @@ public class TableViewCell : ContentControl
             contentWidth -= BorderThickness.Left;
             contentWidth -= BorderThickness.Right;
 
-            element.MaxWidth = contentWidth;
+            if (contentWidth > 0)
+            {
+                element.MaxWidth = contentWidth;
+            }
 
             if (Column is not null)
             {


### PR DESCRIPTION
TableViewCell _MeasureOverride_ can be called by the platform before the control is rendered. This happens for example when the _ItemsSource_ is defined declaratively and column calculations are started before the page is loaded. Your sample app doesn't experience this, since it waits for a _Loaded_ event from its hosting grid. 

When _MeasureOverride_ is called on a tableview that is not yet rendered, then _Column.ActualWidth_ is still zero, and the element is given a negative _MaxWidth_ value. This causes the app to crash.

![NegativeMaxWidth](https://github.com/user-attachments/assets/55d673c5-37eb-45d3-8335-f379384c0d29)
