### PR TITLE
Add Horizontal and Vertical Grid Lines

### DIFF
--- a/src/WinUI.TableView/TableView.Properties.cs
+++ b/src/WinUI.TableView/TableView.Properties.cs
@@ -1,11 +1,10 @@
 ﻿using CommunityToolkit.WinUI.Collections;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace WinUI.TableView;
 public partial class TableView
@@ -25,6 +24,12 @@ public partial class TableView
     public static readonly DependencyProperty MinColumnWidthProperty = DependencyProperty.Register(nameof(MinColumnWidth), typeof(double), typeof(TableView), new PropertyMetadata(50d, OnMinColumnWidthChanged));
     public static readonly DependencyProperty MaxColumnWidthProperty = DependencyProperty.Register(nameof(MaxColumnWidth), typeof(double), typeof(TableView), new PropertyMetadata(double.PositiveInfinity, OnMaxColumnWidthChanged));
     public static readonly DependencyProperty SelectionUnitProperty = DependencyProperty.Register(nameof(SelectionUnit), typeof(TableViewSelectionUnit), typeof(TableView), new PropertyMetadata(TableViewSelectionUnit.CellOrRow, OnSelectionUnitChanged));
+    public static readonly DependencyProperty HeaderGridLinesVisibilityProperty = DependencyProperty.Register(nameof(HeaderGridLinesVisibility), typeof(TableViewGridLinesVisibility), typeof(TableView), new PropertyMetadata(TableViewGridLinesVisibility.All, OnGridLinesPropertyChanged));
+    public static readonly DependencyProperty GridLinesVisibilityProperty = DependencyProperty.Register(nameof(GridLinesVisibility), typeof(TableViewGridLinesVisibility), typeof(TableView), new PropertyMetadata(TableViewGridLinesVisibility.All, OnGridLinesPropertyChanged));
+    public static readonly DependencyProperty HorizontalGridLinesStrokeThicknessProperty = DependencyProperty.Register(nameof(HorizontalGridLinesStrokeThickness), typeof(double), typeof(TableView), new PropertyMetadata(1d, OnGridLinesPropertyChanged));
+    public static readonly DependencyProperty VerticalGridLinesStrokeThicknessProperty = DependencyProperty.Register(nameof(VerticalGridLinesStrokeThickness), typeof(double), typeof(TableView), new PropertyMetadata(1d, OnGridLinesPropertyChanged));
+    public static readonly DependencyProperty HorizontalGridLinesStrokeProperty = DependencyProperty.Register(nameof(HorizontalGridLinesStroke), typeof(Brush), typeof(TableView), new PropertyMetadata(default, OnGridLinesPropertyChanged));
+    public static readonly DependencyProperty VerticalGridLinesStrokeProperty = DependencyProperty.Register(nameof(VerticalGridLinesStroke), typeof(Brush), typeof(TableView), new PropertyMetadata(default, OnGridLinesPropertyChanged));
 
     public IAdvancedCollectionView CollectionView { get; private set; } = new AdvancedCollectionView();
     internal IDictionary<string, Predicate<object>> ActiveFilters { get; } = new Dictionary<string, Predicate<object>>();
@@ -126,6 +131,42 @@ public partial class TableView
     {
         get => (TableViewSelectionUnit)GetValue(SelectionUnitProperty);
         set => SetValue(SelectionUnitProperty, value);
+    }
+
+    public TableViewGridLinesVisibility HeaderGridLinesVisibility
+    {
+        get => (TableViewGridLinesVisibility)GetValue(HeaderGridLinesVisibilityProperty);
+        set => SetValue(HeaderGridLinesVisibilityProperty, value);
+    }
+
+    public TableViewGridLinesVisibility GridLinesVisibility
+    {
+        get => (TableViewGridLinesVisibility)GetValue(GridLinesVisibilityProperty);
+        set => SetValue(GridLinesVisibilityProperty, value);
+    }
+
+    public double VerticalGridLinesStrokeThickness
+    {
+        get => (double)GetValue(VerticalGridLinesStrokeThicknessProperty);
+        set => SetValue(VerticalGridLinesStrokeThicknessProperty, value);
+    }
+
+    public double HorizontalGridLinesStrokeThickness
+    {
+        get => (double)GetValue(HorizontalGridLinesStrokeThicknessProperty);
+        set => SetValue(HorizontalGridLinesStrokeThicknessProperty, value);
+    }
+
+    public Brush VerticalGridLinesStroke
+    {
+        get => (Brush)GetValue(VerticalGridLinesStrokeProperty);
+        set => SetValue(VerticalGridLinesStrokeProperty, value);
+    }
+
+    public Brush HorizontalGridLinesStroke
+    {
+        get => (Brush)GetValue(HorizontalGridLinesStrokeProperty);
+        set => SetValue(HorizontalGridLinesStrokeProperty, value);
     }
 
     private static void OnItemsSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -238,6 +279,14 @@ public partial class TableView
             }
 
             tableView.UpdateBaseSelectionMode();
+        }
+    }
+
+    private static void OnGridLinesPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView)
+        {
+            tableView.EnsureGridLines();
         }
     }
 

--- a/src/WinUI.TableView/TableView.cs
+++ b/src/WinUI.TableView/TableView.cs
@@ -1047,7 +1047,22 @@ public partial class TableView : ListView
 
         base.SelectionMode = SelectionUnit is TableViewSelectionUnit.Cell ? ListViewSelectionMode.None : SelectionMode;
 
+        foreach (var row in _rows)
+        {
+            row.EnsureLayout();
+        }
+
         _shouldThrowSelectionModeChangedException = false;
+    }
+
+    private void EnsureGridLines()
+    {
+        _headerRow?.EnsureGridLines();
+
+        foreach (var row in _rows)
+        {
+            row.EnsureGridLines();
+        }
     }
 
     public event EventHandler<TableViewAutoGeneratingColumnEventArgs>? AutoGeneratingColumn;
@@ -1055,6 +1070,7 @@ public partial class TableView : ListView
     public event EventHandler<TableViewExportContentEventArgs>? ExportSelectedContent;
     public event EventHandler<TableViewCopyToClipboardEventArgs>? CopyToClipboard;
     public event DependencyPropertyChangedEventHandler? IsReadOnlyChanged;
+    public event DependencyPropertyChangedEventHandler? DependencyPropertyChanged;
 
     internal event EventHandler<TableViewCellSelectionChangedEvenArgs>? SelectedCellsChanged;
     internal event EventHandler<TableViewCurrentCellChangedEventArgs>? CurrentCellChanged;

--- a/src/WinUI.TableView/TableView.cs
+++ b/src/WinUI.TableView/TableView.cs
@@ -1070,7 +1070,6 @@ public partial class TableView : ListView
     public event EventHandler<TableViewExportContentEventArgs>? ExportSelectedContent;
     public event EventHandler<TableViewCopyToClipboardEventArgs>? CopyToClipboard;
     public event DependencyPropertyChangedEventHandler? IsReadOnlyChanged;
-    public event DependencyPropertyChangedEventHandler? DependencyPropertyChanged;
 
     internal event EventHandler<TableViewCellSelectionChangedEvenArgs>? SelectedCellsChanged;
     internal event EventHandler<TableViewCurrentCellChangedEventArgs>? CurrentCellChanged;

