### PR TITLE
Implemented Frozen Columns Support

### DIFF
--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -14,6 +14,7 @@ public abstract partial class TableViewColumn : DependencyObject
     private double _desiredWidth;
     private SD? _sortDirection;
     private bool _isFiltered;
+    private bool _isFrozen;
 
     /// <summary>
     /// Generates a display element for the cell.
@@ -264,6 +265,22 @@ public abstract partial class TableViewColumn : DependencyObject
         {
             _isFiltered = value;
             OnIsFilteredChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the column can horizontally scrolled.
+    /// </summary>
+    public bool IsFrozen
+    {
+        get => _isFrozen;
+        internal set
+        {
+            if (_isFrozen != value)
+            {
+                _isFrozen = value;
+                OwningCollection?.HandleColumnPropertyChanged(this, nameof(IsFrozen));
+            }
         }
     }
 

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -269,7 +269,7 @@ public abstract partial class TableViewColumn : DependencyObject
     }
 
     /// <summary>
-    /// Gets a value indicating whether the column can horizontally scrolled.
+    /// Gets a value indicating whether the column can be horizontally scrolled.
     /// </summary>
     public bool IsFrozen
     {

--- a/src/Helpers/ScrollViewerHelper.cs
+++ b/src/Helpers/ScrollViewerHelper.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.UI.Xaml;
+
+namespace WinUI.TableView.Helpers;
+
+/// <summary>
+/// Provides attached properties for ScrollViewer-related functionality.
+/// </summary>
+public class ScrollViewerHelper
+{
+    /// <summary>
+    /// Gets the FrozenColumnScrollBarSpace attached property. This is used to reserve space for the scrollbar in frozen columns.
+    /// </summary>
+    public static double GetFrozenColumnScrollBarSpace(DependencyObject obj)
+    {
+        return (double)obj.GetValue(FrozenColumnScrollBarSpaceProperty);
+    }
+
+    /// <summary>
+    /// Sets the FrozenColumnScrollBarSpace attached property. This is used to reserve space for the scrollbar in frozen columns.
+    /// </summary>
+    public static void SetFrozenColumnScrollBarSpace(DependencyObject obj, double value)
+    {
+        obj.SetValue(FrozenColumnScrollBarSpaceProperty, value);
+    }
+
+    /// <summary>
+    /// Identifies the FrozenColumnScrollBarSpace attached property.
+    /// </summary>
+    public static readonly DependencyProperty FrozenColumnScrollBarSpaceProperty = DependencyProperty.RegisterAttached("FrozenColumnScrollBarSpace", typeof(double), typeof(ScrollViewerHelper), new PropertyMetadata(0d));
+}

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -221,6 +221,11 @@ public partial class TableView
     public static readonly DependencyProperty RowHeaderTemplateSelectorProperty = DependencyProperty.Register(nameof(RowHeaderTemplateSelector), typeof(DataTemplateSelector), typeof(TableView), new PropertyMetadata(null, OnRowHeaderTemplateChanged));
 
     /// <summary>
+    /// Identifies the FrozenColumnCount dependency property.
+    /// </summary>
+    public static readonly DependencyProperty FrozenColumnCountProperty = DependencyProperty.Register(nameof(FrozenColumnCount), typeof(int), typeof(TableView), new PropertyMetadata(0, OnFrozenColumnCountChanged));
+
+    /// <summary>
     /// Gets or sets a value indicating whether opening the column filter over header right-click is enabled.
     /// </summary>
     public bool UseRightClickForColumnFilter
@@ -648,6 +653,15 @@ public partial class TableView
     }
 
     /// <summary>
+    /// Gets or sets the number of columns that stays in view on horizontal scroll.
+    /// </summary>
+    public int FrozenColumnCount
+    {
+        get => (int)GetValue(FrozenColumnCountProperty);
+        set => SetValue(FrozenColumnCountProperty, value);
+    }
+
+    /// <summary>
     /// Handles changes to the ItemsSource property.
     /// </summary>
     private static void OnItemsSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -884,12 +898,7 @@ public partial class TableView
     {
         if (d is TableView tableView)
         {
-            tableView._headerRow?.SetHeadersVisibility();
-
-            foreach (var row in tableView._rows)
-            {
-                row.CellPresenter?.SetRowHeaderVisibility();
-            }
+            tableView.SetHeadersVisibility();
         }
     }
 
