### PR TITLE
Adding Header, Cell, Element styles

### DIFF
--- a/src/WinUI.TableView/Columns/TableViewBoundColumn.cs
+++ b/src/WinUI.TableView/Columns/TableViewBoundColumn.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml.Data;
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
 using System;
 using System.Reflection;
 using WinUI.TableView.Extensions;
@@ -68,4 +69,56 @@ public abstract class TableViewBoundColumn : TableViewColumn
             }
         }
     }
+
+    /// <summary>
+    /// Handles changes to the ElementStyle property.
+    /// </summary>
+    private static void OnElementStyleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableViewColumn column && column.OwningCollection is { })
+        {
+            column.OwningCollection.HandleColumnPropertyChanged(column, nameof(ElementStyle));
+        }
+    }
+
+    /// <summary>
+    /// Handles changes to the EditingElementStyle property.
+    /// </summary>
+    private static void OnEditingElementStyleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableViewColumn column && column.OwningCollection is { })
+        {
+            column.OwningCollection.HandleColumnPropertyChanged(column, nameof(EditingElementStyle));
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the style that is used when rendering the element that the column
+    /// displays for a cell that is not in editing mode.
+    /// </summary>
+    public Style ElementStyle
+    {
+        get => (Style)GetValue(ElementStyleProperty);
+        set => SetValue(ElementStyleProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the style that is used when rendering the element that the column
+    /// displays for a cell in editing mode.
+    /// </summary>
+    public Style EditingElementStyle
+    {
+        get => (Style)GetValue(EditingElementStyleProperty);
+        set => SetValue(EditingElementStyleProperty, value);
+    }
+
+    /// <summary>
+    /// Identifies the <see cref="ElementStyle"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty ElementStyleProperty = DependencyProperty.Register(nameof(ElementStyle), typeof(Style), typeof(TableViewBoundColumn), new PropertyMetadata(null, OnElementStyleChanged));
+
+    /// <summary>
+    /// Identifies the <see cref="EditingElementStyle"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty EditingElementStyleProperty = DependencyProperty.Register(nameof(EditingElementStyle), typeof(Style), typeof(TableViewBoundColumn), new PropertyMetadata(null, OnEditingElementStyleChanged));
 }

--- a/src/WinUI.TableView/Columns/TableViewCheckBoxColumn.cs
+++ b/src/WinUI.TableView/Columns/TableViewCheckBoxColumn.cs
@@ -8,6 +8,7 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents a column in a TableView that displays a CheckBox.
 /// </summary>
+[StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(CheckBox))]
 public class TableViewCheckBoxColumn : TableViewBoundColumn
 {
     /// <summary>

--- a/src/WinUI.TableView/Columns/TableViewColumn.cs
+++ b/src/WinUI.TableView/Columns/TableViewColumn.cs
@@ -136,7 +136,7 @@ public abstract class TableViewColumn : DependencyObject
     }
 
     /// <summary>
-    /// Gets or sets the style for the column header.
+    /// Gets or sets the style that is used when rendering the column header.
     /// </summary>
     public Style? HeaderStyle
     {
@@ -146,7 +146,7 @@ public abstract class TableViewColumn : DependencyObject
 
 
     /// <summary>
-    /// Gets or sets the style for the cells.
+    /// Gets or sets the style that is used to render cells in the column.
     /// </summary>
     public Style CellStyle
     {

--- a/src/WinUI.TableView/Columns/TableViewComboBoxColumn.cs
+++ b/src/WinUI.TableView/Columns/TableViewComboBoxColumn.cs
@@ -8,6 +8,8 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents a column in a TableView that displays a ComboBox.
 /// </summary>
+[StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(TextBlock))]
+[StyleTypedProperty(Property = nameof(EditingElementStyle), StyleTargetType = typeof(ComboBox))]
 public class TableViewComboBoxColumn : TableViewBoundColumn
 {
     private Binding? _textBinding;

--- a/src/WinUI.TableView/Columns/TableViewDateColumn.cs
+++ b/src/WinUI.TableView/Columns/TableViewDateColumn.cs
@@ -13,6 +13,8 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents a column in a TableView that displays a date.
 /// </summary>
+[StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(TextBlock))]
+[StyleTypedProperty(Property = nameof(EditingElementStyle), StyleTargetType = typeof(TableViewDatePicker))]
 public partial class TableViewDateColumn : TableViewBoundColumn
 {
     /// <summary>

--- a/src/WinUI.TableView/Columns/TableViewNumberColumn.cs
+++ b/src/WinUI.TableView/Columns/TableViewNumberColumn.cs
@@ -18,6 +18,7 @@ public class TableViewNumberColumn : TableViewBoundColumn
     {
         var textBlock = new TextBlock
         {
+            TextAlignment = TextAlignment.Right,
             Margin = new Thickness(12, 0, 12, 0),
         };
         textBlock.SetBinding(TextBlock.TextProperty, Binding);

--- a/src/WinUI.TableView/Columns/TableViewNumberColumn.cs
+++ b/src/WinUI.TableView/Columns/TableViewNumberColumn.cs
@@ -6,6 +6,8 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents a column in a TableView that displays a number.
 /// </summary>
+[StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(TextBlock))]
+[StyleTypedProperty(Property = nameof(EditingElementStyle), StyleTargetType = typeof(NumberBox))]
 public class TableViewNumberColumn : TableViewBoundColumn
 {
     /// <summary>

--- a/src/WinUI.TableView/Columns/TableViewTextColumn.cs
+++ b/src/WinUI.TableView/Columns/TableViewTextColumn.cs
@@ -6,6 +6,8 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents a column in a TableView that displays text.
 /// </summary>
+[StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(TextBlock))]
+[StyleTypedProperty(Property = nameof(EditingElementStyle), StyleTargetType = typeof(TextBox))]
 public class TableViewTextColumn : TableViewBoundColumn
 {
     /// <summary>

--- a/src/WinUI.TableView/Columns/TableViewTimeColumn.cs
+++ b/src/WinUI.TableView/Columns/TableViewTimeColumn.cs
@@ -12,6 +12,8 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents a column in a TableView that displays time.
 /// </summary>
+[StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(TextBlock))]
+[StyleTypedProperty(Property = nameof(EditingElementStyle), StyleTargetType = typeof(TableViewTimePicker))]
 public partial class TableViewTimeColumn : TableViewBoundColumn
 {
     /// <summary>

--- a/src/WinUI.TableView/Columns/TableViewToggleSwitchColumn.cs
+++ b/src/WinUI.TableView/Columns/TableViewToggleSwitchColumn.cs
@@ -7,6 +7,7 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents a column in a TableView that displays a ToggleSwitch.
 /// </summary>
+[StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(ToggleSwitch))]
 public class TableViewToggleSwitchColumn : TableViewBoundColumn
 {
     /// <summary>

--- a/src/WinUI.TableView/TableView.Properties.cs
+++ b/src/WinUI.TableView/TableView.Properties.cs
@@ -453,7 +453,7 @@ public partial class TableView
     }
 
     /// <summary>
-    /// Gets or sets the style for the column headers.
+    /// Gets or sets the style applied to all column headers.
     /// </summary>
     public Style ColumnHeaderStyle
     {
@@ -462,7 +462,7 @@ public partial class TableView
     }
 
     /// <summary>
-    /// Gets or sets the style for the cells.
+    /// Gets or sets the style applied to all cells.
     /// </summary>
     public Style CellStyle
     {

--- a/src/WinUI.TableView/TableView.Properties.cs
+++ b/src/WinUI.TableView/TableView.Properties.cs
@@ -141,6 +141,16 @@ public partial class TableView
     public static readonly DependencyProperty CellContextFlyoutProperty = DependencyProperty.Register(nameof(CellContextFlyout), typeof(FlyoutBase), typeof(TableView), new PropertyMetadata(null));
 
     /// <summary>
+    /// Identifies the ColumnHeaderStyle dependency property.
+    /// </summary>
+    public static readonly DependencyProperty ColumnHeaderStyleProperty = DependencyProperty.Register(nameof(ColumnHeaderStyle), typeof(Style), typeof(TableView), new PropertyMetadata(null, OnColumnHeaderStyleChanged));
+
+    /// <summary>
+    /// Identifies the CellStyle dependency property.
+    /// </summary>
+    public static readonly DependencyProperty CellStyleProperty = DependencyProperty.Register(nameof(CellStyle), typeof(Style), typeof(TableView), new PropertyMetadata(null, OnCellStyleChanged));
+
+    /// <summary>
     /// Gets the collection view associated with the TableView.
     /// </summary>
     public ICollectionView CollectionView => _collectionView;
@@ -443,6 +453,24 @@ public partial class TableView
     }
 
     /// <summary>
+    /// Gets or sets the style for the column headers.
+    /// </summary>
+    public Style ColumnHeaderStyle
+    {
+        get => (Style)GetValue(ColumnHeaderStyleProperty);
+        set => SetValue(ColumnHeaderStyleProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the style for the cells.
+    /// </summary>
+    public Style CellStyle
+    {
+        get => (Style)GetValue(CellStyleProperty);
+        set => SetValue(CellStyleProperty, value);
+    }
+
+    /// <summary>
     /// Handles changes to the ItemsSource property.
     /// </summary>
     private static void OnItemsSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -596,6 +624,28 @@ public partial class TableView
         if (d is TableView tableView)
         {
             tableView.EnsureAlternateRowColors();
+        }
+    }
+
+    /// <summary>
+    /// Handles changes to the ColumnHeaderStyle property.
+    /// </summary>
+    private static void OnColumnHeaderStyleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView)
+        {
+            tableView.EnsureColumnHeadersStyle();
+        }
+    }
+
+    /// <summary>
+    /// Handles changes to the CellStyle property.
+    /// </summary>
+    private static void OnCellStyleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView)
+        {
+            tableView.EnsureCellsStyle();
         }
     }
 

