### PR TITLE
replaced ShowOptionsButton proeprty with CornerButtonMode

### DIFF
--- a/src/WinUI.TableView/TableView.Properties.cs
+++ b/src/WinUI.TableView/TableView.Properties.cs
@@ -17,7 +17,7 @@ public partial class TableView
     public static readonly DependencyProperty ShowExportOptionsProperty = DependencyProperty.Register(nameof(ShowExportOptions), typeof(bool), typeof(TableView), new PropertyMetadata(false));
     public static readonly DependencyProperty AutoGenerateColumnsProperty = DependencyProperty.Register(nameof(AutoGenerateColumns), typeof(bool), typeof(TableView), new PropertyMetadata(true, OnAutoGenerateColumnsChanged));
     public static readonly DependencyProperty IsReadOnlyProperty = DependencyProperty.Register(nameof(IsReadOnly), typeof(bool), typeof(TableView), new PropertyMetadata(false, OnIsReadOnlyChanged));
-    public static readonly DependencyProperty ShowOptionsButtonProperty = DependencyProperty.Register(nameof(ShowOptionsButton), typeof(bool), typeof(TableView), new PropertyMetadata(true));
+    public static readonly DependencyProperty CornerButtonModeProperty = DependencyProperty.Register(nameof(CornerButtonMode), typeof(TableViewCornerButtonMode), typeof(TableView), new PropertyMetadata(TableViewCornerButtonMode.Options));
     public static readonly DependencyProperty CanResizeColumnsProperty = DependencyProperty.Register(nameof(CanResizeColumns), typeof(bool), typeof(TableView), new PropertyMetadata(true));
     public static readonly DependencyProperty CanSortColumnsProperty = DependencyProperty.Register(nameof(CanSortColumns), typeof(bool), typeof(TableView), new PropertyMetadata(true, OnCanSortColumnsChanged));
     public static readonly DependencyProperty CanFilterColumnsProperty = DependencyProperty.Register(nameof(CanFilterColumns), typeof(bool), typeof(TableView), new PropertyMetadata(true, OnCanFilterColumnsChanged));
@@ -91,10 +91,10 @@ public partial class TableView
         set => SetValue(IsReadOnlyProperty, value);
     }
 
-    public bool ShowOptionsButton
+    public TableViewCornerButtonMode CornerButtonMode
     {
-        get => (bool)GetValue(ShowOptionsButtonProperty);
-        set => SetValue(ShowOptionsButtonProperty, value);
+        get => (TableViewCornerButtonMode)GetValue(CornerButtonModeProperty);
+        set => SetValue(CornerButtonModeProperty, value);
     }
 
     public bool CanResizeColumns

--- a/src/WinUI.TableView/TableViewCornerButtonMode.cs
+++ b/src/WinUI.TableView/TableViewCornerButtonMode.cs
@@ -1,0 +1,19 @@
+﻿namespace WinUI.TableView;
+
+public enum TableViewCornerButtonMode
+{
+    /// <summary>
+    /// No button.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Show Select All button.
+    /// </summary>
+    SelectAll,
+
+    /// <summary>
+    /// Show Options button.
+    /// </summary>
+    Options
+}

--- a/src/WinUI.TableView/TableViewHeaderRow.cs
+++ b/src/WinUI.TableView/TableViewHeaderRow.cs
@@ -43,17 +43,11 @@ public partial class TableViewHeaderRow : Control
         _selectAllCheckBox = GetTemplateChild("selectAllCheckBox") as CheckBox;
         _v_gridLine = GetTemplateChild("VerticalGridLine") as Rectangle;
         _h_gridLine = GetTemplateChild("HorizontalGridLine") as Rectangle;
-        TableView?.RegisterPropertyChangedCallback(ListViewBase.SelectionModeProperty, delegate { SetSelectAllButtonState(); });
-        TableView?.RegisterPropertyChangedCallback(TableView.ShowOptionsButtonProperty, delegate { SetSelectAllButtonState(); });
-        TableView?.RegisterPropertyChangedCallback(TableView.ItemsSourceProperty, delegate { OnTableViewSelectionChanged(); });
 
         if (TableView is null)
         {
             return;
         }