@@ -905,6 +914,23 @@ public partial class TableView
             foreach (var row in tableView._rows)
             {
                 row.CellPresenter?.SetRowHeaderTemplate();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Handles changes to the FrozenColumnCount property.
+    /// </summary>
+    private static void OnFrozenColumnCountChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView)
+        {
+            tableView.SetValue(HorizontalOffsetProperty, 0d);
+            tableView.UpdateHorizontalScrollBarMargin();
+
+            if (tableView.Columns is TableViewColumnsCollection columnsCollection)
+            {
+                columnsCollection.UpdateFrozenColumns();
             }
         }
     }

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -899,6 +899,7 @@ public partial class TableView
         if (d is TableView tableView)
         {
             tableView.SetHeadersVisibility();
+            tableView.UpdateHorizontalScrollBarMargin();
         }
     }
 

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -34,6 +34,7 @@ public partial class TableView : ListView
 {
     private TableViewHeaderRow? _headerRow;
     private ScrollViewer? _scrollViewer;
+    private RowDefinition? _headerRowDefinition;
     private bool _shouldThrowSelectionModeChangedException;
     private bool _ensureColumns = true;
     private readonly List<TableViewRow> _rows = [];
@@ -261,13 +262,15 @@ public partial class TableView : ListView
 
         _headerRow = GetTemplateChild("HeaderRow") as TableViewHeaderRow;
         _scrollViewer = GetTemplateChild("ScrollViewer") as ScrollViewer;
-
+        _headerRowDefinition = GetTemplateChild("HeaderRowDefinition") as RowDefinition;
         if (IsLoaded)
         {
             while (ItemsPanelRoot is null) await Task.Yield();
 
             EnsureAutoColumns();
         }
+
+        SetHeadersVisibility();
     }
 
     /// <summary>
@@ -1467,6 +1470,25 @@ public partial class TableView : ListView
 
         IsEditing = value;
         UpdateCornerButtonState();
+    }
+
+    /// <summary>
+    /// Sets the visibility of the headers.
+    /// </summary>
+    private void SetHeadersVisibility()
+    {
+        if (_headerRowDefinition is not null)
+        {
+            var areColumnHeadersVisible = HeadersVisibility is TableViewHeadersVisibility.All or TableViewHeadersVisibility.Columns;
+            _headerRowDefinition.Height = areColumnHeadersVisible ? GridLength.Auto : new(0);
+        }
+
+        _headerRow?.SetHeadersVisibility();
+
+        foreach (var row in _rows)
+        {
+            row.CellPresenter?.SetRowHeaderVisibility();
+        }
     }
 
     /// <inheritdoc/>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -1298,7 +1298,7 @@ public partial class TableView : ListView
     private double GetRowHeadersOffset()
     {
         var areHeadersVisible = HeadersVisibility is TableViewHeadersVisibility.All or TableViewHeadersVisibility.Rows;
-        var isMultiSelection = SelectionMode is ListViewSelectionMode.Multiple;
+        var isMultiSelection = this is ListView { SelectionMode: ListViewSelectionMode.Multiple };
 
         return isMultiSelection ? 44 : areHeadersVisible ? RowHeaderActualWidth : 0;
     }
@@ -1312,6 +1312,7 @@ public partial class TableView : ListView
 
         base.SelectionMode = SelectionUnit is TableViewSelectionUnit.Cell ? ListViewSelectionMode.None : SelectionMode;
 
+        UpdateHorizontalScrollBarMargin();
         _headerRow?.SetHeadersVisibility();
 
         foreach (var row in _rows)
@@ -1489,6 +1490,17 @@ public partial class TableView : ListView
         {
             row.CellPresenter?.SetRowHeaderVisibility();
         }
+    }
+
+    /// <summary>
+    /// Updates the margin of the horizontal scroll bar to account for frozen columns and row headers.
+    /// </summary>
+    internal void UpdateHorizontalScrollBarMargin()
+    {
+        if (_scrollViewer is null) return;
+
+        var offset = GetRowHeadersOffset() + Columns.VisibleColumns.Where(c => c.IsFrozen).Sum(c => c.ActualWidth);
+        ScrollViewerHelper.SetFrozenColumnScrollBarSpace(_scrollViewer, offset);
     }
 
     /// <inheritdoc/>

--- a/src/TableViewCellsPresenter.cs
+++ b/src/TableViewCellsPresenter.cs
@@ -19,7 +19,8 @@ public partial class TableViewCellsPresenter : Control
     private TableViewRowHeader? _rowHeader;
     private Panel? _rootPanel;
     private ColumnDefinition? _rowHeaderColumn;
