### PR TITLE
Exposed AllowLiveShaping property

### DIFF
--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -279,6 +279,15 @@ public partial class TableView
     public IList<FilterDescription> FilterDescriptions => _collectionView.FilterDescriptions;
 
     /// <summary>
+    /// Gets or sets a value indicating whether live shaping is enabled.
+    /// </summary>
+    public bool AllowLiveShaping
+    {
+        get => _collectionView.AllowLiveShaping;
+        set => _collectionView.AllowLiveShaping = value;
+    }
+
+    /// <summary>
     /// Gets or sets the last selection unit used.
     /// </summary>
     internal TableViewSelectionUnit LastSelectionUnit { get; set; }


### PR DESCRIPTION
### PR Summary  
This pull request adds a new property to the `TableView` class to enable or disable live shaping functionality, enhancing its data manipulation capabilities.  
- **`TableView.Properties.cs`**: Added the `AllowLiveShaping` property to get or set the `_collectionView.AllowLiveShaping` value.  