--- a/src/WinUI.TableView/TableView.cs
+++ b/src/WinUI.TableView/TableView.cs
@@ -30,6 +30,8 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents a control that displays data in customizable table-like interface.
 /// </summary>
+[StyleTypedProperty(Property = nameof(ColumnHeaderStyle), StyleTargetType = typeof(TableViewColumnHeader))]
+[StyleTypedProperty(Property = nameof(CellStyle), StyleTargetType = typeof(TableViewCell))]
 public partial class TableView : ListView
 {
     private TableViewHeaderRow? _headerRow;
@@ -1273,6 +1275,28 @@ public partial class TableView : ListView
                 row.EnsureAlternateColors();
             }
         });
+    }
+
+    /// <summary>
+    /// Ensures the column headers style is applied.
+    /// </summary>
+    private void EnsureColumnHeadersStyle()
+    {
+        foreach (var column in Columns)
+        {
+            column.EnsureHeaderStyle();
+        }
+    }
+
+    /// <summary>
+    /// Ensures the cells style is applied.
+    /// </summary>
+    private void EnsureCellsStyle()
+    {
+        foreach (var row in _rows)
+        {
+            row.EnsureCellsStyle();
+        }
     }
 
     /// <summary>

--- a/src/WinUI.TableView/TableViewCell.cs
+++ b/src/WinUI.TableView/TableViewCell.cs
@@ -302,7 +302,14 @@ public partial class TableViewCell : ContentControl
     /// </summary>
     internal void SetElement()
     {
-        Content = Column?.GenerateElement(this, Row?.Content);
+        var element = Column?.GenerateElement(this, Row?.Content);
+
+        if (element is not null && Column is TableViewBoundColumn boundColumn)
+        {
+            element.Style = boundColumn.ElementStyle;
+        }
+
+        Content = element;
     }
 
     /// <summary>