--- a/src/WinUI.TableView/TableViewCellsPresenter.cs
+++ b/src/WinUI.TableView/TableViewCellsPresenter.cs
@@ -1,15 +1,69 @@
-﻿using Microsoft.UI.Xaml.Controls;
+﻿using CommunityToolkit.WinUI;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace WinUI.TableView;
 
-public class TableViewCellsPresenter : StackPanel
+public class TableViewCellsPresenter : Control
 {
+    private StackPanel? _stackPanel;
+    private Rectangle? _v_gridLine;
+    private Rectangle? _h_gridLine;
+
     public TableViewCellsPresenter()
     {
-        Orientation = Orientation.Horizontal;
+        DefaultStyleKey = typeof(TableViewCellsPresenter);
     }
 
-    public IList<TableViewCell> Cells => Children.OfType<TableViewCell>().ToList().AsReadOnly();
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        _stackPanel = GetTemplateChild("StackPanel") as StackPanel;
+        _v_gridLine = GetTemplateChild("VerticalGridLine") as Rectangle;
+        _h_gridLine = GetTemplateChild("HorizontalGridLine") as Rectangle;
+
+        TableViewRow = this.FindAscendant<TableViewRow>();
+        TableView = TableViewRow?.TableView;
+
+        EnsureGridLines();
+    }
+
+    internal void EnsureGridLines()
+    {
+        if (TableView is null) return;
+
+        if (_h_gridLine is not null)
+        {
+            _h_gridLine.Fill = TableView.HorizontalGridLinesStroke;
+            _h_gridLine.Height = TableView.HorizontalGridLinesStrokeThickness;
+            _h_gridLine.Visibility = TableView.GridLinesVisibility is TableViewGridLinesVisibility.All or TableViewGridLinesVisibility.Horizontal
+                                     ? Visibility.Visible : Visibility.Collapsed;
+
+            if (_v_gridLine is not null)
+            {
+                _v_gridLine.Fill = TableView.HeaderGridLinesVisibility is TableViewGridLinesVisibility.All or TableViewGridLinesVisibility.Vertical
+                                   ? TableView.VerticalGridLinesStroke : new SolidColorBrush(Colors.Transparent);
+                _v_gridLine.Width = TableView.VerticalGridLinesStrokeThickness;
+                _v_gridLine.Visibility = TableView.HeaderGridLinesVisibility is TableViewGridLinesVisibility.All or TableViewGridLinesVisibility.Vertical
+                                         || TableView.GridLinesVisibility is TableViewGridLinesVisibility.All or TableViewGridLinesVisibility.Vertical
+                                         ? Visibility.Visible : Visibility.Collapsed;
+            }
+        }
+
+        foreach (var cell in Cells)
+        {
+            cell.EnsureGridLines();
+        }
+    }
+
+    internal UIElementCollection Children => _stackPanel?.Children!;
+    public IList<TableViewCell> Cells => _stackPanel?.Children.OfType<TableViewCell>().ToList()!;
+    public TableViewRow? TableViewRow { get; private set; }
+    public TableView? TableView { get; private set; }
 }

--- a/src/WinUI.TableView/TableViewGridLinesVisibility.cs
+++ b/src/WinUI.TableView/TableViewGridLinesVisibility.cs
@@ -1,0 +1,24 @@
+﻿namespace WinUI.TableView;
+
+public enum TableViewGridLinesVisibility
+{
+    /// <summary>
+    /// Both horizontal and vertical grid lines are visible.
+    /// </summary>
+    All,
+
+    /// <summary>
+    ///  Only horizontal grid lines are visible.
+    /// </summary>
+    Horizontal,
+
+    /// <summary>
+    /// No grid lines are visible.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Only vertical grid lines are visible.
+    /// </summary>
+    Vertical
+}

--- a/src/WinUI.TableView/Themes/Generic.xaml
+++ b/src/WinUI.TableView/Themes/Generic.xaml
@@ -5,6 +5,7 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableView.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewCell.xaml" />
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewCellsPresenter.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewColumnHeader.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewHeaderRow.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewRow.xaml" />
@@ -12,7 +13,10 @@
 
     <!--Hack for auto generated resize issue-->
     <local:TableViewTextColumn x:Key="ThisNeedsToBeHere" />
-    
+
+    <Style BasedOn="{StaticResource DefaultTableViewCellsPresenterStyle}"
+           TargetType="local:TableViewCellsPresenter" />
+
     <Style TargetType="local:TableViewHeaderRow"
            BasedOn="{StaticResource DefaultTableViewHeaderRowStyle}" />
 

