### PR TITLE
Improve Columns Collection to work with XAML Hot Reload

### DIFF
--- a/src/EventArgs/TableViewColumnPropertyChangedEventArgs.cs
+++ b/src/EventArgs/TableViewColumnPropertyChangedEventArgs.cs
@@ -5,7 +5,7 @@ namespace WinUI.TableView;
 /// <summary>
 /// Provides data for the ColumnPropertyChanged event.
 /// </summary>
-internal class TableViewColumnPropertyChangedEventArgs : EventArgs
+public class TableViewColumnPropertyChangedEventArgs : EventArgs
 {
     /// <summary>
     /// Initializes a new instance of the TableViewColumnPropertyChanged class.

--- a/src/ITableViewColumnsCollection.cs
+++ b/src/ITableViewColumnsCollection.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.UI.Xaml;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Represents a collection of columns in a <see cref="WinUI.TableView.TableView"/>, providing functionality to manage and interact with the columns.
+/// </summary>
+/// <remarks>This interface extends <see cref="IList{T}"/> to provide standard list operations for <see
+/// cref="TableViewColumn"/> objects. It also implements <see cref="INotifyCollectionChanged"/> to notify subscribers of
+/// changes to the collection, such as additions or removals.</remarks>
+public interface ITableViewColumnsCollection : IList<TableViewColumn>, INotifyCollectionChanged
+{
+    /// <summary>
+    /// Occurs when a property of a column changes.
+    /// </summary>
+    /// <remarks>
+    /// This event is triggered to notify subscribers about changes to column properties, such as width, visibility, or other attributes.
+    /// Handlers can use the <see cref="TableViewColumnPropertyChangedEventArgs"/> parameter to access details about the specific property that changed.
+    /// </remarks>
+    event EventHandler<TableViewColumnPropertyChangedEventArgs>? ColumnPropertyChanged;
+
+    /// <summary>
+    /// Gets the list of visible <see cref="TableViewColumn"/>s.
+    /// </summary>
+    /// <remarks>
+    /// The result is a list of columns that are currently visible in the table view, meaning their <see cref="TableViewColumn.Visibility"/> is set to <see cref="Visibility.Visible"/>.
+    /// The result is also ordered by the <see cref="TableViewColumn.Order"/> property, allowing for a consistent display order of the columns.
+    /// </remarks>
+    IList<TableViewColumn> VisibleColumns { get; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="WinUI.TableView.TableView"/> associated with the collection.
+    /// </summary>
+    /// <remarks>
+    /// This property allows access to the <see cref="WinUI.TableView.TableView"/> that owns this collection of columns.
+    /// </remarks>
+    TableView? TableView { get; }
+}

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -265,7 +265,7 @@ public partial class TableView
     /// <summary>
     /// Gets the collection of columns in the TableView.
     /// </summary>
-    public TableViewColumnsCollection Columns { get; } = [];
+    public ITableViewColumnsCollection Columns { get; }
 
     /// <summary>
     /// Gets or sets the height of the header row.

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -48,7 +48,7 @@ public partial class TableView : ListView
     {
         DefaultStyleKey = typeof(TableView);
 
-        Columns.TableView = this;
+        Columns = new TableViewColumnsCollection(this);
         FilterHandler = new ColumnFilterHandler(this);
         base.ItemsSource = _collectionView;
         base.SelectionMode = SelectionMode;

--- a/src/TableViewColumnsCollection.cs
+++ b/src/TableViewColumnsCollection.cs
@@ -1,70 +1,162 @@
 ﻿using Microsoft.UI.Xaml;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.ComponentModel;
 using System.Linq;
+using Windows.Foundation.Collections;
 
 namespace WinUI.TableView;
 
 /// <summary>
-/// Represents a collection of columns in a TableView.
+/// Represents a collection of <see cref="TableViewColumn"/> objects used in a <see cref="WinUI.TableView.TableView"/>.
 /// </summary>
-public partial class TableViewColumnsCollection : ObservableCollection<TableViewColumn>
+/// <remarks>This collection provides functionality for managing columns in a <see cref="WinUI.TableView.TableView"/>, including adding,
+/// removing,  and tracking changes to column properties. It supports notifications for collection changes and column 
+/// property changes, enabling dynamic updates to the <see cref="WinUI.TableView.TableView"/>.</remarks>
+public partial class TableViewColumnsCollection : DependencyObjectCollection, ITableViewColumnsCollection
 {
-    /// <summary>
-    /// Occurs when a property of a column in the collection changes.
-    /// </summary>
-    internal event EventHandler<TableViewColumnPropertyChangedEventArgs>? ColumnPropertyChanged;
-
-    /// <summary>
-    /// Gets the list of visible columns in the collection.
-    /// </summary>
-    internal IList<TableViewColumn> VisibleColumns =>
-        [.. Items.Where(x => x.Visibility == Visibility.Visible)
-                 .OrderBy(x => x.Order ?? 0)];
-
+    private TableViewColumn[] _itemsCopy = []; // To keep a copy of the items to keep track of removed items
     /// <inheritdoc/>
-    protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+    public event EventHandler<TableViewColumnPropertyChangedEventArgs>? ColumnPropertyChanged;
+    /// <inheritdoc/>
+    public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+    /// <summary>
+    /// The constructor for the <see cref="TableViewColumnsCollection"/> class.
+    /// </summary>
+    /// <param name="tableView">
+    /// The <see cref="WinUI.TableView.TableView"/> that owns this collection.
+    /// </param>
+    public TableViewColumnsCollection(TableView tableView)
     {
-        base.OnCollectionChanged(e);
+        TableView = tableView ?? throw new ArgumentNullException(nameof(tableView));
+        VectorChanged += OnVectorChanged;
+    }
 
-        if (e.NewItems != null)
+    /// <summary>
+    /// Handles changes to the underlying vector of <see cref="DependencyObject"/> items.
+    /// </summary>
+    private void OnVectorChanged(IObservableVector<DependencyObject> sender, IVectorChangedEventArgs args)
+    {
+        var index = (int)args.Index;
+
+        switch (args.CollectionChange)
         {
-            foreach (var column in e.NewItems.OfType<TableViewColumn>())
-            {
-                column.SetOwningCollection(this);
-                column.SetOwningTableView(TableView!);
-            }
+            case CollectionChange.ItemInserted:
+                if (args.Index < Count)
+                {
+                    var column = (TableViewColumn)sender[index];
+                    column.SetOwningCollection(this);
+                    column.SetOwningTableView(((ITableViewColumnsCollection)this).TableView!);
+                    CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, column, (int)args.Index));
+                }
+                break;
+            case CollectionChange.ItemRemoved:
+                if (args.Index < _itemsCopy.Length)
+                {
+                    var column = _itemsCopy[index];
+                    column.SetOwningCollection(null!);
+                    column.SetOwningTableView(null!);
+                    CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, column, (int)args.Index));
+                }
+                break;
+            case CollectionChange.Reset:
+                foreach (var item in _itemsCopy)
+                {
+                    item.SetOwningCollection(null!);
+                    item.SetOwningTableView(null!);
+                    CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                }
+                break;
         }
 
-        if (e.OldItems != null)
-        {
-            foreach (var column in e.OldItems.OfType<TableViewColumn>())
-            {
-                column.SetOwningCollection(null!);
-                column.SetOwningTableView(null!);
-            }
-        }
+        _itemsCopy = new TableViewColumn[Count];
+        CopyTo(_itemsCopy, 0);
     }
 
     /// <summary>
     /// Handles the property changed event for a column.
     /// </summary>
