### PR TITLE
fix: respect DateTimeKind in ToDateTimeOffset

### DIFF
--- a/src/Extensions/DateTimeExtensions.cs
+++ b/src/Extensions/DateTimeExtensions.cs
@@ -8,13 +8,18 @@ namespace WinUI.TableView.Extensions;
 internal static class DateTimeExtensions
 {
     /// <summary>
-    /// Converts a DateTime to a DateTimeOffset using the local time zone.
+    /// Converts a DateTime to a DateTimeOffset, respecting the DateTime's Kind.
+    /// Uses UTC offset for UTC DateTimes and local offset otherwise.
     /// </summary>
     /// <param name="dateTime">The DateTime to convert.</param>
     /// <returns>A DateTimeOffset representing the same point in time as the DateTime.</returns>
     public static DateTimeOffset ToDateTimeOffset(this DateTime dateTime)
     {
-        return new DateTimeOffset(dateTime, TimeZoneInfo.Local.GetUtcOffset(dateTime));
+        var offset = dateTime.Kind == DateTimeKind.Utc
+            ? TimeSpan.Zero
+            : TimeZoneInfo.Local.GetUtcOffset(dateTime);
+
+        return new DateTimeOffset(dateTime, offset);
     }
 
     /// <summary>

--- a/tests/DateTimeExtensionsTests.cs
+++ b/tests/DateTimeExtensionsTests.cs
@@ -17,6 +17,15 @@ public class DateTimeExtensionsTests
     }
 
     [TestMethod]
+    public void ToDateTimeOffset_FromUtcDateTime_UsesZeroOffset()
+    {
+        var dt = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var dto = dt.ToDateTimeOffset();
+        var expected = new DateTimeOffset(dt, TimeSpan.Zero);
+        Assert.AreEqual(expected, dto);
+    }
+
+    [TestMethod]
     public void ToDateTimeOffset_FromTimeSpan_UsesTodayDate()
     {
         var ts = new TimeSpan(12, 34, 56);


### PR DESCRIPTION
## Description

`DateTimeExtensions.ToDateTimeOffset()` always used `TimeZoneInfo.Local.GetUtcOffset()`, which throws `0x80070057` ("The UTC Offset for Utc DateTime instances must be 0") when passed a `DateTime` with `DateTimeKind.Utc`.

The fix checks `dateTime.Kind` and uses `TimeSpan.Zero` for UTC DateTimes, preserving existing behavior for `Unspecified` and `Local` kinds.

## Changes

- **`DateTimeExtensions.cs`** — Check `DateTimeKind.Utc` before selecting the offset
- **`DateTimeExtensionsTests.cs`** — Added `ToDateTimeOffset_FromUtcDateTime_UsesZeroOffset` test

Fixes #330