-
-        TableView.SelectionChanged += delegate { OnTableViewSelectionChanged(); };
-        TableView.Items.VectorChanged += delegate { OnTableViewSelectionChanged(); };
 
         if (_optionsButton is not null)
         {

--- a/src/WinUI.TableView/TableViewHeaderRow.cs
+++ b/src/WinUI.TableView/TableViewHeaderRow.cs
@@ -328,15 +328,15 @@ public partial class TableViewHeaderRow : Control
 
     private void SetSelectAllButtonState()
     {
-        if (TableView?.SelectionMode == ListViewSelectionMode.Multiple)
+        if (TableView is ListView { SelectionMode: ListViewSelectionMode.Multiple })
         {
             VisualStates.GoToState(this, false, VisualStates.StateSelectAllCheckBox);
         }
-        else if (TableView?.CornerButtonMode is TableViewCornerButtonMode.Options)
+        else if (TableView is { CornerButtonMode: TableViewCornerButtonMode.Options })
         {
             VisualStates.GoToState(this, false, VisualStates.StateOptionsButton);
         }
-        else if (TableView?.CornerButtonMode is TableViewCornerButtonMode.SelectAll)
+        else if (TableView is { CornerButtonMode: TableViewCornerButtonMode.SelectAll })
         {
             VisualStates.GoToState(this, false, VisualStates.StateSelectAllButton);
         }

--- a/src/WinUI.TableView/TableViewRow.cs
+++ b/src/WinUI.TableView/TableViewRow.cs
@@ -65,6 +65,7 @@ public class TableViewRow : ListViewItem
         _focusVisualMargin = FocusVisualMargin;
 
         EnsureGridLines();
+        EnsureLayout();
     }
 
     protected override void OnApplyTemplate()

--- a/src/WinUI.TableView/Themes/TableViewHeaderRow.xaml
+++ b/src/WinUI.TableView/Themes/TableViewHeaderRow.xaml
@@ -20,26 +20,26 @@
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
                             </VisualStateGroup>
-                            <VisualStateGroup x:Name="SelectAllButtonStates">
-                                <VisualState x:Name="SelectAllButton" />
+                            <VisualStateGroup x:Name="CornerButtonStates">
+                                <VisualState x:Name="NoButton" />
+                                <VisualState x:Name="SelectAllButton">
+                                    <VisualState.Setters>
+                                        <Setter Target="selectAllButton.Visibility"
+                                                Value="Visible" />
+                                    </VisualState.Setters>
+                                </VisualState>
                                 <VisualState x:Name="OptionsButton">
                                     <VisualState.Setters>
                                         <Setter Target="optionsButton.Visibility"
                                                 Value="Visible" />
-                                        <Setter Target="selectAllButton.Visibility"
-                                                Value="Collapsed" />
-                                        <Setter Target="selectAllCheckBox.Visibility"
-                                                Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="SelectAllCheckBox">
                                     <VisualState.Setters>
                                         <Setter Target="selectAllCheckBox.Visibility"
                                                 Value="Visible" />
-                                        <Setter Target="selectAllButton.Visibility"
-                                                Value="Collapsed" />
-                                        <Setter Target="optionsButton.Visibility"
-                                                Value="Collapsed" />
+                                        <Setter Target="cornerButtonColumn.Width"
+                                                Value="40" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -54,43 +54,39 @@
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition x:Name="cornerButtonColumn"
+                                                  MinWidth="16"
+                                                  Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
 
                             <Button x:Name="selectAllButton"
-                                    VerticalAlignment="Stretch"
                                     BorderThickness="0"
                                     Background="Transparent"
                                     Padding="0"
                                     CornerRadius="4,0,0,0"
-                                    Width="16"
-                                    Visibility="Visible"
-                                    IsTabStop="False">
-                                <FontIcon FontSize="12"
-                                          Margin="6,20,0,0"
-                                          Opacity="0.5"
-                                          Glyph="{ThemeResource SelectAllButtonIcon}"
-                                          RenderTransformOrigin="0.5,0.5">
-                                    <FontIcon.RenderTransform>
-                                        <RotateTransform Angle="-45" />
-                                    </FontIcon.RenderTransform>
-                                </FontIcon>
+                                    Visibility="Collapsed"
+                                    IsTabStop="False"
+                                    VerticalAlignment="Stretch">
+                                <FontIcon Opacity="0.5"
+                                          Glyph="&#xE788;"
+                                          Margin="-8,6,0,0"
+                                          VerticalAlignment="Bottom" />
                             </Button>
 
                             <Button x:Name="optionsButton"
+                                    HorizontalAlignment="Stretch"
                                     VerticalAlignment="Stretch"
                                     BorderThickness="0"
                                     Background="Transparent"
                                     Padding="0"
                                     CornerRadius="4,0,0,0"
-                                    Width="16"
                                     Visibility="Collapsed"
                                     IsTabStop="False">
                                 <FontIcon FontSize="12"
                                           MaxWidth="10"
-                                          Margin="-4,0,0,0"
+                                          Margin="-2,0,0,0"
                                           VerticalAlignment="Center"
                                           HorizontalAlignment="Center"
                                           Glyph="{ThemeResource OptionsButtonIcon}"
@@ -151,22 +147,24 @@
                             </Button>
 
                             <CheckBox x:Name="selectAllCheckBox"
-                                      Margin="10,0,2,0"
-                                      MinWidth="0"
+                                      Padding="0"
+                                      MinWidth="20"
+                                      MinHeight="20"
                                       IsTabStop="False"
-                                      IsThreeState="True"
-                                      Visibility="Collapsed" />
+                                      Visibility="Collapsed"
+                                      VerticalAlignment="Center"
+                                      HorizontalAlignment="Center" />
 
                             <Rectangle x:Name="VerticalGridLine"
-                                           Grid.Column="1"
-                                           Width="1"
-                                           VerticalAlignment="Stretch" />
+                                       Grid.Column="1"
+                                       Width="1"
+                                       VerticalAlignment="Stretch" />
 
                             <Rectangle x:Name="HorizontalGridLine"
                                        Grid.Row="1"
                                        Grid.ColumnSpan="3"
                                        HorizontalAlignment="Stretch" />
-                            
+
                             <StackPanel x:Name="HeadersStackPanel"
                                         Grid.Column="2"
                                         Orientation="Horizontal" />

--- a/src/WinUI.TableView/VisualStates.cs
+++ b/src/WinUI.TableView/VisualStates.cs
@@ -266,7 +266,12 @@ internal static class VisualStates
     /// </summary>
     public const string GroupScrollBars = "ScrollBarsStates";
 
-    // GroupSelectAllButton
+    // Group Corner Button
+
+    /// <summary>
+    /// No button state
+    /// </summary>
+    public const string StateNoButton = "NoButton";
 
     /// <summary>
     /// Select all button state
@@ -286,7 +291,7 @@ internal static class VisualStates
     /// <summary>
     /// Select all button state group
     /// </summary>
-    public const string GroupSelectAllButton = "SelectAllButtonStates";
+    public const string GroupCornerButton = "CornerButtonStates";
 
     /// <summary>
     /// Use VisualStateManager to change the visual state of the control.


### PR DESCRIPTION
closes #23 

### Description
This PR introduces a new property, `CornerButtonMode`, which replaces the existing `ShowOptionsButton` property. The `ShowOptionsButton` property was a boolean that toggled the visibility of the `OptionsButton`. When hidden, the `SelectAllButton` would appear instead. The new `CornerButtonMode` property is an Enum that provides more clarity and flexibility by offering three distinct options:

1. **`NoButton`**  
   No button will be displayed in the top-left corner.
1. **`SelectAllButton`**  
   The `SelectAllButton` will be visible in the top-left corner.
1. **`OptionsButton`** _(default)_
   The `OptionsButton` will be displayed in the top-left corner.

Note: If the `SelectionMode` is set to `Multiple` and `SelectionUnit` is set to `CellOrRow` or `Row`, a checkbox will always be visible in the top-left corner, regardless of the value set for the `CornerButtonMode` property.

### Breaking Changes
- The `ShowOptionsButton` property has been removed in favor of the new `CornerButtonMode` Enum.