-    private StackPanel? _cellsStackPanel;
+    private StackPanel? _scrollableCellsPanel;
+    private StackPanel? _frozenCellsPanel;
     private Rectangle? _v_gridLine;
     private Rectangle? _h_gridLine;
     private TableViewRowPresenter? _rowPresenter;
@@ -40,7 +41,8 @@ public partial class TableViewCellsPresenter : Control
         _rootPanel = GetTemplateChild("RootPanel") as Panel;
         _rowHeaderColumn = GetTemplateChild("RowHeaderColumn") as ColumnDefinition;
         _rowHeader = GetTemplateChild("RowHeader") as TableViewRowHeader;
-        _cellsStackPanel = GetTemplateChild("CellsStackPanel") as StackPanel;
+        _scrollableCellsPanel = GetTemplateChild("ScrollableCellsPanel") as StackPanel;
+        _frozenCellsPanel = GetTemplateChild("FrozenCellsPanel") as StackPanel;
         _v_gridLine = GetTemplateChild("VerticalGridLine") as Rectangle;
         _h_gridLine = GetTemplateChild("HorizontalGridLine") as Rectangle;
         _rowPresenter = this.FindAscendant<TableViewRowPresenter>();
@@ -76,28 +78,32 @@ public partial class TableViewCellsPresenter : Control
     {
         finalSize = base.ArrangeOverride(finalSize);
 
-        if (TableView is not null && _rootPanel is not null && _cellsStackPanel is not null && _v_gridLine is not null)
+        if (TableView is not null && _rootPanel is not null && _scrollableCellsPanel is not null && _frozenCellsPanel is not null && _v_gridLine is not null)
         {
-            var height = finalSize.Height;
             var areHeadersVisible = TableView.HeadersVisibility is TableViewHeadersVisibility.All or TableViewHeadersVisibility.Rows;
             var isMultiSelection = TableView is ListView { SelectionMode: ListViewSelectionMode.Multiple };
             var headerWidth = areHeadersVisible && !isMultiSelection ? TableView.RowHeaderActualWidth + _v_gridLine.ActualWidth : 0;
             var cornerRadius = _rowPresenter?.CornerRadius ?? new CornerRadius(4);
             var left = isMultiSelection ? 44 : Math.Max(cornerRadius.TopLeft, cornerRadius.BottomLeft);
-            var xScroll = headerWidth - TableView.HorizontalOffset;
-            var xClip = (xScroll * -1) + headerWidth;
+            var xScroll = headerWidth + _frozenCellsPanel.ActualWidth - TableView.HorizontalOffset;
+            var xClip = (xScroll * -1) + headerWidth + _frozenCellsPanel.ActualWidth;
 
-            _rootPanel.Arrange(new(left, 0, _rootPanel.ActualWidth - left, finalSize.Height));
-            _cellsStackPanel.Arrange(new(xScroll, 0, _cellsStackPanel.ActualWidth, height));
-            _cellsStackPanel.Clip = xScroll >= headerWidth ? null :
-                new RectangleGeometry
-                {
-                    Rect = new Rect(xClip, 0, _cellsStackPanel.ActualWidth - xClip, height)
-                };
+            _rootPanel.Arrange(new(left, 0, _rootPanel.ActualWidth - left, _rootPanel.ActualHeight));
+            _frozenCellsPanel.Arrange(new(headerWidth, 0, _frozenCellsPanel.ActualWidth, _frozenCellsPanel.ActualHeight));
+
+            if (_scrollableCellsPanel.ActualWidth > 0)
+            {
+                _scrollableCellsPanel.Arrange(new(xScroll, 0, _scrollableCellsPanel.ActualWidth, _scrollableCellsPanel.ActualHeight));
+                _scrollableCellsPanel.Clip = xScroll >= headerWidth + _frozenCellsPanel.ActualWidth ? null :
+                    new RectangleGeometry
+                    {
+                        Rect = new(xClip, 0, _scrollableCellsPanel.ActualWidth - xClip, _scrollableCellsPanel.ActualHeight)
+                    };
+            }
 
             if (isMultiSelection)
             {
-                _v_gridLine.Arrange(new(0, 0, _v_gridLine.ActualWidth, height));
+                _v_gridLine.Arrange(new(0, 0, _v_gridLine.ActualWidth, _v_gridLine.ActualHeight));
             }
         }
 
@@ -202,14 +208,65 @@ public partial class TableViewCellsPresenter : Control
     }
 
     /// <summary>
-    /// Gets the collection of child elements.
+    /// Inserts a cell at the specified index.
     /// </summary>
