### PR TITLE
Enhance ComboBoxColumn with DisplayMemberPath support

### DIFF
--- a/src/Columns/TableViewComboBoxColumn.cs
+++ b/src/Columns/TableViewComboBoxColumn.cs
@@ -2,7 +2,6 @@
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Data;
-using System;
 
 namespace WinUI.TableView;
 


### PR DESCRIPTION
Closes #208 
Enhanced `TableViewComboBoxColumn` to use `DisplayMemberPath` for displaying text in cell.