--- a/src/WinUI.TableView/Themes/Resources.xaml
+++ b/src/WinUI.TableView/Themes/Resources.xaml
@@ -1,0 +1,189 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="using:WinUI.TableView.Converters">
+    
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Light">
+            <x:String x:Key="SortIconAscending">&#xf0ad;</x:String>
+            <x:String x:Key="SortIconDescending">&#xf0ae;</x:String>
+            <x:String x:Key="FilterIcon">&#xe71c;</x:String>
+            <x:String x:Key="OptionsButtonIcon">&#xe712;</x:String>
+            <x:String x:Key="SelectAllButtonIcon">&#xE936;</x:String>
+            <x:Double x:Key="TableViewRowDisabledThemeOpacity">0.3</x:Double>
+            <x:Double x:Key="TableViewRowDragThemeOpacity">0.80</x:Double>
+            <x:Double x:Key="TableViewRowReorderHintThemeOffset">10.0</x:Double>
+            <x:Double x:Key="TableViewRowMinWidth">88</x:Double>
+            <x:Double x:Key="TableViewRowMinHeight">40</x:Double>
+            <x:Boolean x:Key="TableViewRowSelectionCheckMarkVisualEnabled">True</x:Boolean>
+            <x:Boolean x:Key="TableViewRowSelectionIndicatorVisualEnabled">True</x:Boolean>
+            <CornerRadius x:Key="TableViewRowCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="TableViewRowCheckBoxCornerRadius">3</CornerRadius>
+            <CornerRadius x:Key="TableViewRowSelectionIndicatorCornerRadius">1.5</CornerRadius>
+            <ListViewItemPresenterCheckMode x:Key="TableViewRowCheckMode">Inline</ListViewItemPresenterCheckMode>            
+            <StaticResource x:Key="TableViewBorderBrush" ResourceKey="CardStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewCellSelectionBrush" ResourceKey="FocusStrokeColorOuterBrush" />
+            <StaticResource x:Key="TableViewCellBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewCellBackgroundSelected" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewHeaderForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewHeaderRowBackground" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundSelected" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundSelectedPointerOver" ResourceKey="SubtleFillColorTertiaryBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundSelectedPressed" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowForegroundSelected" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowFocusVisualPrimaryBrush" ResourceKey="FocusStrokeColorOuterBrush" />
+            <StaticResource x:Key="TableViewRowFocusVisualSecondaryBrush" ResourceKey="FocusStrokeColorInnerBrush" />
+            <StaticResource x:Key="TableViewRowFocusBorderBrush" ResourceKey="FocusStrokeColorOuterBrush" />
+            <StaticResource x:Key="TableViewRowFocusSecondaryBorderBrush" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBrush" ResourceKey="TextOnAccentFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxBrush" ResourceKey="ControlAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowDragBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TableViewRowDragForeground" ResourceKey="TextOnAccentFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowPlaceholderBackground" ResourceKey="ControlStrongFillColorDisabledBrush" />
+            <StaticResource x:Key="TableViewRowCheckPressedBrush" ResourceKey="TextOnAccentFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckDisabledBrush" ResourceKey="TextOnAccentFillColorDisabledBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxPointerOverBrush" ResourceKey="ControlAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxPressedBrush" ResourceKey="ControlAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxDisabledBrush" ResourceKey="ControlAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxSelectedBrush" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxSelectedPointerOverBrush" ResourceKey="AccentFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxSelectedPressedBrush" ResourceKey="AccentFillColorTertiaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxSelectedDisabledBrush" ResourceKey="AccentFillColorDisabledBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxBorderBrush" ResourceKey="ControlStrongStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxPointerOverBorderBrush" ResourceKey="ControlStrongStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxPressedBorderBrush" ResourceKey="ControlStrongStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxDisabledBorderBrush" ResourceKey="ControlStrongStrokeColorDisabledBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundSelectedDisabled" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowSelectionIndicatorBrush" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowSelectionIndicatorPointerOverBrush" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowSelectionIndicatorPressedBrush" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowSelectionIndicatorDisabledBrush" ResourceKey="AccentFillColorDisabledBrush" />
+        </ResourceDictionary>
+        
+        <ResourceDictionary x:Key="Dark">
+            <x:String x:Key="SortIconAscending">&#xf0ad;</x:String>
+            <x:String x:Key="SortIconDescending">&#xf0ae;</x:String>
+            <x:String x:Key="FilterIcon">&#xe71c;</x:String>
+            <x:String x:Key="OptionsButtonIcon">&#xe712;</x:String>
+            <x:String x:Key="SelectAllButtonIcon">&#xE936;</x:String>
+            <x:Double x:Key="TableViewRowDisabledThemeOpacity">0.3</x:Double>
+            <x:Double x:Key="TableViewRowDragThemeOpacity">0.80</x:Double>
+            <x:Double x:Key="TableViewRowReorderHintThemeOffset">10.0</x:Double>
+            <x:Double x:Key="TableViewRowMinWidth">88</x:Double>
+            <x:Double x:Key="TableViewRowMinHeight">40</x:Double>
+            <x:Boolean x:Key="TableViewRowSelectionCheckMarkVisualEnabled">True</x:Boolean>
+            <x:Boolean x:Key="TableViewRowSelectionIndicatorVisualEnabled">True</x:Boolean>
+            <CornerRadius x:Key="TableViewRowCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="TableViewRowCheckBoxCornerRadius">3</CornerRadius>
+            <CornerRadius x:Key="TableViewRowSelectionIndicatorCornerRadius">1.5</CornerRadius>
+            <ListViewItemPresenterCheckMode x:Key="TableViewRowCheckMode">Inline</ListViewItemPresenterCheckMode>
+            <StaticResource x:Key="TableViewBorderBrush" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewCellSelectionBrush" ResourceKey="FocusStrokeColorOuterBrush" />
+            <StaticResource x:Key="TableViewCellBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewCellBackgroundSelected" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewHeaderForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewHeaderRowBackground" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundSelected" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundSelectedPointerOver" ResourceKey="SubtleFillColorTertiaryBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundSelectedPressed" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowForegroundSelected" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowFocusVisualPrimaryBrush" ResourceKey="FocusStrokeColorOuterBrush" />
+            <StaticResource x:Key="TableViewRowFocusVisualSecondaryBrush" ResourceKey="FocusStrokeColorInnerBrush" />
+            <StaticResource x:Key="TableViewRowFocusBorderBrush" ResourceKey="FocusStrokeColorOuterBrush" />
+            <StaticResource x:Key="TableViewRowFocusSecondaryBorderBrush" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBrush" ResourceKey="TextOnAccentFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxBrush" ResourceKey="ControlAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowDragBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TableViewRowDragForeground" ResourceKey="TextOnAccentFillColorPrimaryBrush" />
+            <StaticResource x:Key="TableViewRowPlaceholderBackground" ResourceKey="ControlStrongFillColorDisabledBrush" />
+            <StaticResource x:Key="TableViewRowCheckPressedBrush" ResourceKey="TextOnAccentFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckDisabledBrush" ResourceKey="TextOnAccentFillColorDisabledBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxPointerOverBrush" ResourceKey="ControlAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxPressedBrush" ResourceKey="ControlAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxDisabledBrush" ResourceKey="ControlAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxSelectedBrush" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxSelectedPointerOverBrush" ResourceKey="AccentFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxSelectedPressedBrush" ResourceKey="AccentFillColorTertiaryBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxSelectedDisabledBrush" ResourceKey="AccentFillColorDisabledBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxBorderBrush" ResourceKey="ControlStrongStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxPointerOverBorderBrush" ResourceKey="ControlStrongStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxPressedBorderBrush" ResourceKey="ControlStrongStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowCheckBoxDisabledBorderBrush" ResourceKey="ControlStrongStrokeColorDisabledBrush" />
+            <StaticResource x:Key="TableViewRowBackgroundSelectedDisabled" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewRowSelectionIndicatorBrush" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowSelectionIndicatorPointerOverBrush" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowSelectionIndicatorPressedBrush" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowSelectionIndicatorDisabledBrush" ResourceKey="AccentFillColorDisabledBrush" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="HighContrast">
+            <x:String x:Key="SortIconAscending">&#xf0ad;</x:String>
+            <x:String x:Key="SortIconDescending">&#xf0ae;</x:String>
+            <x:String x:Key="FilterIcon">&#xe71c;</x:String>
+            <x:String x:Key="OptionsButtonIcon">&#xe712;</x:String>
+            <x:String x:Key="SelectAllButtonIcon">&#xE936;</x:String>
+            <x:Double x:Key="TableViewRowDisabledThemeOpacity">0.3</x:Double>
+            <x:Double x:Key="TableViewRowDragThemeOpacity">0.80</x:Double>
+            <x:Double x:Key="TableViewRowReorderHintThemeOffset">10.0</x:Double>
+            <x:Double x:Key="TableViewRowMinWidth">88</x:Double>
+            <x:Double x:Key="TableViewRowMinHeight">40</x:Double>
+            <x:Boolean x:Key="TableViewRowSelectionCheckMarkVisualEnabled">True</x:Boolean>
+            <x:Boolean x:Key="TableViewRowSelectionIndicatorVisualEnabled">True</x:Boolean>
+            <CornerRadius x:Key="TableViewRowCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="TableViewRowCheckBoxCornerRadius">3</CornerRadius>
+            <CornerRadius x:Key="TableViewRowSelectionIndicatorCornerRadius">1.5</CornerRadius>
+            <ListViewItemPresenterCheckMode x:Key="TableViewRowCheckMode">Inline</ListViewItemPresenterCheckMode>
+            <StaticResource x:Key="TableViewBorderBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+            <SolidColorBrush x:Key="TableViewCellSelectionBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+            <SolidColorBrush x:Key="TableViewCellBackgroundPointerOver" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="TableViewCellBackgroundSelected" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="TableViewHeaderForeground" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="TableViewHeaderRowBackground" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="TableViewRowBackground" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="TableViewRowBackgroundPointerOver" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="TableViewRowBackgroundPressed" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="TableViewRowBackgroundSelected" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="TableViewRowBackgroundSelectedPointerOver" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="TableViewRowBackgroundSelectedPressed" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="TableViewRowForeground" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowForegroundPointerOver" Color="{ThemeResource SystemColorHighlightTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowFocusVisualPrimaryBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowFocusVisualSecondaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="TableViewRowFocusBorderBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowFocusSecondaryBorderBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
+            <SolidColorBrush x:Key="TableViewRowDragBackground" Color="Transparent" />
+            <SolidColorBrush x:Key="TableViewRowDragForeground" Color="{ThemeResource SystemColorWindowTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowPlaceholderBackground" Color="{ThemeResource SystemColorButtonFaceColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckPressedBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckDisabledBrush" Color="{ThemeResource SystemColorGrayTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxPointerOverBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxPressedBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxDisabledBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxSelectedBrush" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxSelectedPointerOverBrush" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxSelectedPressedBrush" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxSelectedDisabledBrush" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxPointerOverBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxPressedBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowCheckBoxDisabledBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowBackgroundSelectedDisabled" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="TableViewRowSelectionIndicatorBrush" Color="{ThemeResource SystemColorHighlightTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowSelectionIndicatorPointerOverBrush" Color="{ThemeResource SystemColorHighlightTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowSelectionIndicatorPressedBrush" Color="{ThemeResource SystemColorHighlightTextColor}" />
+            <SolidColorBrush x:Key="TableViewRowSelectionIndicatorDisabledBrush" Color="{ThemeResource SystemColorGrayTextColor}" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+    
+</ResourceDictionary>

--- a/src/WinUI.TableView/Themes/Resources.xaml
+++ b/src/WinUI.TableView/Themes/Resources.xaml
@@ -14,8 +14,12 @@
             <x:Double x:Key="TableViewRowReorderHintThemeOffset">10.0</x:Double>
             <x:Double x:Key="TableViewRowMinWidth">88</x:Double>
             <x:Double x:Key="TableViewRowMinHeight">40</x:Double>
+            <x:Double x:Key="TableViewHorizontalGridLineStrokeThickness">1</x:Double>
+            <x:Double x:Key="TableViewVerticalGridLineStrokeThickness">1</x:Double>
             <x:Boolean x:Key="TableViewRowSelectionCheckMarkVisualEnabled">True</x:Boolean>
             <x:Boolean x:Key="TableViewRowSelectionIndicatorVisualEnabled">True</x:Boolean>
+            <Thickness x:Key="TableViewCellSelectionBorderThickness">2</Thickness>
+            <CornerRadius x:Key="TableViewRowCellSelectionBorderCornerRadius">4</CornerRadius>
             <CornerRadius x:Key="TableViewRowCornerRadius">4</CornerRadius>
             <CornerRadius x:Key="TableViewRowCheckBoxCornerRadius">3</CornerRadius>
             <CornerRadius x:Key="TableViewRowSelectionIndicatorCornerRadius">1.5</CornerRadius>
@@ -62,6 +66,8 @@
             <StaticResource x:Key="TableViewRowSelectionIndicatorPointerOverBrush" ResourceKey="AccentFillColorDefaultBrush" />
             <StaticResource x:Key="TableViewRowSelectionIndicatorPressedBrush" ResourceKey="AccentFillColorDefaultBrush" />
             <StaticResource x:Key="TableViewRowSelectionIndicatorDisabledBrush" ResourceKey="AccentFillColorDisabledBrush" />
+            <StaticResource x:Key="TableViewHorizontalGridLineStroke" ResourceKey="CardStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewVerticalGridLineStroke" ResourceKey="CardStrokeColorDefaultBrush" />            
         </ResourceDictionary>
         
         <ResourceDictionary x:Key="Dark">
@@ -75,8 +81,12 @@
             <x:Double x:Key="TableViewRowReorderHintThemeOffset">10.0</x:Double>
             <x:Double x:Key="TableViewRowMinWidth">88</x:Double>
             <x:Double x:Key="TableViewRowMinHeight">40</x:Double>
+            <x:Double x:Key="TableViewHorizontalGridLineStrokeThickness">1</x:Double>
+            <x:Double x:Key="TableViewVerticalGridLineStrokeThickness">1</x:Double>
             <x:Boolean x:Key="TableViewRowSelectionCheckMarkVisualEnabled">True</x:Boolean>
             <x:Boolean x:Key="TableViewRowSelectionIndicatorVisualEnabled">True</x:Boolean>
+            <Thickness x:Key="TableViewCellSelectionBorderThickness">2</Thickness>
+            <CornerRadius x:Key="TableViewRowCellSelectionBorderCornerRadius">4</CornerRadius>
             <CornerRadius x:Key="TableViewRowCornerRadius">4</CornerRadius>
             <CornerRadius x:Key="TableViewRowCheckBoxCornerRadius">3</CornerRadius>
             <CornerRadius x:Key="TableViewRowSelectionIndicatorCornerRadius">1.5</CornerRadius>
@@ -123,6 +133,8 @@
             <StaticResource x:Key="TableViewRowSelectionIndicatorPointerOverBrush" ResourceKey="AccentFillColorDefaultBrush" />
             <StaticResource x:Key="TableViewRowSelectionIndicatorPressedBrush" ResourceKey="AccentFillColorDefaultBrush" />
             <StaticResource x:Key="TableViewRowSelectionIndicatorDisabledBrush" ResourceKey="AccentFillColorDisabledBrush" />
+            <StaticResource x:Key="TableViewHorizontalGridLineStroke" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewVerticalGridLineStroke" ResourceKey="ControlStrokeColorDefaultBrush" />
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
@@ -136,8 +148,12 @@
             <x:Double x:Key="TableViewRowReorderHintThemeOffset">10.0</x:Double>
             <x:Double x:Key="TableViewRowMinWidth">88</x:Double>
             <x:Double x:Key="TableViewRowMinHeight">40</x:Double>
+            <x:Double x:Key="TableViewHorizontalGridLineStrokeThickness">1</x:Double>
+            <x:Double x:Key="TableViewVerticalGridLineStrokeThickness">1</x:Double>
             <x:Boolean x:Key="TableViewRowSelectionCheckMarkVisualEnabled">True</x:Boolean>
             <x:Boolean x:Key="TableViewRowSelectionIndicatorVisualEnabled">True</x:Boolean>
+            <Thickness x:Key="TableViewCellSelectionBorderThickness">2</Thickness>
+            <CornerRadius x:Key="TableViewRowCellSelectionBorderCornerRadius">4</CornerRadius>
             <CornerRadius x:Key="TableViewRowCornerRadius">4</CornerRadius>
             <CornerRadius x:Key="TableViewRowCheckBoxCornerRadius">3</CornerRadius>
             <CornerRadius x:Key="TableViewRowSelectionIndicatorCornerRadius">1.5</CornerRadius>
@@ -183,6 +199,8 @@
             <SolidColorBrush x:Key="TableViewRowSelectionIndicatorPointerOverBrush" Color="{ThemeResource SystemColorHighlightTextColor}" />
             <SolidColorBrush x:Key="TableViewRowSelectionIndicatorPressedBrush" Color="{ThemeResource SystemColorHighlightTextColor}" />
             <SolidColorBrush x:Key="TableViewRowSelectionIndicatorDisabledBrush" Color="{ThemeResource SystemColorGrayTextColor}" />
+            <StaticResource x:Key="TableViewHorizontalGridLineStroke" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TableViewVerticalGridLineStroke" ResourceKey="SystemColorButtonTextColorBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
     

--- a/src/WinUI.TableView/Themes/TableView.xaml
+++ b/src/WinUI.TableView/Themes/TableView.xaml
@@ -4,8 +4,9 @@
                     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
                     xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors">
 
-    <StaticResource x:Key="TableViewGridLinesBrush"
-                    ResourceKey="ControlStrokeColorDefaultBrush" />
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
+    </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="DefaultTableViewStyle"
            TargetType="local:TableView">
@@ -38,7 +39,7 @@
         <Setter Property="CornerRadius"
                 Value="{ThemeResource ControlCornerRadius}" />
         <Setter Property="BorderBrush"
-                Value="{ThemeResource TableViewGridLinesBrush}" />
+                Value="{ThemeResource TableViewBorderBrush}" />
         <Setter Property="BorderThickness"
                 Value="1" />
         <Setter Property="SingleSelectionFollowsFocus"

--- a/src/WinUI.TableView/Themes/TableView.xaml
+++ b/src/WinUI.TableView/Themes/TableView.xaml
@@ -44,6 +44,14 @@
                 Value="1" />
         <Setter Property="SingleSelectionFollowsFocus"
                 Value="False" />
+        <Setter Property="HorizontalGridLinesStroke"
+                Value="{ThemeResource TableViewHorizontalGridLineStroke}" />
+        <Setter Property="VerticalGridLinesStroke"
+                Value="{ThemeResource TableViewVerticalGridLineStroke}" />
+        <Setter Property="HorizontalGridLinesStrokeThickness"
+                Value="{ThemeResource TableViewHorizontalGridLineStrokeThickness}" />
+        <Setter Property="VerticalGridLinesStrokeThickness"
+                Value="{ThemeResource TableViewVerticalGridLineStrokeThickness}" />
         <Setter Property="ItemContainerTransitions">
             <Setter.Value>
                 <TransitionCollection>
@@ -64,7 +72,7 @@
         <Setter Property="ItemTemplate">
             <Setter.Value>
                 <DataTemplate>
-                    <local:TableViewCellsPresenter IsTabStop="False"/>
+                    <local:TableViewCellsPresenter IsTabStop="False" />
                 </DataTemplate>
             </Setter.Value>
         </Setter>

--- a/src/WinUI.TableView/Themes/TableViewCell.xaml
+++ b/src/WinUI.TableView/Themes/TableViewCell.xaml
@@ -2,14 +2,9 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:WinUI.TableView">
 
-    <StaticResource x:Key="TableViewGridLinesBrush"
-                    ResourceKey="ControlStrokeColorDefaultBrush" />
-
-    <StaticResource x:Key="TableViewCellSelectionBrush"
-                    ResourceKey="FocusStrokeColorOuterBrush" />
-
-    <SolidColorBrush x:Key="TableViewCellHighlightBrush"
-                     Color="{StaticResource LayerFillColorDefault}" />
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
+    </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="DefaultTableViewCellStyle"
            TargetType="local:TableViewCell">
@@ -36,7 +31,7 @@
                                 <VisualState x:Name="PointerOver">
                                     <VisualState.Setters>
                                         <Setter Target="RootBorder.Background"
-                                                Value="{ThemeResource ListViewItemBackgroundPointerOver}" />
+                                                Value="{ThemeResource TableViewCellBackgroundPointerOver}" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -44,7 +39,7 @@
                                 <VisualState x:Name="Selected">
                                     <VisualState.Setters>
                                         <Setter Target="SelectionBorder.Background"
-                                                Value="{ThemeResource ListViewItemBackgroundSelected}" />
+                                                Value="{ThemeResource TableViewCellBackgroundSelected}" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Unselected" />
@@ -54,7 +49,7 @@
                                 <VisualState x:Name="Current">
                                     <VisualState.Setters>
                                         <Setter Target="SelectionBorder.BorderBrush"
-                                                Value="{StaticResource TableViewCellSelectionBrush}" />
+                                                Value="{ThemeResource TableViewCellSelectionBrush}" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>

--- a/src/WinUI.TableView/Themes/TableViewCell.xaml
+++ b/src/WinUI.TableView/Themes/TableViewCell.xaml
@@ -12,10 +12,6 @@
                 Value="Center" />
         <Setter Property="HorizontalContentAlignment"
                 Value="Stretch" />
-        <Setter Property="BorderThickness"
-                Value="2" />
-        <Setter Property="CornerRadius"
-                Value="{ThemeResource ControlCornerRadius}" />
         <Setter Property="Background">
             <Setter.Value>
                 <SolidColorBrush Opacity="0" />
@@ -24,7 +20,15 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:TableViewCell">
-                    <Grid>
+                    <Grid Background="{TemplateBinding Background}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}"
+                          CornerRadius="{TemplateBinding CornerRadius}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
@@ -55,18 +59,21 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <Border x:Name="SelectionBorder"
-                                CornerRadius="{TemplateBinding CornerRadius}"
-                                BorderThickness="{TemplateBinding BorderThickness}" />
+                                BorderThickness="{ThemeResource TableViewCellSelectionBorderThickness}"
+                                CornerRadius="{ThemeResource TableViewRowCellSelectionBorderCornerRadius}" />
                         <Border x:Name="RootBorder"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding CornerRadius}">
