### PR TITLE
fix: Prevent MenuFlyout click action on Space key press

### DIFF
--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -257,6 +257,8 @@ public partial class TableViewColumnHeader : ContentControl
 #else
             _searchBox.KeyDown += OnSearchBoxKeyDown;
 #endif
+            // Handle Space key to prevent MenuFlyoutItem performing click action.
+            menuItem.PreviewKeyUp += static (_, e) => e.Handled = e.Key is VirtualKey.Space;
         }
 
         SetFilterButtonVisibility();


### PR DESCRIPTION
fixes #169 

### PR Summary

This PR fixes an issue where the `FilterFlyout` closed when pressing the `Space` key in the search box.