@@ -312,7 +319,14 @@ public partial class TableViewCell : ContentControl
     {
         if (Column?.UseSingleElement is false)
         {
-            Content = Column.GenerateEditingElement(this, Row?.Content);
+            var element = Column.GenerateEditingElement(this, Row?.Content);
+
+            if(element is not null && Column is TableViewBoundColumn boundColumn)
+            {
+                element.Style = boundColumn.EditingElementStyle;
+            }
+
+            Content = element;
         }
 
         if (TableView is not null)

--- a/src/WinUI.TableView/TableViewRow.cs
+++ b/src/WinUI.TableView/TableViewRow.cs
@@ -265,6 +265,34 @@ public partial class TableViewRow : ListViewItem
         {
             UpdateCellsState();
         }
+        else if (e.PropertyName is nameof(TableViewColumn.CellStyle))
+        {
+            EnsureCellsStyle(e.Column);
+        }
+        else if (e.PropertyName is nameof(TableViewBoundColumn.ElementStyle))
+        {
+            foreach (var cell in Cells)
+            {
+                if (cell.Column == e.Column
+                    && cell.Content is FrameworkElement element
+                    && cell.Column is TableViewBoundColumn boundColumn
+                    && (TableView?.IsEditing is false || TableView?.CurrentCellSlot != cell.Slot))
+                {
+                    element.Style = boundColumn.ElementStyle;
+                }
+            }
+        }
+        else if (e.PropertyName is nameof(TableViewBoundColumn.EditingElementStyle))
+        {
+            if (TableView?.IsEditing is true
+                && TableView.CurrentCellSlot is not null
+                && e.Column is TableViewBoundColumn boundColumn
+                && TableView.GetCellFromSlot(TableView.CurrentCellSlot.Value) is { } cell
+                && cell.Content is FrameworkElement element)
+            {
+                element.Style = boundColumn.EditingElementStyle;
+            }
+        }
     }
 
     /// <summary>
