### PR TITLE
Project update

### DIFF
--- a/src/WinUI.TableView.csproj
+++ b/src/WinUI.TableView.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">
-    <PackageReference Include="Uno.WinUI" Version="5.6.91" />
+    <PackageReference Include="Uno.WinUI" Version="6.0.465" />
   </ItemGroup>
   
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">

--- a/src/WinUI.TableView.csproj
+++ b/src/WinUI.TableView.csproj
@@ -5,8 +5,8 @@
       net9.0;
       net8.0-windows10.0.19041.0;
       net9.0-windows10.0.19041.0;
-    </TargetFrameworks>
-    <Nullable>enable</Nullable>
+    </TargetFrameworks> 
+    <Nullable>enable</Nullable> 
   </PropertyGroup>
 
   <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows'">
@@ -16,9 +16,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.1.240916" />
+    <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402" />
+    <!--CommunityToolkit.WinUI.Behaviors version 8.2 is not supported on .net8.0 so let's downgrade it-->
+    <PackageReference Update="CommunityToolkit.WinUI.Behaviors" Version="8.1.240916" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
-
+  
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">
     <PackageReference Include="Uno.WinUI" Version="5.6.91" />
   </ItemGroup>
@@ -26,7 +28,7 @@
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
   </ItemGroup>
-
+  
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">
     <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
     <Compile Update="**\*.xaml.cs">

--- a/src/WinUI.TableView.csproj
+++ b/src/WinUI.TableView.csproj
@@ -1,34 +1,38 @@
-﻿<Project Sdk="Uno.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>
-      net8.0-desktop;
-      net8.0-maccatalyst;
-      net8.0-windows10.0.22621.0;
-      net8.0-browserwasm;
+      net8.0;
+      net9.0;
+      net8.0-windows10.0.19041.0;
+      net9.0-windows10.0.19041.0;
     </TargetFrameworks>
-    <IsPackable>true</IsPackable>
-    <UnoSingleProject>true</UnoSingleProject>
-    <OutputType>Library</OutputType>
-    <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
-    <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <Nullable>enable</Nullable>
-    <DisableImplicitUnoPackages>true</DisableImplicitUnoPackages>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows'">
+    <UseWinUI>true</UseWinUI>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <WindowsSdkPackageVersion>10.0.19041.56</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.1.240916" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'windows'">
-    <PackageReference Include="Uno.WinUI" Version="5.6.91" />    
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">
+    <PackageReference Include="Uno.WinUI" Version="5.6.91" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows'">
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">
+    <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+    <Compile Update="**\*.xaml.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
+    <PRIResource Include="**\*.resw" Exclude="bin\**\*.resw;obj\**\*.resw" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-    "Uno.Sdk": "5.6.51"
-  }
-}


### PR DESCRIPTION
This PR will make WinUI.TableView able to be used on all the Uno-platform targets including Android and iOS.

- Removed Uno SDK from the project.
- Upgraded `CommunityToolkit.WinUI.Behaviors` package to 8.2.250402.