-    internal UIElementCollection Children => _cellsStackPanel?.Children!;
+    /// <param name="cell">The cell to insert.</param>
+    public void InsertCell( TableViewCell cell)
+    {
+        if (TableView is null || cell is not { Column: { } column }) return;
+
+        var _frozenColumns = TableView.Columns.VisibleColumns.Where(x => x.IsFrozen).ToList();
+        var _scrollableColumns = TableView.Columns.VisibleColumns.Where(x => !x.IsFrozen).ToList();
+
+        if (cell is { Column.IsFrozen: true } && _frozenCellsPanel is not null)
+        {
+            var index = _frozenColumns.IndexOf(column);
+            index = Math.Min(index, _frozenColumns.Count);
+            index = Math.Max(index, 0); // handles -ve index;
+
+            _frozenCellsPanel.Children.Insert(index, cell);
+        }
+        else if (_scrollableCellsPanel is not null)
+        {
+            var index = _scrollableColumns.IndexOf(column);
+            index = Math.Min(index, _scrollableColumns.Count);
+            index = Math.Max(index, 0); // handles -ve index;
+
+            _scrollableCellsPanel.Children.Insert(index, cell);
+        }
+    }
+
+    /// <summary>
+    /// Removes a cell from the presenter.
+    /// </summary>
+    /// <param name="cell">The cell to remove.</param>
+    public void RemoveCell(TableViewCell cell)
+    {
+        if (_frozenCellsPanel?.Children.Contains(cell) ?? false)
+        {
+            _frozenCellsPanel.Children.Remove(cell);
+        }
+        else if (_scrollableCellsPanel?.Children.Contains(cell) ?? false)
+        {
+            _scrollableCellsPanel.Children.Remove(cell);
+        }
+    }
+
+    /// <summary>
+    /// Clears all cells from the presenter.
+    /// </summary>
+    public void ClearCells()
+    {
+        _frozenCellsPanel?.Children.Clear();
+        _scrollableCellsPanel?.Children.Clear();
+    }
 
     /// <summary>
     /// Gets the list of cells in the presenter.
     /// </summary>
-    public IList<TableViewCell> Cells => _cellsStackPanel?.Children.OfType<TableViewCell>().ToList()!;
+    public IReadOnlyList<TableViewCell> Cells =>
+        [.. _frozenCellsPanel?.Children.OfType<TableViewCell>() ?? [],
+         .. _scrollableCellsPanel?.Children.OfType<TableViewCell>() ?? []];
 
     /// <summary>
     /// Gets or sets the TableViewRow associated with the presenter.

--- a/src/TableViewCellsPresenter.cs
+++ b/src/TableViewCellsPresenter.cs
@@ -211,7 +211,7 @@ public partial class TableViewCellsPresenter : Control
     /// Inserts a cell at the specified index.
     /// </summary>
     /// <param name="cell">The cell to insert.</param>