@@ -301,6 +329,7 @@ public partial class TableViewRow : ListViewItem
                     TableView = TableView!,
                     Index = TableView.Columns.VisibleColumns.IndexOf(column),
                     Width = column.ActualWidth,
+                    Style = column.CellStyle ?? TableView.CellStyle
                 };
 
                 index = Math.Min(index, _cellPresenter.Children.Count);
@@ -361,6 +390,20 @@ public partial class TableViewRow : ListViewItem
         foreach (var cell in Cells)
         {
             cell.UpdateElementState();
+        }
+    }
+
+    /// <summary>
+    /// Ensures the cells style is applied.
+    /// </summary>
+    internal void EnsureCellsStyle(TableViewColumn? column = null)
+    {
+        var cells = Cells.Where(x => column is null || x.Column == column);
+
+        foreach (var cell in cells)
+        {
+            var style = cell.Column?.CellStyle ?? TableView?.CellStyle;
+            cell.Style = style;
         }
     }
 


### PR DESCRIPTION
This pulls request introduces offers easy implementation of styles for column headers, cells, display elements and editing elements.

### Properties
- **`TableView.ColumnHeaderStyle`**: Gets or sets the style applied to all column headers.
- **`TableView.CellStyle`:** Gets or sets the style applied to all cells.
- **`TableViewColumn.HeaderStyle`:** Gets or sets the style that is used when rendering the column header. This will override 'TableView.ColumnHeaderStyle'.
- **`TableViewCoolumn.CellStyle`**: Gets or sets the style that is used to render cells in the column. This will override 'TableView.CellStyle'.
- **`TableViewBoundColumn.ElementStyle`:** Gets or sets the style that is used when rendering the element that the column displays for a cell that is not in editing mode. 
- **`TableViewBoundColumn.EditingElementStyle`**: Gets or sets the style that is used when rendering the element that the column displays for a cell in editing mode.