+                                Margin="{ThemeResource TableViewCellSelectionBorderThickness}"
+                                CornerRadius="{ThemeResource TableViewRowCellSelectionBorderCornerRadius}">
                             <ContentPresenter x:Name="Content"
                                               Margin="{TemplateBinding Padding}"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
                         </Border>
+                        
+                        <Rectangle x:Name="VerticalGridLine"
+                                   Grid.Column="1"
+                                   Width="1"
+                                   VerticalAlignment="Stretch" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/WinUI.TableView/Themes/TableViewCellsPresenter.xaml
+++ b/src/WinUI.TableView/Themes/TableViewCellsPresenter.xaml
@@ -1,0 +1,43 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="using:WinUI.TableView">
+
+    <Style x:Key="DefaultTableViewCellsPresenterStyle"
+           TargetType="local:TableViewCellsPresenter">
+        <Setter Property="Padding"
+                Value="20,0,16,0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="local:TableViewCellsPresenter">
+                    <Grid Background="{TemplateBinding Background}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <Grid Margin="{TemplateBinding Padding}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel x:Name="StackPanel"
+                                        Grid.Column="1"
+                                        Orientation="Horizontal" />
+
+                            <Rectangle x:Name="VerticalGridLine"
+                                       Width="1"
+                                       VerticalAlignment="Stretch" />
+                        </Grid>
+
+                        <Rectangle x:Name="HorizontalGridLine"
+                                   Grid.Row="1"
+                                   Margin="-24,0,0,0"
+                                   HorizontalAlignment="Stretch" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/WinUI.TableView/Themes/TableViewColumnHeader.xaml
+++ b/src/WinUI.TableView/Themes/TableViewColumnHeader.xaml
@@ -14,10 +14,6 @@
                 Value="InnerBorderEdge" />
         <Setter Property="Foreground"
                 Value="{ThemeResource TableViewHeaderForeground}" />