-    /// <param name="column">The column that changed.</param>
-    /// <param name="propertyName">The name of the property that changed.</param>
     internal void HandleColumnPropertyChanged(TableViewColumn column, string propertyName)
     {
-        if (Items.Contains(column))
+        if (Contains(column) && this is ITableViewColumnsCollection d)
         {
             var index = IndexOf(column);
             ColumnPropertyChanged?.Invoke(this, new TableViewColumnPropertyChangedEventArgs(column, propertyName, index));
         }
     }
 
-    /// <summary>
-    /// Gets or sets the TableView associated with the collection.
-    /// </summary>
-    public TableView? TableView { get; internal set; }
+    /// <inheritdoc/>
+    public TableView? TableView { get; }
+
+    /// <inheritdoc/>
+    public IList<TableViewColumn> VisibleColumns => [.. this.OfType<TableViewColumn>()
+                                                            .Where(x => x.Visibility == Visibility.Visible)
+                                                            .OrderBy(x => x.Order ?? 0)];
+
+    TableViewColumn IList<TableViewColumn>.this[int index]
+    {
+        get => (TableViewColumn)base[index];
+        set => base[index] = value;
+    }
+
+    int ICollection<TableViewColumn>.Count => Count;
+
+    bool ICollection<TableViewColumn>.IsReadOnly => IsReadOnly;
+
+    void ICollection<TableViewColumn>.Add(TableViewColumn item)
+    {
+        Add(item);
+    }
+
+    void ICollection<TableViewColumn>.Clear()
+    {
+        Clear();
+    }
+
+    bool ICollection<TableViewColumn>.Contains(TableViewColumn item)
+    {
+        return Contains(item);
+    }
+
+    void ICollection<TableViewColumn>.CopyTo(TableViewColumn[] array, int arrayIndex)
+    {
+        CopyTo(array, arrayIndex);
+    }
+
+    IEnumerator<TableViewColumn> IEnumerable<TableViewColumn>.GetEnumerator()
+    {
+        foreach (var item in this)
+        {
+            yield return (TableViewColumn)item;
+        }
+    }
+
+    int IList<TableViewColumn>.IndexOf(TableViewColumn item)
+    {
+        return IndexOf(item);
+    }
+
+    void IList<TableViewColumn>.Insert(int index, TableViewColumn item)
+    {
+        Insert(index, item);
+    }
+
+    bool ICollection<TableViewColumn>.Remove(TableViewColumn item)
+    {
+        var index = IndexOf(item);
+
+        if (index >= 0)
+        {
+            RemoveAt(index);
+            return true;
+        }
+
+        return false;
+    }
+
+    void IList<TableViewColumn>.RemoveAt(int index)
+    {
+        RemoveAt(index);
+    }
 }