-    public void InsertCell( TableViewCell cell)
+    public void InsertCell(TableViewCell cell)
     {
         if (TableView is null || cell is not { Column: { } column }) return;
 

--- a/src/TableViewColumnsCollection.cs
+++ b/src/TableViewColumnsCollection.cs
@@ -38,6 +38,8 @@ public partial class TableViewColumnsCollection : DependencyObjectCollection, IT
     /// </summary>
     private void OnVectorChanged(IObservableVector<DependencyObject> sender, IVectorChangedEventArgs args)
     {
+        UpdateFrozenColumns();
+
         var index = (int)args.Index;
 
         switch (args.CollectionChange)
@@ -72,6 +74,14 @@ public partial class TableViewColumnsCollection : DependencyObjectCollection, IT
 
         _itemsCopy = new TableViewColumn[Count];
         CopyTo(_itemsCopy, 0);
+    }
+
+    internal void UpdateFrozenColumns()
+    {
+        foreach (var column in this.OfType<TableViewColumn>())
+        {
+            column.IsFrozen = VisibleColumns.IndexOf(column) < (TableView?.FrozenColumnCount ?? 0);
+        }
     }
 
     /// <summary>

--- a/src/TableViewHeaderRow.cs
+++ b/src/TableViewHeaderRow.cs
@@ -32,7 +32,8 @@ public partial class TableViewHeaderRow : Control
     private CheckBox? _selectAllCheckBox;
     private Rectangle? _v_gridLine;
     private Rectangle? _h_gridLine;
-    private StackPanel? _headersStackPanel;
+    private StackPanel? _frozenHeadersPanel;
+    private StackPanel? _scrollableHeadersPanel;
     private bool _calculatingHeaderWidths;
     private DispatcherTimer? _timer;
     private readonly Dictionary<DependencyProperty, long> _callbackTokens = [];
@@ -55,7 +56,8 @@ public partial class TableViewHeaderRow : Control
         _selectAllCheckBox = GetTemplateChild("selectAllCheckBox") as CheckBox;
         _v_gridLine = GetTemplateChild("VerticalGridLine") as Rectangle;
         _h_gridLine = GetTemplateChild("HorizontalGridLine") as Rectangle;
-        _headersStackPanel = GetTemplateChild("HeadersStackPanel") as StackPanel;
+        _frozenHeadersPanel = GetTemplateChild("FrozenHeadersPanel") as StackPanel;
+        _scrollableHeadersPanel = GetTemplateChild("ScrollableHeadersPanel") as StackPanel;
 
         if (TableView is null)
         {
@@ -92,6 +94,7 @@ public partial class TableViewHeaderRow : Control
 
         SetExportOptionsVisibility();
         SetCornerButtonState();
+        SetHeadersVisibility();
         EnsureGridLines();
     }
 
@@ -100,17 +103,17 @@ public partial class TableViewHeaderRow : Control
     {
         finalSize = base.ArrangeOverride(finalSize);
 
-        if (_headersStackPanel is not null && _v_gridLine is not null && TableView is not null)
+        if (_scrollableHeadersPanel is not null && _frozenHeadersPanel is not null && TableView is not null && _scrollableHeadersPanel.ActualWidth > 0)
         {
-            var xGridLine = _v_gridLine.Visibility is Visibility.Visible ? _v_gridLine.ActualOffset.X + _v_gridLine.ActualWidth : 0;
-            var headersOffset = -TableView.HorizontalOffset + xGridLine;
-            var xClip = (headersOffset * -1) + xGridLine;
+            var frozenOffset = _frozenHeadersPanel.ActualOffset.X + _frozenHeadersPanel.ActualWidth;
+            var headersOffset = -TableView.HorizontalOffset + frozenOffset;
+            var xClip = (headersOffset * -1) + frozenOffset;
 
-            _headersStackPanel.Arrange(new Rect(headersOffset, 0, _headersStackPanel.ActualWidth, finalSize.Height));
-            _headersStackPanel.Clip = headersOffset >= xGridLine ? null :
+            _scrollableHeadersPanel.Arrange(new Rect(headersOffset, 0, _scrollableHeadersPanel.ActualWidth, _scrollableHeadersPanel.ActualHeight));
+            _scrollableHeadersPanel.Clip = headersOffset >= frozenOffset ? null :
                 new RectangleGeometry
                 {
-                    Rect = new Rect(xClip, 0, _headersStackPanel.ActualWidth - xClip, finalSize.Height)
+                    Rect = new Rect(xClip, 0, _scrollableHeadersPanel.ActualWidth - xClip, finalSize.Height)
                 };
         }
 
@@ -130,9 +133,9 @@ public partial class TableViewHeaderRow : Control
         {
             RemoveHeaders(oldItems);
         }
-        else if (e.Action == NotifyCollectionChangedAction.Reset && _headersStackPanel is not null)
+        else if (e.Action == NotifyCollectionChangedAction.Reset && _scrollableHeadersPanel is not null)
         {
-            _headersStackPanel.Children.Clear();
+            ClearHeaders();
         }
     }
 
@@ -152,7 +155,9 @@ public partial class TableViewHeaderRow : Control
                 RemoveHeaders([e.Column]);
             }
         }
