### PR TITLE
fix: Missing `Visuals` binding failure

### DIFF
--- a/src/Themes/TableViewHeaderRow.xaml
+++ b/src/Themes/TableViewHeaderRow.xaml
@@ -200,6 +200,7 @@
                                 Translation="0, 0, 32"
                                 BorderThickness="1"
                                 RenderTransformOrigin="0.5,0.5"
+                                DataContext="{x:Null}"
                                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
                             <Border.Shadow>


### PR DESCRIPTION
### PR Summary
This PR ensures that a `ColumnDropIndicator` does not inherit its `DataContext` from parent elements.

fixes #263 