--- a/tests/TableViewColumnsCollectionTests.cs
+++ b/tests/TableViewColumnsCollectionTests.cs
@@ -1,0 +1,189 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System;
+using System.Collections.Specialized;
+
+namespace WinUI.TableView.Tests;
+
+[TestClass]
+public class TableViewColumnsCollectionTests
+{
+    [UITestMethod]
+    public void Constructor_ShouldInitializeTableViewProperty()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+        Assert.AreEqual(tableView, collection.TableView);
+    }
+
+    [UITestMethod]
+    public void Add_ShouldRaiseCollectionChangedEvent()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+        var column = new TableViewTextColumn();
+
+        var eventRaised = false;
+        collection.CollectionChanged += (s, e) => eventRaised = true;
+
+        collection.Add(column);
+
+        Assert.IsTrue(eventRaised);
+    }
+
+    [UITestMethod]
+    public void Remove_ShouldRaiseCollectionChangedEvent()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+        var column = new TableViewTextColumn();
+
+        collection.Add(column);
+
+        var eventRaised = false;
+        collection.CollectionChanged += (s, e) => eventRaised = true;
+
+        collection.Remove(column);
+
+        Assert.IsTrue(eventRaised);
+    }
+
+    [UITestMethod]
+    public void VisibleColumns_ShouldReturnOnlyVisibleColumns()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+
+        var visibleColumn = new TableViewTextColumn { Visibility = Visibility.Visible };
+        var hiddenColumn = new TableViewTextColumn { Visibility = Visibility.Collapsed };
+
+        collection.Add(visibleColumn);
+        collection.Add(hiddenColumn);
+
+        var visibleColumns = collection.VisibleColumns;
+
+        Assert.AreEqual(1, visibleColumns.Count);
+        Assert.AreEqual(visibleColumn, visibleColumns[0]);
+    }
+
+    [UITestMethod]
+    public void HandleColumnPropertyChanged_ShouldRaiseColumnPropertyChangedEvent()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+        var column = new TableViewTextColumn();
+
+        collection.Add(column);
+
+        var eventRaised = false;
+        collection.ColumnPropertyChanged += (s, e) => eventRaised = true;
+
+        collection.HandleColumnPropertyChanged(column, "TestProperty");
+
+        Assert.IsTrue(eventRaised);
+    }
+
+    [UITestMethod]
+    public void HandleColumnPropertyChanged_ShouldNotRaiseEvent_ForInvalidColumn()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+        var column = new TableViewTextColumn();
+
+        var eventRaised = false;
+        collection.ColumnPropertyChanged += (s, e) => eventRaised = true;
+
+        collection.HandleColumnPropertyChanged(column, "TestProperty");
+
+        Assert.IsFalse(eventRaised);
+    }
+
+    [UITestMethod]
+    public void ResetCollection_ShouldRaiseCollectionChangedEvent()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+        var column1 = new TableViewTextColumn();
+        var column2 = new TableViewTextColumn();
+
+        collection.Add(column1);
+        collection.Add(column2);
+
+        var eventRaised = false;
+        collection.CollectionChanged += (s, e) =>
+        {
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                eventRaised = true;
+            }
+        };
+
+        collection.Clear();
+
+        Assert.IsTrue(eventRaised);
+    }
+
+
+    [UITestMethod]
+    public void VisibleColumns_ShouldReturnColumnsInCorrectOrder()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+
+        var column1 = new TableViewTextColumn { Header = "column1", Visibility = Visibility.Visible, Order = 1 };
+        var column2 = new TableViewTextColumn { Header = "column2", Visibility = Visibility.Visible, Order = 2 };
+        var column3 = new TableViewTextColumn { Header = "column3", Visibility = Visibility.Visible, Order = 1 };
+
+        collection.Add(column1);
+        collection.Add(column2);
+        collection.Add(column3);
+
+        var visibleColumns = collection.VisibleColumns;
+
+        Assert.AreEqual(column1, visibleColumns[0]);
+        Assert.AreEqual(column3, visibleColumns[1]);
+        Assert.AreEqual(column2, visibleColumns[2]);
+    }
+
+    [UITestMethod]
+    public void AddDuplicateColumns_ShouldHandleCorrectly()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+        var column = new TableViewTextColumn();
+
+        collection.Add(column);
+        collection.Add(column);
+
+        Assert.AreEqual(2, collection.Count);
+    }
+
+    [UITestMethod]
+    public void ColumnVisibilityChange_ShouldUpdateVisibleColumns()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+
+        var column = new TableViewTextColumn { Visibility = Visibility.Visible };
+        collection.Add(column);
+
+        Assert.AreEqual(1, collection.VisibleColumns.Count);
+
+        column.Visibility = Visibility.Collapsed;
+
+        Assert.AreEqual(0, collection.VisibleColumns.Count);
+    }
+
+    [UITestMethod]
+    public void Add_ShouldThrowException_ForInvalidObjectType()
+    {
+        var tableView = new TableView();
+        var collection = new TableViewColumnsCollection(tableView);
+
+        var invalidObject = new TextBox();
+
+        Assert.ThrowsExactly<InvalidCastException>(() => collection.Add(invalidObject));
+    }
+}


### PR DESCRIPTION
Closes #20 

This PR improves `TableViewColumnsCollection` to work with [XAMLHot Reload](https://learn.microsoft.com/en-us/visualstudio/xaml-tools/xaml-hot-reload?view=vs-2022) by inheriting from `DependencyObjectCollection`. A new interface `ITableViewColumnsCollection` is added to use as a contract for the `TableViewColumnsCollection`, it is necessary to force the InteliSence to only show `TableViewColumns` when adding columns from the XAML. 

Here is the new implementation:
```cs
// Interface with some other properties like 'TableView', 'VisibleColumns'
public interface ITableViewColumnsCollection : IList<TableViewColumn>, INotifyCollectionChanged {  }

// Implementation
public partial class TableViewColumnsCollection : DependencyObjectCollection, ITableViewColumnsCollection {  }

// Actual Columns property in TableView
public ITableViewColumnsCollection Columns { get; }
```

### Limitations:
It seems that WinUI3 cannot update properties of type `Binding` with XAML hot reload, so the `TableViewBoundColumn.Binding` property won't reflect any changes made in XAML.