-        <Setter Property="BorderBrush"
-                Value="{ThemeResource TableViewBorderBrush}" />
-        <Setter Property="BorderThickness"
-                Value="0,0,1,0" />
         <Setter Property="Padding"
                 Value="12,0" />
         <Setter Property="UseSystemFocusVisuals"
@@ -90,8 +86,12 @@
                               BackgroundSizing="{TemplateBinding BackgroundSizing}"
                               VerticalAlignment="{TemplateBinding VerticalAlignment}"
                               HorizontalAlignment="{TemplateBinding HorizontalAlignment}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
                             <ContentPresenter x:Name="ContentPresenter"
-                                              Padding="{TemplateBinding Padding}"
+                                              Margin="{TemplateBinding Padding}"
                                               Foreground="{TemplateBinding Foreground}"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
@@ -216,6 +216,12 @@
                                     </Button.Flyout>
                                 </Button>
                             </Grid>
+
+                            <Rectangle x:Name="VerticalGridLine"
+                                       Grid.Column="1"
+                                       Width="1"
+                                       HorizontalAlignment="Right"
+                                       VerticalAlignment="Stretch" />
                         </Grid>
                     </Grid>
                 </ControlTemplate>

--- a/src/WinUI.TableView/Themes/TableViewColumnHeader.xaml
+++ b/src/WinUI.TableView/Themes/TableViewColumnHeader.xaml
@@ -1,17 +1,10 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:converters="using:WinUI.TableView.Converters"
                     xmlns:local="using:WinUI.TableView">
 
