### PR TITLE
Fix for #169

### DIFF
--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -261,6 +261,22 @@ public partial class TableViewColumnHeader : ContentControl
 
             e.Handled = true;
         }
+        else if (e.Key == VirtualKey.Space)
+        {
+            // Prevent the Space key event from bubbling up to the TableView
+            // but still allow normal text input
+
+            e.Handled = true;
+
+            // Manually add the space character to the TextBox
+            if (_searchBox != null)
+            {
+                var selectionStart = _searchBox.SelectionStart;
+                var currentText = _searchBox.Text ?? string.Empty;
+                _searchBox.Text = currentText.Insert(selectionStart, " ");
+                _searchBox.SelectionStart = selectionStart + 1;
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
When typing in the embedded search TextBox, pressing Spacebar was bubbling up to the TableView,

causing unintended row selection or scrolling.

This fix:
- marks the Space key event as handled when focus is in the search box
- manually inserts a space character into the TextBox at the caret
- prevents TableView from reacting to Space input during search

Fixes #169