### PR TITLE
Suppress ScrollRowIntoView during multi‑selection

### DIFF
--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -79,9 +79,9 @@ public partial class TableView : ListView
         CurrentCellSlot = null;
         OnCellSelectionChanged();
 
-        if (SelectedItems?.Count <= 1)
+        if (SelectedItems?.Count == 1)
         {
-            DispatcherQueue.TryEnqueue(async () => await ScrollRowIntoView(base.SelectedIndex));
+            DispatcherQueue.TryEnqueue(async () => await ScrollRowIntoView(SelectedIndex));
         }
     }
 

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -79,9 +79,9 @@ public partial class TableView : ListView
         CurrentCellSlot = null;
         OnCellSelectionChanged();
 
-        if (SelectedIndex > 0)
+        if (SelectedItems?.Count <= 1)
         {
-            DispatcherQueue.TryEnqueue(async () => await ScrollRowIntoView(SelectedIndex));
+            DispatcherQueue.TryEnqueue(async () => await ScrollRowIntoView(base.SelectedIndex));
         }
     }
 


### PR DESCRIPTION
When doing multiple selectionsin a scrolled TableView, the view unexpectedly jumps around. The issue is caused by the ScrollRowIntoView call being executed every time selection changes—even when several rows/cells are being selected simultaneously.

This change ensures that ScrollRowIntoView is only triggered when exactly one row is selected.

Maybe it should also been considered, to dont do it at all. I guess its used anyway only if a row/cell is set programatically and then we can use the ScrollIntView...direct from code.