### PR TITLE
Add ListView-like hotkeys support to TableView

### DIFF
--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -311,6 +311,11 @@ public partial class TableView
     public static readonly DependencyProperty ShowDragRectangleProperty = DependencyProperty.Register(nameof(ShowDragRectangle), typeof(bool), typeof(TableView), new PropertyMetadata(true, OnShowDragRectangleChanged));
 
     /// <summary>
+    /// Identifies the <see cref="UseListViewHotkeys"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty UseListViewHotkeysProperty = DependencyProperty.Register(nameof(UseListViewHotkeys), typeof(bool), typeof(TableView), new PropertyMetadata(false));
+
+    /// <summary>
     /// Gets or sets a value indicating whether opening the column filter over header right-click is enabled.
     /// </summary>
     public bool UseRightClickForColumnFilter
@@ -867,6 +872,15 @@ public partial class TableView
     {
         get => (bool)GetValue(CanReorderColumnsProperty);
         set => SetValue(CanReorderColumnsProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the TableView should use ListView like hotkeys for navigation and selection.
+    /// </summary>
+    public bool UseListViewHotkeys
+    {
+        get => (bool)GetValue(UseListViewHotkeysProperty);
+        set => SetValue(UseListViewHotkeysProperty, value);
     }
 
     /// <summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -170,6 +170,16 @@ public partial class TableView : ListView
         return row;
     }
 
+    /// <summary>
+    /// Gets a value indicating whether keyboard input should be handled in row context,
+    /// i.e. when <see cref="UseListViewHotkeys"/> is enabled and the effective selection unit is a row.
+    /// </summary>
+    private bool IsRowKeyboardContext =>
+        UseListViewHotkeys &&
+        (SelectionUnit == TableViewSelectionUnit.Row ||
+         (SelectionUnit == TableViewSelectionUnit.CellOrRow &&
+          LastSelectionUnit == TableViewSelectionUnit.Row));
+
     /// <inheritdoc/>
     protected override void OnKeyDown(KeyRoutedEventArgs e)
     {
@@ -182,7 +192,90 @@ public partial class TableView : ListView
             return;
         }
 
+        if (!IsEditing && IsRowKeyboardContext)
+        {
+            if (!shiftKey &&
+                !ctrlKey &&
+                SelectionMode == ListViewSelectionMode.Multiple &&
+                e.Key == VirtualKey.Enter)
+            {
+                ToggleCurrentRowSelection();
+                e.Handled = true;
+                return;
+            }
+
+            var rowSelectionOnly = SelectionUnit == TableViewSelectionUnit.Row;
+
+            if (e.Key is VirtualKey.Up or VirtualKey.Down or
+                    VirtualKey.Home or VirtualKey.End or
+                    VirtualKey.PageUp or VirtualKey.PageDown ||
+                (rowSelectionOnly && (e.Key is VirtualKey.Left or VirtualKey.Right)))
+            {
+                int? prevCellRow = null;
+                if (SelectionUnit == TableViewSelectionUnit.Row && CurrentCellSlot.HasValue)
+                {
+                    prevCellRow = CurrentCellSlot.Value.Row;
+                }
+
+                base.OnKeyDown(e); // Let ListView move the row focus / selection
+
+                var focusedIndex = GetFocusedRowIndex();
+                if (focusedIndex >= 0)
+                {
+                    CurrentRowIndex = focusedIndex;
+                    SelectionStartRowIndex ??= focusedIndex;
+                }
+
+                if (SelectionUnit == TableViewSelectionUnit.Row &&
+                    prevCellRow.HasValue &&
+                    focusedIndex >= 0 &&
+                    focusedIndex != prevCellRow.Value)
+                {
+                    CurrentCellSlot = null;  // will un-apply old cell's current-state border
+                }
+                return;
+            }
+        }
+
+        // Everything else (cell nav, F2 in cell mode, Space, etc.)
         HandleNavigations(e, shiftKey, ctrlKey);
+    }
+
+    private void ToggleCurrentRowSelection()
+    {
+        var index = GetFocusedRowIndex();
+
+        if (index < 0)
+        {
+            var rowIndex = CurrentRowIndex ?? SelectedIndex;
+
+            if (rowIndex is < 0 || rowIndex >= Items.Count)
+            {
+                return;
+            }
+
+            index = rowIndex;
+        }
+
+
+        if (index < 0 || index >= Items.Count) { return; }
+
+        var isSelected = SelectedRanges.Any(r => r.IsInRange(index));
+
+        var singleIndexRange = new ItemIndexRange(index, 1u);
+
+        if (isSelected)
+        {
+            DeselectRange(singleIndexRange);
+        }
+        else
+        {
+            SelectRange(singleIndexRange);
+        }
+
+        SelectionStartRowIndex = index;
+        CurrentRowIndex = index;
+
     }
 
     /// <summary>
@@ -531,6 +624,34 @@ public partial class TableView : ListView
         }
 
         return new TableViewCellSlot(nextRow, nextColumn);
+    }
+
+    private int GetFocusedRowIndex()
+    {
+        if (XamlRoot is null)
+            return -1;
+
+        var focused = FocusManager.GetFocusedElement(XamlRoot) as DependencyObject;
+        if (focused is null)
+            return -1;
+
+        var row = GetRowFromElement(focused);
+        return row?.Index ?? -1;
+    }
+
+    private static TableViewRow? GetRowFromElement(DependencyObject element)
+    {
+        var current = element;
+
+        while (current is not null)
+        {
+            if (current is TableViewRow row)
+                return row;
+
+            current = VisualTreeHelper.GetParent(current);
+        }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
Not sure if this is fixing a bug or adding feature so I've added a property, UseListViewHotkeys that makes TableView in SelectionMode="Multiple" use ListView hotkeys.  It defaults to false, so there won't be any backwards compatibility issues.

In the default WinUI 3 ListView, when SelectionMode="Multiple,
The 'Up' and 'Down' keys move the selection border
'Enter' toggles selection.
'Shift'+'Up'/'Down' when moving from a SelectedItem selects the destination item without deselecting other items anywhere.
The new property causes TableView to be like this, whilst still maintaining "tab" to edit next cell, 'enter' to edit the below cell and all other hotkeys.
If set to false... it keeps the original behaviour.

In TableView, when SelectionMode="Multiple" and SelectionUnit is "Row".
(or the checkbox column if "RowOrColumn")

'Up' selects the destination item and keeps anything below it selected, deselecting all consequentive rows above it. (non-consequentive items stay selected
'Down' does the reverse.
'Left'/'Right' deselects all consequentive items but the current cell.
'Enter' behaves super weirdly, if the checkbox cell is highlighted, it selects the second row and moves the selection border to the second row whilst keeping the prior item selected. Otherwise it behaves like the 'Down' key.
'Shift' key has no effect. (I've checked TableView.SelectRows() so I'm surprised)
I also had a look at SelectionMode="Extended" but TableView/ListView behave the same.

Added helper methods `ToggleCurrentRowSelection`,
`GetFocusedRowIndex`, and `GetRowFromElement` to manage row selection and focus. Updated `using` directives to include `Microsoft.UI.Xaml.Media` for visual tree traversal.

I did not change the VirtualKey.Left in the selection checkbox column, selecting the row.  I'm assuming this is intended behaviour.