-        else if (e.PropertyName is nameof(TableViewColumn.Order) && e.Column.Visibility is Visibility.Visible)
+        else if ((e.PropertyName is nameof(TableViewColumn.Order) ||
+            e.PropertyName is nameof(TableViewColumn.IsFrozen)) &&
+            e.Column.Visibility is Visibility.Visible)
         {
             RemoveHeaders([e.Column]);
             AddHeaders([e.Column]);
@@ -202,14 +207,14 @@ public partial class TableViewHeaderRow : Control
     /// </summary>
     private void RemoveHeaders(IEnumerable<TableViewColumn> columns)
     {
-        if (_headersStackPanel is not null)
+        if (_scrollableHeadersPanel is not null)
         {
             foreach (var column in columns)
             {
-                var header = _headersStackPanel.Children.OfType<TableViewColumnHeader>().FirstOrDefault(x => x.Column == column);
+                var header = Headers.FirstOrDefault(x => x.Column == column);
                 if (header is not null)
                 {
-                    _headersStackPanel.Children.Remove(header);
+                    RemoveHeader(header);
                 }
             }
         }
@@ -220,17 +225,14 @@ public partial class TableViewHeaderRow : Control
     /// </summary>
     private void AddHeaders(IEnumerable<TableViewColumn> columns)
     {
-        if (TableView is not null && _headersStackPanel is not null)
+        if (TableView is not null && _scrollableHeadersPanel is not null)
         {
             foreach (var column in columns)
             {
                 var header = new TableViewColumnHeader { DataContext = column, Column = column };
                 column.HeaderControl = header;
 
-                var index = TableView.Columns.VisibleColumns.IndexOf(column);
-                index = Math.Min(index, _headersStackPanel.Children.Count);
-                index = Math.Max(index, 0); // handles -ve index;
-                _headersStackPanel.Children.Insert(index, header);
+                InsertHeader(header);
 
                 header.SetBinding(ContentControl.ContentProperty,
                                   new Binding { Path = new PropertyPath(nameof(TableViewColumn.Header)) });
@@ -324,7 +326,7 @@ public partial class TableViewHeaderRow : Control
                     DispatcherQueue.TryEnqueue(() =>
                         header.Measure(
                             new Size(header.Width,
-                            _headersStackPanel?.ActualHeight ?? ActualHeight)));
+                            _scrollableHeadersPanel?.ActualHeight ?? ActualHeight)));
                 }
             }
 
@@ -473,10 +475,19 @@ public partial class TableViewHeaderRow : Control
     /// <summary>
     /// Gets the previous header in the header row.
     /// </summary>
-    internal TableViewColumnHeader? GetPreviousHeader(TableViewColumnHeader? currentHeader)
+    internal TableViewColumnHeader? GetPreviousHeader(TableViewColumnHeader currentHeader)
     {
-        var previousCellIndex = currentHeader is null ? Headers.Count - 1 : Headers.IndexOf(currentHeader) - 1;
-        return previousCellIndex >= 0 ? Headers[previousCellIndex] : default;
+        if (TableView is { Columns: { } } && currentHeader is { Column: { } })
+        {
+            var index = TableView.Columns.VisibleColumns.IndexOf(currentHeader.Column);
+
+            if (index > 0)
+            {
+                return TableView.Columns.VisibleColumns[index - 1].HeaderControl;
+            }
+        }
+
+        return default;
     }
 
     /// <summary>
@@ -486,11 +497,12 @@ public partial class TableViewHeaderRow : Control
     {
         if (_cornerButtonColumn is not null && TableView is not null)
         {
+            var isMultiSelection = TableView is ListView { SelectionMode: ListViewSelectionMode.Multiple };
             var headerWidth = TableView.RowHeaderWidth is double.NaN ? TableView.RowHeaderActualWidth : TableView.RowHeaderWidth;
 
             _cornerButtonColumn.Width = new(headerWidth);
-            _cornerButtonColumn.MinWidth = TableView.RowHeaderMinWidth;
-            _cornerButtonColumn.MaxWidth = TableView.RowHeaderMaxWidth;
+            _cornerButtonColumn.MinWidth = isMultiSelection ? 0 : TableView.RowHeaderMinWidth;
+            _cornerButtonColumn.MaxWidth = isMultiSelection ? double.PositiveInfinity : TableView.RowHeaderMaxWidth;
         }
     }
 
@@ -503,11 +515,8 @@ public partial class TableViewHeaderRow : Control
 
         if (_cornerButtonColumn is not null && _v_gridLine is not null && TableView is not null)
         {
-            var areColumnHeadersVisible = TableView.HeadersVisibility is TableViewHeadersVisibility.All or TableViewHeadersVisibility.Columns;
             var areRowHeadersVisible = TableView.HeadersVisibility is TableViewHeadersVisibility.All or TableViewHeadersVisibility.Rows;
             var isMultiSelection = TableView is ListView { SelectionMode: ListViewSelectionMode.Multiple };
-
-            Visibility = areColumnHeadersVisible ? Visibility.Visible : Visibility.Collapsed;
 
             if (areRowHeadersVisible || isMultiSelection)
             {
@@ -522,6 +531,60 @@ public partial class TableViewHeaderRow : Control
                 _cornerButtonColumn.MaxWidth = 0;
             }
         }