-    <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
-
-    <StaticResource x:Key="TableViewGridLinesBrush"
-                    ResourceKey="ControlStrokeColorDefaultBrush" />
-
-    <x:String x:Key="SortIconAscending">&#xf0ad;</x:String>
-    <x:String x:Key="SortIconDescending">&#xf0ae;</x:String>
-    <x:String x:Key="FilterIcon">&#xe71c;</x:String>
-    <x:String x:Key="OptionsButtonIcon">&#xe712;</x:String>
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
+    </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="DefaultTableViewColumnHeaderStyle"
            TargetType="local:TableViewColumnHeader">
@@ -20,9 +13,9 @@
         <Setter Property="BackgroundSizing"
                 Value="InnerBorderEdge" />
         <Setter Property="Foreground"
-                Value="{ThemeResource ButtonForeground}" />
+                Value="{ThemeResource TableViewHeaderForeground}" />
         <Setter Property="BorderBrush"
-                Value="{ThemeResource TableViewGridLinesBrush}" />
+                Value="{ThemeResource TableViewBorderBrush}" />
         <Setter Property="BorderThickness"
                 Value="0,0,1,0" />
         <Setter Property="Padding"
@@ -168,7 +161,7 @@
                                                                             Text="{Binding FilterText, Mode=TwoWay}" />
                                                             <Border Grid.Row="1"
                                                                     BorderThickness="0,0,0,1"
-                                                                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
+                                                                    BorderBrush="{ThemeResource MenuFlyoutSeparatorBackground}">
                                                                 <CheckBox x:Name="SelectAllCheckBox"
                                                                           Margin="12,8,12,1"
                                                                           IsThreeState="True"

--- a/src/WinUI.TableView/Themes/TableViewHeaderRow.xaml
+++ b/src/WinUI.TableView/Themes/TableViewHeaderRow.xaml
@@ -5,7 +5,7 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
     </ResourceDictionary.MergedDictionaries>
-   
+
     <Style x:Key="DefaultTableViewHeaderRowStyle"
            TargetType="local:TableViewHeaderRow">
         <Setter Property="Height"
@@ -45,22 +45,29 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
-                        <Grid Background="{TemplateBinding Background}">
+                        <Grid x:Name="root"
+                              Background="{TemplateBinding Background}"
+                              BorderBrush="{TemplateBinding BorderBrush}"
+                              BorderThickness="{TemplateBinding BorderThickness}">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
 
                             <Button x:Name="selectAllButton"
                                     VerticalAlignment="Stretch"
-                                    BorderThickness="0,0,1,1"
+                                    BorderThickness="0"
                                     Background="Transparent"
                                     Padding="0"
                                     CornerRadius="4,0,0,0"
                                     Width="16"
                                     Visibility="Visible"
-                                    IsTabStop="False"
-                                    BorderBrush="{ThemeResource TableViewBorderBrush}">
+                                    IsTabStop="False">
                                 <FontIcon FontSize="12"
                                           Margin="6,20,0,0"
                                           Opacity="0.5"
@@ -74,16 +81,16 @@
 
                             <Button x:Name="optionsButton"
                                     VerticalAlignment="Stretch"
-                                    BorderThickness="0,0,1,1"
+                                    BorderThickness="0"
                                     Background="Transparent"
                                     Padding="0"
                                     CornerRadius="4,0,0,0"
                                     Width="16"
                                     Visibility="Collapsed"
-                                    IsTabStop="False"
-                                    BorderBrush="{ThemeResource TableViewBorderBrush}">
+                                    IsTabStop="False">
                                 <FontIcon FontSize="12"
-                                          Margin="4,0,0,0"
+                                          MaxWidth="10"
+                                          Margin="-4,0,0,0"
                                           VerticalAlignment="Center"
                                           HorizontalAlignment="Center"
                                           Glyph="{ThemeResource OptionsButtonIcon}"
@@ -126,7 +133,7 @@
                                         <MenuFlyoutSeparator />
                                         <MenuFlyoutItem Command="{Binding ClearSortingCommand}" />
                                         <MenuFlyoutItem Command="{Binding ClearFilterCommand}" />
-                                        <MenuFlyoutSeparator Visibility="{Binding Visibility, ElementName=ExportAllMenuItem}"/>
+                                        <MenuFlyoutSeparator Visibility="{Binding Visibility, ElementName=ExportAllMenuItem}" />
                                         <MenuFlyoutItem x:Name="ExportAllMenuItem"
                                                         Command="{Binding ExportAllToCSVCommand}">
                                             <MenuFlyoutItem.Icon>
@@ -144,19 +151,25 @@
                             </Button>
 
                             <CheckBox x:Name="selectAllCheckBox"
-                                      Margin="14,0,2,0"
+                                      Margin="10,0,2,0"
                                       MinWidth="0"
                                       IsTabStop="False"
                                       IsThreeState="True"
                                       Visibility="Collapsed" />
 
-                            <StackPanel x:Name="HeadersStackPanel"
-                                        Grid.Column="1"
-                                        Orientation="Horizontal" />
+                            <Rectangle x:Name="VerticalGridLine"
+                                           Grid.Column="1"
+                                           Width="1"
+                                           VerticalAlignment="Stretch" />
 
-                            <Border Grid.Column="1"
-                                    BorderThickness="0,0,0,1"
-                                    BorderBrush="{ThemeResource TableViewBorderBrush}" />
+                            <Rectangle x:Name="HorizontalGridLine"
+                                       Grid.Row="1"
+                                       Grid.ColumnSpan="3"
+                                       HorizontalAlignment="Stretch" />
+                            
+                            <StackPanel x:Name="HeadersStackPanel"
+                                        Grid.Column="2"
+                                        Orientation="Horizontal" />
                         </Grid>
                     </Grid>
                 </ControlTemplate>

--- a/src/WinUI.TableView/Themes/TableViewHeaderRow.xaml
+++ b/src/WinUI.TableView/Themes/TableViewHeaderRow.xaml
@@ -2,18 +2,16 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:WinUI.TableView">
 
-    <StaticResource x:Key="TableViewGridLinesBrush"
-                    ResourceKey="ControlStrokeColorDefaultBrush" />
-
-    <x:String x:Key="OptionsButtonIcon">&#xe712;</x:String>
-    <x:String x:Key="SelectAllButtonIcon">&#xE936;</x:String>
-
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+   
     <Style x:Key="DefaultTableViewHeaderRowStyle"
            TargetType="local:TableViewHeaderRow">
         <Setter Property="Height"
                 Value="32" />
         <Setter Property="Background"
