### PR TITLE
added AlternateRowBackground/Foreground properties

### DIFF
--- a/src/WinUI.TableView/TableView.Properties.cs
+++ b/src/WinUI.TableView/TableView.Properties.cs
@@ -30,6 +30,8 @@ public partial class TableView
     public static readonly DependencyProperty VerticalGridLinesStrokeThicknessProperty = DependencyProperty.Register(nameof(VerticalGridLinesStrokeThickness), typeof(double), typeof(TableView), new PropertyMetadata(1d, OnGridLinesPropertyChanged));
     public static readonly DependencyProperty HorizontalGridLinesStrokeProperty = DependencyProperty.Register(nameof(HorizontalGridLinesStroke), typeof(Brush), typeof(TableView), new PropertyMetadata(default, OnGridLinesPropertyChanged));
     public static readonly DependencyProperty VerticalGridLinesStrokeProperty = DependencyProperty.Register(nameof(VerticalGridLinesStroke), typeof(Brush), typeof(TableView), new PropertyMetadata(default, OnGridLinesPropertyChanged));
+    public static readonly DependencyProperty AlternateRowForegroundProperty = DependencyProperty.Register(nameof(AlternateRowForeground), typeof(Brush), typeof(TableView), new PropertyMetadata(null, OnAlternateRowColorChanged));
+    public static readonly DependencyProperty AlternateRowBackgroundProperty = DependencyProperty.Register(nameof(AlternateRowBackground), typeof(Brush), typeof(TableView), new PropertyMetadata(null, OnAlternateRowColorChanged));
 
     public IAdvancedCollectionView CollectionView { get; private set; } = new AdvancedCollectionView();
     internal IDictionary<string, Predicate<object>> ActiveFilters { get; } = new Dictionary<string, Predicate<object>>();
@@ -169,6 +171,18 @@ public partial class TableView
         set => SetValue(HorizontalGridLinesStrokeProperty, value);
     }
 
+    public Brush AlternateRowBackground
+    {
+        get => (Brush)GetValue(AlternateRowBackgroundProperty);
+        set => SetValue(AlternateRowBackgroundProperty, value);
+    }
+
+    public Brush AlternateRowForeground
+    {
+        get => (Brush)GetValue(AlternateRowForegroundProperty);
+        set => SetValue(AlternateRowForegroundProperty, value);
+    }
+
     private static void OnItemsSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is TableView tableView)
@@ -287,6 +301,14 @@ public partial class TableView
         if (d is TableView tableView)
         {
             tableView.EnsureGridLines();
+        }
+    }
+
+    private static void OnAlternateRowColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView)
+        {
+            tableView.EnsureAlternateRowColors();
         }
     }
 

--- a/src/WinUI.TableView/TableView.cs
+++ b/src/WinUI.TableView/TableView.cs
@@ -1065,6 +1065,14 @@ public partial class TableView : ListView
         }
     }
 
+    private void EnsureAlternateRowColors()
+    {
+        foreach (var row in _rows)
+        {
+            row.EnsureAlternateColors();
+        }
+    }
+
     public event EventHandler<TableViewAutoGeneratingColumnEventArgs>? AutoGeneratingColumn;
     public event EventHandler<TableViewExportContentEventArgs>? ExportAllContent;
     public event EventHandler<TableViewExportContentEventArgs>? ExportSelectedContent;

--- a/src/WinUI.TableView/TableViewRow.cs
+++ b/src/WinUI.TableView/TableViewRow.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -22,6 +23,8 @@ public class TableViewRow : ListViewItem
     private TableViewCellsPresenter? _cellPresenter;
     private bool _ensureCells = true;
     private Border? _selectionBackground;
+    private Brush? _cellPresenterBackground;
+    private Brush? _cellPresenterForeground;
 
     public TableViewRow()
     {
@@ -103,6 +106,8 @@ public class TableViewRow : ListViewItem
                 cell.RefreshElement();
             }
         }
+
+        EnsureAlternateColors();
     }
 
     protected override void OnPointerPressed(PointerRoutedEventArgs e)
@@ -144,9 +149,13 @@ public class TableViewRow : ListViewItem
         }
 
         _cellPresenter = ContentTemplateRoot as TableViewCellsPresenter;
+
         if (_cellPresenter is not null)
         {
+            _cellPresenterBackground = _cellPresenter.Background;
+            _cellPresenterForeground = _cellPresenter.Foreground;
             _cellPresenter.Children.Clear();
+
             AddCells(TableView.Columns.VisibleColumns);
         }
 
@@ -344,6 +353,17 @@ public class TableViewRow : ListViewItem
                                      ? new Thickness(16, 0, 16, 0)
                                      : new Thickness(20, 0, 16, 0);
         }
+    }
+
+    internal void EnsureAlternateColors()
+    {
+        if (TableView is null || _cellPresenter is null) return;
+
+        _cellPresenter.Background =
+            Index % 2 == 1 && TableView.AlternateRowBackground is not null ? TableView.AlternateRowBackground : _cellPresenterBackground;
+
+        _cellPresenter.Foreground =
+            Index % 2 == 1 && TableView.AlternateRowForeground is not null ? TableView.AlternateRowForeground : _cellPresenterForeground;
     }
 
     internal IList<TableViewCell> Cells => _cellPresenter?.Cells ?? new List<TableViewCell>();


### PR DESCRIPTION
Closes #21  

![image](https://github.com/user-attachments/assets/e1aa21ed-b133-4721-be27-173e5bb0a360)


### Description  
This PR introduces new properties to provide greater flexibility for customizing the appearance of alternate rows and improving readability.

1. **`AlternateRowBackground`**  
   Sets the background color for alternate rows.  

2. **`AlternateRowForeground`**  
   Sets the foreground color (e.g., text color) for alternate rows.  
