### PR TITLE
Added IsAOTCompatible flag for analysers

### DIFF
--- a/src/WinUI.TableView.csproj
+++ b/src/WinUI.TableView.csproj
@@ -8,6 +8,7 @@
     </TargetFrameworks> 
     <Nullable>enable</Nullable> 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsAOTCompatible>true</IsAOTCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows'">


### PR DESCRIPTION
This pull request introduces a small configuration change to the project file to improve compatibility.

* Project configuration: Added `<IsAOTCompatible>true</IsAOTCompatible>` to the main property group in `WinUI.TableView.csproj` to enable Ahead-of-Time (AOT) compilation compatibility.

This will allow for analysers and warnings for both NativeAOT compatibility and Trimming