-                Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
+                Value="{ThemeResource TableViewHeaderRowBackground}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:TableViewHeaderRow">
@@ -62,7 +60,7 @@
                                     Width="16"
                                     Visibility="Visible"
                                     IsTabStop="False"
-                                    BorderBrush="{ThemeResource TableViewGridLinesBrush}">
+                                    BorderBrush="{ThemeResource TableViewBorderBrush}">
                                 <FontIcon FontSize="12"
                                           Margin="6,20,0,0"
                                           Opacity="0.5"
@@ -83,7 +81,7 @@
                                     Width="16"
                                     Visibility="Collapsed"
                                     IsTabStop="False"
-                                    BorderBrush="{ThemeResource TableViewGridLinesBrush}">
+                                    BorderBrush="{ThemeResource TableViewBorderBrush}">
                                 <FontIcon FontSize="12"
                                           Margin="4,0,0,0"
                                           VerticalAlignment="Center"
@@ -158,7 +156,7 @@
 
                             <Border Grid.Column="1"
                                     BorderThickness="0,0,0,1"
-                                    BorderBrush="{ThemeResource TableViewGridLinesBrush}" />
+                                    BorderBrush="{ThemeResource TableViewBorderBrush}" />
                         </Grid>
                     </Grid>
                 </ControlTemplate>

--- a/src/WinUI.TableView/Themes/TableViewRow.xaml
+++ b/src/WinUI.TableView/Themes/TableViewRow.xaml
@@ -2,17 +2,31 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:WinUI.TableView">
 
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
     <Style x:Key="DefaultTableViewRowStyle"
            TargetType="local:TableViewRow"
            BasedOn="{StaticResource DefaultListViewItemStyle}">
-        <Setter Property="VerticalContentAlignment"
-                Value="Stretch" />
-        <Setter Property="IsTabStop"
-                Value="True" />
-        <Setter Property="UseSystemFocusVisuals"
-                Value="False" />
-        <Setter Property="Padding"
-                Value="16,0,12,0" />
+        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+        <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+        <Setter Property="Background" Value="{ThemeResource TableViewRowBackground}" />
+        <Setter Property="Foreground" Value="{ThemeResource TableViewRowForeground}" />
+        <Setter Property="TabNavigation" Value="Local" />
+        <Setter Property="IsHoldingEnabled" Value="True" />
+        <Setter Property="Padding" Value="16,0,12,0" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="MinWidth" Value="{ThemeResource TableViewRowMinWidth}" />
+        <Setter Property="MinHeight" Value="{ThemeResource TableViewRowMinHeight}" />
+        <Setter Property="AllowDrop" Value="False" />
+        <Setter Property="UseSystemFocusVisuals" Value="True" />
+        <Setter Property="FocusVisualMargin" Value="1" />
+        <Setter Property="FocusVisualPrimaryBrush" Value="{ThemeResource TableViewRowFocusVisualPrimaryBrush}" />
+        <Setter Property="FocusVisualPrimaryThickness" Value="2" />
+        <Setter Property="FocusVisualSecondaryBrush" Value="{ThemeResource TableViewRowFocusVisualSecondaryBrush}" />
+        <Setter Property="FocusVisualSecondaryThickness" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListViewItem">
@@ -24,50 +38,50 @@
                                            FocusVisualPrimaryThickness="{TemplateBinding FocusVisualPrimaryThickness}"
                                            FocusVisualSecondaryBrush="{TemplateBinding FocusVisualSecondaryBrush}"
                                            FocusVisualSecondaryThickness="{TemplateBinding FocusVisualSecondaryThickness}"
-                                           SelectionCheckMarkVisualEnabled="{ThemeResource ListViewItemSelectionCheckMarkVisualEnabled}"
-                                           CheckBrush="{ThemeResource ListViewItemCheckBrush}"
-                                           CheckBoxBrush="{ThemeResource ListViewItemCheckBoxBrush}"
-                                           DragBackground="{ThemeResource ListViewItemDragBackground}"
-                                           DragForeground="{ThemeResource ListViewItemDragForeground}"
-                                           FocusBorderBrush="{ThemeResource ListViewItemFocusBorderBrush}"
-                                           FocusSecondaryBorderBrush="{ThemeResource ListViewItemFocusSecondaryBorderBrush}"
-                                           PlaceholderBackground="{ThemeResource ListViewItemPlaceholderBackground}"
-                                           PointerOverBackground="{ThemeResource ListViewItemBackgroundPointerOver}"
-                                           PointerOverForeground="{ThemeResource ListViewItemForegroundPointerOver}"
-                                           SelectedBackground="{ThemeResource ListViewItemBackgroundSelected}"
-                                           SelectedForeground="{ThemeResource ListViewItemForegroundSelected}"
-                                           SelectedPointerOverBackground="{ThemeResource ListViewItemBackgroundSelectedPointerOver}"
-                                           PressedBackground="{ThemeResource ListViewItemBackgroundPressed}"
-                                           SelectedPressedBackground="{ThemeResource ListViewItemBackgroundSelectedPressed}"
-                                           DisabledOpacity="{ThemeResource ListViewItemDisabledThemeOpacity}"
-                                           DragOpacity="{ThemeResource ListViewItemDragThemeOpacity}"
-                                           ReorderHintOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
+                                           SelectionCheckMarkVisualEnabled="{ThemeResource TableViewRowSelectionCheckMarkVisualEnabled}"
+                                           CheckBrush="{ThemeResource TableViewRowCheckBrush}"
+                                           CheckBoxBrush="{ThemeResource TableViewRowCheckBoxBrush}"
+                                           DragBackground="{ThemeResource TableViewRowDragBackground}"
+                                           DragForeground="{ThemeResource TableViewRowDragForeground}"
+                                           FocusBorderBrush="{ThemeResource TableViewRowFocusBorderBrush}"
+                                           FocusSecondaryBorderBrush="{ThemeResource TableViewRowFocusSecondaryBorderBrush}"
+                                           PlaceholderBackground="{ThemeResource TableViewRowPlaceholderBackground}"
+                                           PointerOverBackground="{ThemeResource TableViewRowBackgroundPointerOver}"
+                                           PointerOverForeground="{ThemeResource TableViewRowForegroundPointerOver}"
+                                           SelectedBackground="{ThemeResource TableViewRowBackgroundSelected}"
+                                           SelectedForeground="{ThemeResource TableViewRowForegroundSelected}"
+                                           SelectedPointerOverBackground="{ThemeResource TableViewRowBackgroundSelectedPointerOver}"
+                                           PressedBackground="{ThemeResource TableViewRowBackgroundPressed}"
+                                           SelectedPressedBackground="{ThemeResource TableViewRowBackgroundSelectedPressed}"
+                                           DisabledOpacity="{ThemeResource TableViewRowDisabledThemeOpacity}"
+                                           DragOpacity="{ThemeResource TableViewRowDragThemeOpacity}"
+                                           ReorderHintOffset="{ThemeResource TableViewRowReorderHintThemeOffset}"
                                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                            ContentMargin="{TemplateBinding Padding}"
