### PR TITLE
Added WinRT attribute to Columns

### DIFF
--- a/src/Columns/TableViewBoundColumn.cs
+++ b/src/Columns/TableViewBoundColumn.cs
@@ -10,6 +10,9 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents a column in a TableView that is bound to a data source.
 /// </summary>
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
 public abstract class TableViewBoundColumn : TableViewColumn
 {
     private string? _propertyPath;

--- a/src/Columns/TableViewCheckBoxColumn.cs
+++ b/src/Columns/TableViewCheckBoxColumn.cs
@@ -9,7 +9,10 @@ namespace WinUI.TableView;
 /// Represents a column in a TableView that displays a CheckBox.
 /// </summary>
 [StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(CheckBox))]
-public class TableViewCheckBoxColumn : TableViewBoundColumn
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
+public partial class TableViewCheckBoxColumn : TableViewBoundColumn
 {
     /// <summary>
     /// Initializes a new instance of the TableViewCheckBoxColumn class.

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -8,6 +8,9 @@ namespace WinUI.TableView;
 /// </summary>
 [StyleTypedProperty(Property = nameof(HeaderStyle), StyleTargetType = typeof(TableViewColumnHeader))]
 [StyleTypedProperty(Property = nameof(CellStyle), StyleTargetType = typeof(TableViewCell))]
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
 public abstract partial class TableViewColumn : DependencyObject
 {
     private TableViewColumnHeader? _headerControl;

--- a/src/Columns/TableViewComboBoxColumn.cs
+++ b/src/Columns/TableViewComboBoxColumn.cs
@@ -10,7 +10,10 @@ namespace WinUI.TableView;
 /// </summary>
 [StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(TextBlock))]
 [StyleTypedProperty(Property = nameof(EditingElementStyle), StyleTargetType = typeof(ComboBox))]
-public class TableViewComboBoxColumn : TableViewBoundColumn
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
+public partial class TableViewComboBoxColumn : TableViewBoundColumn
 {
     private Binding? _textBinding;
     private Binding? _selectedValueBinding;

--- a/src/Columns/TableViewDateColumn.cs
+++ b/src/Columns/TableViewDateColumn.cs
@@ -14,6 +14,9 @@ namespace WinUI.TableView;
 /// </summary>
 [StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(TextBlock))]
 [StyleTypedProperty(Property = nameof(EditingElementStyle), StyleTargetType = typeof(TableViewDatePicker))]
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
 public partial class TableViewDateColumn : TableViewBoundColumn
 {
     /// <summary>

--- a/src/Columns/TableViewNumberColumn.cs
+++ b/src/Columns/TableViewNumberColumn.cs
@@ -8,7 +8,10 @@ namespace WinUI.TableView;
 /// </summary>
 [StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(TextBlock))]
 [StyleTypedProperty(Property = nameof(EditingElementStyle), StyleTargetType = typeof(NumberBox))]
-public class TableViewNumberColumn : TableViewBoundColumn
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
+public partial class TableViewNumberColumn : TableViewBoundColumn
 {
     /// <summary>
     /// Generates a TextBlock element for the cell.

--- a/src/Columns/TableViewTemplateColumn.cs
+++ b/src/Columns/TableViewTemplateColumn.cs
@@ -6,7 +6,10 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents a column in a TableView that uses a DataTemplate for its content.
 /// </summary>
-public class TableViewTemplateColumn : TableViewColumn
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
+public partial class TableViewTemplateColumn : TableViewColumn
 {
     /// <summary>
     /// Initializes a new instance of the TableViewTemplateColumn class.

--- a/src/Columns/TableViewTextColumn.cs
+++ b/src/Columns/TableViewTextColumn.cs
@@ -8,7 +8,10 @@ namespace WinUI.TableView;
 /// </summary>
 [StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(TextBlock))]
 [StyleTypedProperty(Property = nameof(EditingElementStyle), StyleTargetType = typeof(TextBox))]
-public class TableViewTextColumn : TableViewBoundColumn
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
+public partial class TableViewTextColumn : TableViewBoundColumn
 {
     /// <summary>
     /// Generates a TextBlock element for the cell.

--- a/src/Columns/TableViewTimeColumn.cs
+++ b/src/Columns/TableViewTimeColumn.cs
@@ -14,6 +14,9 @@ namespace WinUI.TableView;
 /// </summary>
 [StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(TextBlock))]
 [StyleTypedProperty(Property = nameof(EditingElementStyle), StyleTargetType = typeof(TableViewTimePicker))]
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
 public partial class TableViewTimeColumn : TableViewBoundColumn
 {
     /// <summary>

--- a/src/Columns/TableViewToggleSwitchColumn.cs
+++ b/src/Columns/TableViewToggleSwitchColumn.cs
@@ -8,7 +8,10 @@ namespace WinUI.TableView;
 /// Represents a column in a TableView that displays a ToggleSwitch.
 /// </summary>
 [StyleTypedProperty(Property = nameof(ElementStyle), StyleTargetType = typeof(ToggleSwitch))]
-public class TableViewToggleSwitchColumn : TableViewBoundColumn
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
+public partial class TableViewToggleSwitchColumn : TableViewBoundColumn
 {
     /// <summary>
     /// Initializes a new instance of the TableViewToggleSwitchColumn class.


### PR DESCRIPTION
This pull request adds the `[WinRT.GeneratedBindableCustomProperty]` attribute to several TableView column classes to improve WinRT binding support on Windows platforms. Additionally, it changes the affected classes from non-partial to `partial` where appropriate, enabling further extensibility and compatibility with code generation tools.

I did this to ensure that if columns are auto generated, WinRT bindings work correctly. 

**WinRT binding support enhancements:**

* Added `[WinRT.GeneratedBindableCustomProperty]` attribute to all TableView column classes, gated behind the `WINDOWS` conditional compilation directive. This ensures custom property generation for WinRT bindings only on Windows. [[1]](diffhunk://#diff-28dba9a684b1327cbd2958d7cfb13fc426342a1bdd9be434635546cd7e364444R13-R15) [[2]](diffhunk://#diff-79a376abd7af8514f893863d0bd837e0c03d49c43b3542646a8d7105fe50bde3L12-R15) [[3]](diffhunk://#diff-3ae247b3ddb78889b7e872d462f1136316234a07c6f4a50d085b54a06fb67ae2R11-R13) [[4]](diffhunk://#diff-cf31e73a7b00e55c6f6e503ddf4ee9aa469aac50e397552a80d959efc90e2273L13-R16) [[5]](diffhunk://#diff-906c01cce51cb32d8c38c76b6d31d62c9187cdfcc5199a6d261992129f0e8a1dR17-R19) [[6]](diffhunk://#diff-5b8a1c3f27c55c84869b2ca0a699dbc1994fcda50bbafc7fb4727b69788b96a3L11-R14) [[7]](diffhunk://#diff-2e8234135b7e517d27154315bdd3f872afc85056ec2a464f41e6299175447947L9-R12) [[8]](diffhunk://#diff-6122dcc1df61712e83f2deafd975527023261049a44e76fd3452fd940d70ab78L11-R14) [[9]](diffhunk://#diff-e59c50d18b447e71c11d027b6d1e7b56eb5487af9872914890d37766d844cb0eR17-R19) [[10]](diffhunk://#diff-4605654bc0bf8f77837efdba95fd8dc143cc5351378baa8066c23ce6cf7b93acL11-R14)

**Class definition changes for extensibility:**

* Changed all affected column classes (`TableViewCheckBoxColumn`, `TableViewComboBoxColumn`, `TableViewDateColumn`, `TableViewNumberColumn`, `TableViewTemplateColumn`, `TableViewTextColumn`, `TableViewTimeColumn`, `TableViewToggleSwitchColumn`) to be `partial` classes, allowing for future extensions and compatibility with code generation. [[1]](diffhunk://#diff-79a376abd7af8514f893863d0bd837e0c03d49c43b3542646a8d7105fe50bde3L12-R15) [[2]](diffhunk://#diff-cf31e73a7b00e55c6f6e503ddf4ee9aa469aac50e397552a80d959efc90e2273L13-R16) [[3]](diffhunk://#diff-906c01cce51cb32d8c38c76b6d31d62c9187cdfcc5199a6d261992129f0e8a1dR17-R19) [[4]](diffhunk://#diff-5b8a1c3f27c55c84869b2ca0a699dbc1994fcda50bbafc7fb4727b69788b96a3L11-R14) [[5]](diffhunk://#diff-2e8234135b7e517d27154315bdd3f872afc85056ec2a464f41e6299175447947L9-R12) [[6]](diffhunk://#diff-6122dcc1df61712e83f2deafd975527023261049a44e76fd3452fd940d70ab78L11-R14) [[7]](diffhunk://#diff-e59c50d18b447e71c11d027b6d1e7b56eb5487af9872914890d37766d844cb0eR17-R19) [[8]](diffhunk://#diff-4605654bc0bf8f77837efdba95fd8dc143cc5351378baa8066c23ce6cf7b93acL11-R14)

**Base class updates:**

* Updated the abstract base classes `TableViewBoundColumn` and `TableViewColumn` to include the new attribute and, for `TableViewColumn`, to be `partial` as well. [[1]](diffhunk://#diff-28dba9a684b1327cbd2958d7cfb13fc426342a1bdd9be434635546cd7e364444R13-R15) [[2]](diffhunk://#diff-3ae247b3ddb78889b7e872d462f1136316234a07c6f4a50d085b54a06fb67ae2R11-R13)