### PR TITLE
added HeaderRowMin & Max properties

### DIFF
--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -28,7 +28,17 @@ public partial class TableView
     /// <summary>
     /// Identifies the HeaderRowHeight dependency property.
     /// </summary>
-    public static readonly DependencyProperty HeaderRowHeightProperty = DependencyProperty.Register(nameof(HeaderRowHeight), typeof(double), typeof(TableView), new PropertyMetadata(32d, OnHeaderRowHeightChanged));
+    public static readonly DependencyProperty HeaderRowHeightProperty = DependencyProperty.Register(nameof(HeaderRowHeight), typeof(double), typeof(TableView), new PropertyMetadata(double.NaN, OnHeaderRowHeightChanged));
+
+    /// <summary>
+    /// Identifies the HeaderRowMaxHeight dependency property.
+    /// </summary>
+    public static readonly DependencyProperty HeaderRowMaxHeightProperty = DependencyProperty.Register(nameof(HeaderRowMaxHeight), typeof(double), typeof(TableView), new PropertyMetadata(double.PositiveInfinity, OnHeaderRowHeightChanged));
+
+    /// <summary>
+    /// Identifies the HeaderRowMinHeight dependency property.
+    /// </summary>
+    public static readonly DependencyProperty HeaderRowMinHeightProperty = DependencyProperty.Register(nameof(HeaderRowMinHeight), typeof(double), typeof(TableView), new PropertyMetadata(32d, OnHeaderRowHeightChanged));
 
     /// <summary>
     /// Identifies the RowHeight dependency property.
@@ -250,6 +260,24 @@ public partial class TableView
     {
         get => (double)GetValue(HeaderRowHeightProperty);
         set => SetValue(HeaderRowHeightProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the max height of the header row.
+    /// </summary>
+    public double HeaderRowMaxHeight
+    {
+        get => (double)GetValue(HeaderRowMaxHeightProperty);
+        set => SetValue(HeaderRowMaxHeightProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the min height of the header row.
+    /// </summary>
+    public double HeaderRowMinHeight
+    {
+        get => (double)GetValue(HeaderRowMinHeightProperty);
+        set => SetValue(HeaderRowMinHeightProperty, value);
     }
 
     /// <summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -735,7 +735,7 @@ public partial class TableView : ListView
             var verticalScrollBar = scrollViewer.FindDescendant<ScrollBar>(x => x.Name == "VerticalScrollBar");
             if (verticalScrollBar is not null)
             {
-                verticalScrollBar.Margin = new Thickness(0, HeaderRowHeight, 0, 0);
+                verticalScrollBar.Margin = new Thickness(0, _headerRow?.ActualHeight ?? 0, 0, 0);
             }
         }
     }
@@ -1364,7 +1364,7 @@ public partial class TableView : ListView
             RowContextFlyout.ShowAt(row, new FlyoutShowOptions
             {
 #if WINDOWS
-                ShowMode = FlyoutShowMode.Standard, 
+                ShowMode = FlyoutShowMode.Standard,
 #endif
                 Placement = RowContextFlyout.Placement,
                 Position = position
@@ -1389,7 +1389,7 @@ public partial class TableView : ListView
             CellContextFlyout.ShowAt(cell, new FlyoutShowOptions
             {
 #if WINDOWS
-                ShowMode = FlyoutShowMode.Standard, 
+                ShowMode = FlyoutShowMode.Standard,
 #endif
                 Placement = CellContextFlyout.Placement,
                 Position = position

--- a/src/TableViewHeaderRow.cs
+++ b/src/TableViewHeaderRow.cs
@@ -224,7 +224,7 @@ public partial class TableViewHeaderRow : Control
             var autoColumns = allColumns.Where(x => x.Width.IsAuto).ToList();
             var absoluteColumns = allColumns.Where(x => x.Width.IsAbsolute).ToList();
 
-            var height = TableView.HeaderRowHeight;
+            var height = ActualHeight;
             var availableWidth = TableView.ActualWidth - 32;
             var starUnitWeight = starColumns.Select(x => x.Width.Value).Sum();
             var fixedWidth = autoColumns.Select(x =>
@@ -294,7 +294,7 @@ public partial class TableViewHeaderRow : Control
                     DispatcherQueue.TryEnqueue(() =>
                         header.Measure(
                             new Size(header.Width,
-                            _headersStackPanel?.ActualHeight ?? TableView.HeaderRowHeight)));
+                            _headersStackPanel?.ActualHeight ?? ActualHeight)));
                 }
             }
 

--- a/src/Themes/TableView.xaml
+++ b/src/Themes/TableView.xaml
@@ -103,6 +103,8 @@
                                     <local:TableViewHeaderRow x:Name="HeaderRow" 
                                                               IsTabStop="False"
                                                               Height="{TemplateBinding HeaderRowHeight}"
+                                                              MaxHeight="{TemplateBinding HeaderRowMaxHeight}"
+                                                              MinHeight="{TemplateBinding HeaderRowMinHeight}"
                                                               TableView="{Binding RelativeSource={RelativeSource TemplatedParent}}">
                                         <interactivity:Interaction.Behaviors>
                                             <behaviors:StickyHeaderBehavior />

--- a/src/Themes/TableViewHeaderRow.xaml
+++ b/src/Themes/TableViewHeaderRow.xaml
@@ -8,8 +8,6 @@
 
     <Style x:Key="DefaultTableViewHeaderRowStyle"
            TargetType="local:TableViewHeaderRow">
-        <Setter Property="Height"
-                Value="32" />
         <Setter Property="Background"
                 Value="{ThemeResource TableViewHeaderRowBackground}" />
         <Setter Property="Template">


### PR DESCRIPTION
* `HeaderRowMinHeight` property added with default value `32d`.
* `HeaderRowMaxHeight` property added with default value `double.PositiveInfinity`.
* Changed default value of `HeaderRowHeight` from `32d` to `double.NaN` to support auto height increase.