### PR TITLE
Fire ContextFlyoutOpened even if Flyout is null

### DIFF
--- a/src/EventArgs/TableViewCellContextFlyoutEventArgs.cs
+++ b/src/EventArgs/TableViewCellContextFlyoutEventArgs.cs
@@ -15,7 +15,7 @@ public partial class TableViewCellContextFlyoutEventArgs : HandledEventArgs
     /// <param name="cell">The cell for which the context flyout is being shown.</param>
     /// <param name="item">The item associated with the cell.</param>
     /// <param name="flyout">The context flyout to be shown.</param>
-    public TableViewCellContextFlyoutEventArgs(TableViewCellSlot slot, TableViewCell cell, object item, FlyoutBase flyout)
+    public TableViewCellContextFlyoutEventArgs(TableViewCellSlot slot, TableViewCell cell, object item, FlyoutBase? flyout)
     {
         Slot = slot;
         Cell = cell;
@@ -41,5 +41,5 @@ public partial class TableViewCellContextFlyoutEventArgs : HandledEventArgs
     /// <summary>
     /// Gets the context flyout to be shown.
     /// </summary>
-    public FlyoutBase Flyout { get; }
+    public FlyoutBase? Flyout { get; }
 }

--- a/src/EventArgs/TableViewRowContextFlyoutEventArgs.cs
+++ b/src/EventArgs/TableViewRowContextFlyoutEventArgs.cs
@@ -15,7 +15,7 @@ public partial class TableViewRowContextFlyoutEventArgs : HandledEventArgs
     /// <param name="row">The TableViewRow associated with the event.</param>
     /// <param name="item">The item associated with the row.</param>
     /// <param name="flyout">The flyout to be shown.</param>
-    public TableViewRowContextFlyoutEventArgs(int index, TableViewRow row, object item, FlyoutBase flyout)
+    public TableViewRowContextFlyoutEventArgs(int index, TableViewRow row, object item, FlyoutBase? flyout)
     {
         Index = index;
         Row = row;
@@ -41,5 +41,5 @@ public partial class TableViewRowContextFlyoutEventArgs : HandledEventArgs
     /// <summary>
     /// Gets the flyout to be shown.
     /// </summary>
-    public FlyoutBase Flyout { get; }
+    public FlyoutBase? Flyout { get; }
 }

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -1295,10 +1295,11 @@ public partial class TableView : ListView
     /// </summary>
     internal void ShowRowContext(TableViewRow row, Point position)
     {
-        if (RowContextFlyout is null) return;
 
         var eventArgs = new TableViewRowContextFlyoutEventArgs(row.Index, row, row.Content, RowContextFlyout);
         RowContextFlyoutOpening?.Invoke(this, eventArgs);
+
+        if (RowContextFlyout is null) return;
 
         if (!eventArgs.Handled)
         {
@@ -1318,10 +1319,11 @@ public partial class TableView : ListView
     /// </summary>
     internal void ShowCellContext(TableViewCell cell, Point position)
     {
-        if (CellContextFlyout is null) return;
 
         var eventArgs = new TableViewCellContextFlyoutEventArgs(cell.Slot, cell, cell.Row?.Content!, CellContextFlyout);
         CellContextFlyoutOpening?.Invoke(this, eventArgs);
+
+        if (CellContextFlyout is null) return;
 
         if (!eventArgs.Handled)
         {

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -1295,13 +1295,10 @@ public partial class TableView : ListView
     /// </summary>
     internal void ShowRowContext(TableViewRow row, Point position)
     {
-
         var eventArgs = new TableViewRowContextFlyoutEventArgs(row.Index, row, row.Content, RowContextFlyout);
         RowContextFlyoutOpening?.Invoke(this, eventArgs);
 
-        if (RowContextFlyout is null) return;
-
-        if (!eventArgs.Handled)
+        if (RowContextFlyout is not null && !eventArgs.Handled)
         {
             var presenter = row.FindDescendant<ListViewItemPresenter>();
 
@@ -1319,13 +1316,10 @@ public partial class TableView : ListView
     /// </summary>
     internal void ShowCellContext(TableViewCell cell, Point position)
     {
-
         var eventArgs = new TableViewCellContextFlyoutEventArgs(cell.Slot, cell, cell.Row?.Content!, CellContextFlyout);
         CellContextFlyoutOpening?.Invoke(this, eventArgs);
 
-        if (CellContextFlyout is null) return;
-
-        if (!eventArgs.Handled)
+        if (CellContextFlyout is not null && !eventArgs.Handled)
         {
             CellContextFlyout.ShowAt(cell, new FlyoutShowOptions
             {


### PR DESCRIPTION
As I wrote in Issue #106 :
> My usecase demands that I show a Window when requested by user's Right-Mouse-Click, while current solution forces me to use a Flyout instead. I could use a Flyout with a single menuitem that invokes my window but users don't like that.
A Workaround is to define an (empty) Dummy-Flyout and set the Handled Flag in the Eventhandler in order to suppress the Flyout.ShowAt().

Idea: Always fire ContextFlyoutOpened (if set), **then** check for Flyout not null and open it (if args.Handled is not set) .
