### PR TITLE
use ContentControl with template for TemplateColumn

### DIFF
--- a/src/Columns/TableViewTemplateColumn.cs
+++ b/src/Columns/TableViewTemplateColumn.cs
@@ -25,8 +25,10 @@ public class TableViewTemplateColumn : TableViewColumn
     /// <returns>A ContentControl element.</returns>
     public override FrameworkElement GenerateElement(TableViewCell cell, object? dataItem)
     {
-        var template = CellTemplateSelector?.SelectTemplate(dataItem) ?? CellTemplate;
-        return (template?.LoadContent() as FrameworkElement)!;
+        return new ContentControl
+        {
+            ContentTemplate = CellTemplateSelector?.SelectTemplate(dataItem) ?? CellTemplate
+        };
     }
 
     /// <summary>
@@ -40,8 +42,10 @@ public class TableViewTemplateColumn : TableViewColumn
     {
         if (EditingTemplate is not null || EditingTemplateSelector is not null)
         {
-            var template = EditingTemplateSelector?.SelectTemplate(dataItem) ?? EditingTemplate;
-            return (template?.LoadContent() as FrameworkElement)!;
+            return new ContentControl
+            {
+                ContentTemplate = EditingTemplateSelector?.SelectTemplate(dataItem) ?? EditingTemplate
+            };
         }
 
         return GenerateElement(cell, dataItem);


### PR DESCRIPTION
Fixes #188 and might also address #211.

This PR updates the way cell content is loaded in a template column. Previously, the content was manually set after loading the template using `DataTemplate.LoadContent()`, which caused issues with `x:Bind` and `Binding.Converters`. The new approach uses a `ContentControl` with the cell template, which is then used as the cell content.