+    }
+
+    /// <summary>
+    /// Inserts a header at the specified index.
+    /// </summary>
+    /// <param name="header">The header to insert.</param>
+    public void InsertHeader(TableViewColumnHeader header)
+    {
+        if (TableView is null || header is not { Column: { } column }) return;
+
+        var _frozenColumns = TableView.Columns.VisibleColumns.Where(x => x.IsFrozen).ToList();
+        var _scrollableColumns = TableView.Columns.VisibleColumns.Where(x => !x.IsFrozen).ToList();
+
+        if (header is { Column.IsFrozen: true } && _frozenHeadersPanel is not null)
+        {
+            var index = _frozenColumns.IndexOf(column);
+            index = Math.Min(index, _frozenColumns.Count);
+            index = Math.Max(index, 0); // handles -ve index;
+
+            _frozenHeadersPanel.Children.Insert(index, header);
+        }
+        else if (_scrollableHeadersPanel is not null)
+        {
+            var index = _scrollableColumns.IndexOf(column);
+            index = Math.Min(index, _scrollableColumns.Count);
+            index = Math.Max(index, 0); // handles -ve index;
+
+            _scrollableHeadersPanel.Children.Insert(index, header);
+        }
+    }
+
+    /// <summary>
+    /// Removes a header from the header row.
+    /// </summary>
+    /// <param name="header">The header to remove.</param>
+    public void RemoveHeader(TableViewColumnHeader header)
+    {
+        if (_frozenHeadersPanel?.Children.Contains(header) ?? false)
+        {
+            _frozenHeadersPanel.Children.Remove(header);
+        }
+        else if (_scrollableHeadersPanel?.Children.Contains(header) ?? false)
+        {
+            _scrollableHeadersPanel.Children.Remove(header);
+        }
+    }
+
+    /// <summary>
+    /// Clears all headers from the header row.
+    /// </summary>
+    public void ClearHeaders()
+    {
+        _frozenHeadersPanel?.Children.Clear();
+        _scrollableHeadersPanel?.Children.Clear();
     }
 
     /// <summary>
@@ -577,7 +640,9 @@ public partial class TableViewHeaderRow : Control
     /// <summary>
     /// Gets the list of headers in the header row.
     /// </summary>
-    public IList<TableViewColumnHeader> Headers => [.. _headersStackPanel?.Children.OfType<TableViewColumnHeader>() ?? []];
+    public IReadOnlyList<TableViewColumnHeader> Headers =>
+        [.. _frozenHeadersPanel?.Children.OfType<TableViewColumnHeader>() ?? [],
+         .. _scrollableHeadersPanel?.Children.OfType<TableViewColumnHeader>() ?? []];
 
     /// <summary>
     /// Gets or sets the TableView associated with the header row.

--- a/src/TableViewHeaderRow.cs
+++ b/src/TableViewHeaderRow.cs
@@ -331,6 +331,8 @@ public partial class TableViewHeaderRow : Control
             }
 
             _calculatingHeaderWidths = false;
+
+            TableView.UpdateHorizontalScrollBarMargin();
         }
     }
 

--- a/src/Themes/TableView.xaml
+++ b/src/Themes/TableView.xaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:WinUI.TableView"
+                    xmlns:helpers="using:WinUI.TableView.Helpers"
                     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
                     xmlns:behaviors="using:CommunityToolkit.WinUI.Behaviors"
                     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">

--- a/src/Themes/TableView.xaml
+++ b/src/Themes/TableView.xaml
@@ -99,6 +99,7 @@
 
                             <ScrollViewer x:Name="ScrollViewer"
                                           Grid.Row="1"
+                                          helpers:ScrollViewerHelper.FrozenColumnScrollBarSpace="{TemplateBinding RowHeaderMinWidth}"
                                           TabNavigation="{TemplateBinding TabNavigation}"
                                           HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
                                           HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
@@ -370,7 +371,18 @@
                 <Grid Grid.Row="1"
                       Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
                       Padding="{ThemeResource ScrollViewerScrollBarMargin}">
+
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border Opacity="0"
+                            MinWidth="{Binding (helpers:ScrollViewerHelper.FrozenColumnScrollBarSpace), RelativeSource={RelativeSource TemplatedParent}}"
+                            Background="{ThemeResource ScrollViewerScrollBarSeparatorBackground}" />
+
                     <ScrollBar x:Name="HorizontalScrollBar2"
+                               Grid.Column="1"
                                IsTabStop="False"
                                Maximum="{TemplateBinding ScrollableWidth}"
                                Orientation="Horizontal"

