### PR TITLE
fix: Simplify boxing logic for nullable value types

### DIFF
--- a/src/Extensions/ObjectExtensions.cs
+++ b/src/Extensions/ObjectExtensions.cs
@@ -134,10 +134,8 @@ internal static partial class ObjectExtensions
 
     private static Expression EnsureObjectCompatibleResult(Expression expression)
     {
-        // Only convert to object if the expression type is not already assignable to object without boxing
-        if (expression.Type.IsValueType
-            && !expression.Type.IsNullableType()  // e.g. int? is considered a ValueType, but also nullable, which means it can be converted to object without boxing
-           )
+        // Ensure the final expression can be used in an object-returning lambda (boxing value types, including nullable value types)
+        if (expression.Type.IsValueType)
             return Expression.Convert(expression, typeof(object));
         return expression;
     }

--- a/tests/ObjectExtensionsTests.cs
+++ b/tests/ObjectExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -16,6 +17,22 @@ public class ObjectExtensionsTests
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual(7, result);
+    }
+
+    [TestMethod]
+    public void GetFuncCompiledPropertyPath_ShouldAccessSimpleNullableProperty()
+    {
+        var today = DateTimeOffset.Now;
+        var testItem = new TestItem { CompletedDate = today };
+        var func = testItem.GetFuncCompiledPropertyPath("CompletedDate");
+        Assert.IsNotNull(func);
+
+        var result = func(testItem);
+        Assert.AreEqual(today, result);
+
+        testItem.CompletedDate = null;
+        result = func(testItem);
+        Assert.IsNull(result);
     }
 
     [TestMethod]
@@ -347,6 +364,7 @@ public class ObjectExtensionsTests
     private class TestItem
     {
         public int Number { get; set; } = 0;
+        public DateTimeOffset? CompletedDate { get; set; }
         public TestStruct ValueTypeStruct { get; set; }
         public IList NonGenericList { get; set; } = new ArrayList();
         public List<SubItem> SubItems { get; set; } = [];


### PR DESCRIPTION
Fixes #272 

### PR Summary
This pull request updates the expression conversion logic to consistently box all value types and adds a test for nullable property access. 
- ObjectExtensions.cs: Modified `EnsureObjectCompatibleResult` to always box value types, including nullable types, when converting to `object`.
- ObjectExtensionsTests.cs: Added a unit test for accessing a nullable property and updated `TestItem` to include a nullable `CompletedDate` property.