-                                           CheckMode="{ThemeResource ListViewItemCheckMode}"
-                                           CornerRadius="{ThemeResource ListViewItemCornerRadius}"
-                                           CheckPressedBrush="{ThemeResource ListViewItemCheckPressedBrush}"
-                                           CheckDisabledBrush="{ThemeResource ListViewItemCheckDisabledBrush}"
-                                           CheckBoxPointerOverBrush="{ThemeResource ListViewItemCheckBoxPointerOverBrush}"
-                                           CheckBoxPressedBrush="{ThemeResource ListViewItemCheckBoxPressedBrush}"
-                                           CheckBoxDisabledBrush="{ThemeResource ListViewItemCheckBoxDisabledBrush}"
-                                           CheckBoxSelectedBrush="{ThemeResource ListViewItemCheckBoxSelectedBrush}"
-                                           CheckBoxSelectedPointerOverBrush="{ThemeResource ListViewItemCheckBoxSelectedPointerOverBrush}"
-                                           CheckBoxSelectedPressedBrush="{ThemeResource ListViewItemCheckBoxSelectedPressedBrush}"
-                                           CheckBoxSelectedDisabledBrush="{ThemeResource ListViewItemCheckBoxSelectedDisabledBrush}"
-                                           CheckBoxBorderBrush="{ThemeResource ListViewItemCheckBoxBorderBrush}"
-                                           CheckBoxPointerOverBorderBrush="{ThemeResource ListViewItemCheckBoxPointerOverBorderBrush}"
-                                           CheckBoxPressedBorderBrush="{ThemeResource ListViewItemCheckBoxPressedBorderBrush}"
-                                           CheckBoxDisabledBorderBrush="{ThemeResource ListViewItemCheckBoxDisabledBorderBrush}"
-                                           CheckBoxCornerRadius="{ThemeResource ListViewItemCheckBoxCornerRadius}"
-                                           SelectionIndicatorCornerRadius="{ThemeResource ListViewItemSelectionIndicatorCornerRadius}"
-                                           SelectionIndicatorVisualEnabled="{ThemeResource ListViewItemSelectionIndicatorVisualEnabled}"
-                                           SelectionIndicatorBrush="{ThemeResource ListViewItemSelectionIndicatorBrush}"
-                                           SelectionIndicatorPointerOverBrush="{ThemeResource ListViewItemSelectionIndicatorPointerOverBrush}"
-                                           SelectionIndicatorPressedBrush="{ThemeResource ListViewItemSelectionIndicatorPressedBrush}"
-                                           SelectionIndicatorDisabledBrush="{ThemeResource ListViewItemSelectionIndicatorDisabledBrush}"
-                                           SelectedDisabledBackground="{ThemeResource ListViewItemBackgroundSelectedDisabled}" />
+                                           CheckMode="{ThemeResource TableViewRowCheckMode}"
+                                           CornerRadius="{ThemeResource TableViewRowCornerRadius}"
+                                           CheckPressedBrush="{ThemeResource TableViewRowCheckPressedBrush}"
+                                           CheckDisabledBrush="{ThemeResource TableViewRowCheckDisabledBrush}"
+                                           CheckBoxPointerOverBrush="{ThemeResource TableViewRowCheckBoxPointerOverBrush}"
+                                           CheckBoxPressedBrush="{ThemeResource TableViewRowCheckBoxPressedBrush}"
+                                           CheckBoxDisabledBrush="{ThemeResource TableViewRowCheckBoxDisabledBrush}"
+                                           CheckBoxSelectedBrush="{ThemeResource TableViewRowCheckBoxSelectedBrush}"
+                                           CheckBoxSelectedPointerOverBrush="{ThemeResource TableViewRowCheckBoxSelectedPointerOverBrush}"
+                                           CheckBoxSelectedPressedBrush="{ThemeResource TableViewRowCheckBoxSelectedPressedBrush}"
+                                           CheckBoxSelectedDisabledBrush="{ThemeResource TableViewRowCheckBoxSelectedDisabledBrush}"
+                                           CheckBoxBorderBrush="{ThemeResource TableViewRowCheckBoxBorderBrush}"
+                                           CheckBoxPointerOverBorderBrush="{ThemeResource TableViewRowCheckBoxPointerOverBorderBrush}"
+                                           CheckBoxPressedBorderBrush="{ThemeResource TableViewRowCheckBoxPressedBorderBrush}"
+                                           CheckBoxDisabledBorderBrush="{ThemeResource TableViewRowCheckBoxDisabledBorderBrush}"
+                                           CheckBoxCornerRadius="{ThemeResource TableViewRowCheckBoxCornerRadius}"
+                                           SelectionIndicatorCornerRadius="{ThemeResource TableViewRowSelectionIndicatorCornerRadius}"
+                                           SelectionIndicatorVisualEnabled="{ThemeResource TableViewRowSelectionIndicatorVisualEnabled}"
+                                           SelectionIndicatorBrush="{ThemeResource TableViewRowSelectionIndicatorBrush}"
+                                           SelectionIndicatorPointerOverBrush="{ThemeResource TableViewRowSelectionIndicatorPointerOverBrush}"
+                                           SelectionIndicatorPressedBrush="{ThemeResource TableViewRowSelectionIndicatorPressedBrush}"
+                                           SelectionIndicatorDisabledBrush="{ThemeResource TableViewRowSelectionIndicatorDisabledBrush}"
+                                           SelectedDisabledBackground="{ThemeResource TableViewRowBackgroundSelectedDisabled}" />
 
                 </ControlTemplate>
             </Setter.Value>

--- a/src/WinUI.TableView/Themes/TableViewRow.xaml
+++ b/src/WinUI.TableView/Themes/TableViewRow.xaml
@@ -15,9 +15,9 @@
         <Setter Property="Foreground" Value="{ThemeResource TableViewRowForeground}" />
         <Setter Property="TabNavigation" Value="Local" />
         <Setter Property="IsHoldingEnabled" Value="True" />
-        <Setter Property="Padding" Value="16,0,12,0" />
+        <Setter Property="Padding" Value="0" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="MinWidth" Value="{ThemeResource TableViewRowMinWidth}" />
         <Setter Property="MinHeight" Value="{ThemeResource TableViewRowMinHeight}" />
         <Setter Property="AllowDrop" Value="False" />


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/46348013-adde-4b6a-acba-4b72f62ed34f)


### Description  
This pull request adds support for horizontal and vertical grid lines. By default, grid lines are enabled, and developers can fully customize their appearance and visibility using the properties below:

### New Properties  
1. **`HeaderGridLinesVisibility`**  
   Controls the visibility of grid lines in the header row. Options include: `All`, `Horizontal`, `Vertical`, or `None`.  

2. **`GridLinesVisibility`**  
   Controls the visibility of grid lines in table rows. Options include: `All`, `Horizontal`, `Vertical`, or `None`.  

3. **`VerticalGridLinesStrokeThickness`**  
   Specifies the stroke thickness of vertical grid lines. The default value is `1`.  

4. **`HorizontalGridLinesStrokeThickness`**  
   Specifies the stroke thickness of horizontal grid lines. The default value is `1`.  

5. **`VerticalGridLinesStroke`**  
   Specifies the brush used for vertical grid lines. The default value is the same as `TableView.BorderBrush`.  

6. **`HorizontalGridLinesStroke`**  
   Specifies the brush used for horizontal grid lines. The default value is the same as `TableView.BorderBrush`.  

### Breaking Changes  
- The left margin of checkboxes in multiple selection mode has been reduced by four pixels.  

### Known Issues  
- Changing grid line thickness or visibility proeprty at runtime may lead to unexpected layouts of column headers and row cells. This is due to an issue in `ItemsStackPanel` microsoft/microsoft-ui-xaml#9860
