### PR TITLE
fix: Header row freeze issue

### DIFF
--- a/src/Themes/TableView.xaml
+++ b/src/Themes/TableView.xaml
@@ -30,7 +30,7 @@
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility"
                 Value="Auto" />
         <Setter Property="ScrollViewer.HorizontalScrollMode"
-                Value="Disabled" />
+                Value="Auto" />
         <win:Setter Property="ScrollViewer.IsHorizontalRailEnabled"
                     Value="True" />
         <Setter Property="ScrollViewer.VerticalScrollMode"
@@ -110,7 +110,7 @@
                                           Grid.Row="1"
                                           helpers:AttachedPropertiesHelper.FrozenColumnScrollBarSpace="{TemplateBinding RowHeaderMinWidth}"
                                           TabNavigation="{TemplateBinding TabNavigation}"
-                                          HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                                          HorizontalScrollMode="Disabled"
                                           HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                                           win:IsHorizontalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsHorizontalScrollChainingEnabled}"
                                           VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"


### PR DESCRIPTION
Fixes #270 

Disabled default horizontal scroll mode because `TableView` has its own implementation of horizontal scrolling. The default scroll mode was causing the issue when scrolling with only with touchpad at the row headers.