--- a/src/Themes/TableView.xaml
+++ b/src/Themes/TableView.xaml
@@ -86,7 +86,7 @@
                             CornerRadius="{TemplateBinding CornerRadius}">
                         <Grid>
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
+                                <RowDefinition x:Name="HeaderRowDefinition" Height="Auto" />
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
 

--- a/src/Themes/TableViewCellsPresenter.xaml
+++ b/src/Themes/TableViewCellsPresenter.xaml
@@ -24,18 +24,10 @@
 
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="RowHeaderColumn" Width="Auto" />
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition x:Name="VerticalGridLineColumn" Width="Auto" />
+                                <ColumnDefinition x:Name="FrozenCellsPanelColumn" Width="Auto" />
+                                <ColumnDefinition x:Name="ScrollableCellsPanelColumn" Width="*" />
                             </Grid.ColumnDefinitions>
-
-                            <StackPanel x:Name="CellsStackPanel"
-                                        Grid.Column="2"
-                                        Orientation="Horizontal">
-                                <!--This is just dummy textblock. It would be removed at runtime-->
-                                <TextBlock Margin="16,0"
-                                           Text="{Binding}"
-                                           VerticalAlignment="Center" />
-                            </StackPanel>
 
                             <local:TableViewRowHeader x:Name="RowHeader" />
 
@@ -44,6 +36,19 @@
                                        Grid.Column="1"
                                        VerticalAlignment="Stretch"
                                        IsHitTestVisible="False" />
+
+                            <StackPanel x:Name="FrozenCellsPanel"
+                                        Grid.Column="2"
+                                        Orientation="Horizontal" />
+
+                            <StackPanel x:Name="ScrollableCellsPanel"
+                                        Grid.Column="3"
+                                        Orientation="Horizontal">
+                                <!--This is just dummy textblock. It would be removed at runtime-->
+                                <TextBlock Margin="16,0"
+                                           Text="{Binding}"
+                                           VerticalAlignment="Center" />
+                            </StackPanel>
                         </Grid>
 
                         <Rectangle x:Name="HorizontalGridLine"

--- a/src/Themes/TableViewHeaderRow.xaml
+++ b/src/Themes/TableViewHeaderRow.xaml
@@ -14,6 +14,11 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:TableViewHeaderRow">
                     <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
@@ -73,15 +78,12 @@
                               Background="{TemplateBinding Background}"
                               BorderBrush="{TemplateBinding BorderBrush}"
                               BorderThickness="{TemplateBinding BorderThickness}">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="*" />
-                                <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
+                            
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="cornerButtonColumn"
-                                                  Width="16" />
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition x:Name="cornerButtonColumn" Width="16" />
+                                <ColumnDefinition x:Name="VerticalGridLineColumn" Width="Auto" />
+                                <ColumnDefinition x:Name="FrozenHeadersPanelColumn" Width="Auto" />
+                                <ColumnDefinition x:Name="ScrollableHeadersPanelColumn" Width="*" />
                             </Grid.ColumnDefinitions>
 
                             <Button x:Name="selectAllButton"
@@ -185,15 +187,18 @@
                                        Width="1"
                                        VerticalAlignment="Stretch" />
 
-                            <Rectangle x:Name="HorizontalGridLine"
-                                       Grid.Row="1"
-                                       Grid.ColumnSpan="3"
-                                       HorizontalAlignment="Stretch" />
-
-                            <StackPanel x:Name="HeadersStackPanel"
+                            <StackPanel x:Name="FrozenHeadersPanel"
                                         Grid.Column="2"
                                         Orientation="Horizontal" />
+
+                            <StackPanel x:Name="ScrollableHeadersPanel"
+                                        Grid.Column="3"
+                                        Orientation="Horizontal" />
                         </Grid>
+
+                        <Rectangle x:Name="HorizontalGridLine"
+                                   Grid.Row="1"
+                                   HorizontalAlignment="Stretch" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
This PR introduces the `FrozenColumnsCount` property to `TableView`, allowing to freeze a specified number of columns on the left side of the control.

### Implementation
- Added `TableView.FrozenColumnsCount` dependency property.
- When set, the specified number of columns remain fixed on the left side and do not move during horizontal scrolling.
- The rest of the columns continue to scroll as usual.
- Works seamlessly with existing features like selection, sorting, and resizing.

### Example Usage
```
<TableView FrozenColumnsCount="2" ... />
```
![frozen columns](https://github.com/user-attachments/assets/55ce2170-fec1-461e-a888-e864e437ea27)

closes #154 