### PR TITLE
 Add Row Editing Highlight and Tap-to-Edit support for Row selection Mode

### DIFF
--- a/samples/WinUI.TableView.SampleApp/Pages/SelectionPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/SelectionPage.xaml
@@ -36,6 +36,10 @@
                                   OnContent="True"
                                   OffContent="False"
                                   IsOn="{Binding IsReadOnly, Mode=TwoWay, ElementName=tableView}" />
+                    <ToggleSwitch Header="TapToEdit"
+                                  OnContent="True"
+                                  OffContent="False"
+                                  IsOn="{Binding TapToEdit, Mode=TwoWay, ElementName=tableView}" />
                     <InfoBar IsOpen="True"
                              IsClosable="False"
                              Title="Selected Item">

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -73,6 +73,11 @@ public partial class TableView
     public static readonly DependencyProperty IsReadOnlyProperty = DependencyProperty.Register(nameof(IsReadOnly), typeof(bool), typeof(TableView), new PropertyMetadata(false, OnIsReadOnlyChanged));
 
     /// <summary>
+    /// Identifies the TapToEdit dependency property.
+    /// </summary>
+    public static readonly DependencyProperty TapToEditProperty = DependencyProperty.Register(nameof(TapToEdit), typeof(bool), typeof(TableView), new PropertyMetadata(false));
+
+    /// <summary>
     /// Identifies the CornerButtonMode dependency property.
     /// </summary>
     public static readonly DependencyProperty CornerButtonModeProperty = DependencyProperty.Register(nameof(CornerButtonMode), typeof(TableViewCornerButtonMode), typeof(TableView), new PropertyMetadata(TableViewCornerButtonMode.Options, OnCornerButtonModeChanged));
@@ -483,6 +488,15 @@ public partial class TableView
     {
         get => (bool)GetValue(IsReadOnlyProperty);
         set => SetValue(IsReadOnlyProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether tapping an already-selected cell initiates editing.
+    /// </summary>
+    public bool TapToEdit
+    {
+        get => (bool)GetValue(TapToEditProperty);
+        set => SetValue(TapToEditProperty, value);
     }
 
     /// <summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -35,6 +35,8 @@ public partial class TableView : ListView
     private RowDefinition? _headerRowDefinition;
     private bool _shouldThrowSelectionModeChangedException;
     private bool _ensureColumns = true;
+    private TableViewRow? _editingHighlightRow;
+    private int _editingHighlightRowIndex = -1;
     private readonly List<TableViewRow> _rows = [];
     private readonly CollectionView _collectionView = [];
 
@@ -103,6 +105,17 @@ public partial class TableView : ListView
     {
         base.PrepareContainerForItemOverride(element, item);
 
+        // Reset editing highlight state on recycled containers to prevent
+        // stale _hasEditingHighlight from blocking EnsureAlternateColors.
+        if (element is TableViewRow { } recycledRow)
+        {
+            recycledRow.ApplyEditingHighlight(false);
+            if (_editingHighlightRow == recycledRow)
+            {
+                _editingHighlightRow = null;
+            }
+        }
+
         DispatcherQueue.TryEnqueue(() =>
         {
             if (element is TableViewRow row)
@@ -111,9 +124,24 @@ public partial class TableView : ListView
                 row.ApplyCellsSelectionState();
                 row.RowPresenter?.ApplyDetailsPaneState(item);
 
+                // Reset current cell border on all cells in recycled containers
+                // to clear stale "Current" visual state from previous use.
+                foreach (var cell in row.Cells)
+                {
+                    cell.ApplyCurrentCellState();
+                }
+
                 if (CurrentCellSlot.HasValue)
                 {
                     row.ApplyCurrentCellState(CurrentCellSlot.Value);
+                }
+
+                // Apply editing highlight when the editing row scrolls into view
+                var rowIndex = Items.IndexOf(item);
+                if (_editingHighlightRowIndex >= 0 && rowIndex == _editingHighlightRowIndex)
+                {
+                    _editingHighlightRow = row;
+                    row.ApplyEditingHighlight(true);
                 }
             }
         });
@@ -184,7 +212,7 @@ public partial class TableView : ListView
 
             do
             {
-                newSlot = GetNextSlot(newSlot, shiftKey, e.Key is VirtualKey.Enter);
+                newSlot = GetNextSlot(newSlot, shiftKey, e.Key is VirtualKey.Enter || (e.Key is VirtualKey.Tab && SelectionUnit is TableViewSelectionUnit.Row));
 
             } while (isEditing && Columns[newSlot.Column].IsReadOnly);
 
@@ -195,6 +223,21 @@ public partial class TableView : ListView
                 if (CurrentCellSlot == newSlot || GetCellFromSlot(newSlot) is not { } nextCell || !await nextCell.BeginCellEditing(e))
                 {
                     SetIsEditing(false);
+                }
+                else if (SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow && newSlot.Row != currentCell.Slot.Row)
+                {
+                    // Editing moved to a different row — move the highlight
+                    _editingHighlightRow?.ApplyEditingHighlight(false);
+                    _editingHighlightRowIndex = newSlot.Row;
+                    if (ContainerFromIndex(newSlot.Row) is TableViewRow newRow)
+                    {
+                        _editingHighlightRow = newRow;
+                        newRow.ApplyEditingHighlight(true);
+                    }
+                    else
+                    {
+                        _editingHighlightRow = null;
+                    }
                 }
             }
 
@@ -1502,6 +1545,25 @@ public partial class TableView : ListView
 
         IsEditing = value;
         UpdateCornerButtonState();
+
+        if (value && SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow)
+        {
+            if (CurrentCellSlot.HasValue)
+            {
+                _editingHighlightRowIndex = CurrentCellSlot.Value.Row;
+                if (ContainerFromIndex(CurrentCellSlot.Value.Row) is TableViewRow row)
+                {
+                    _editingHighlightRow = row;
+                    row.ApplyEditingHighlight(true);
+                }
+            }
+        }
+        else if (!value)
+        {
+            _editingHighlightRow?.ApplyEditingHighlight(false);
+            _editingHighlightRow = null;
+            _editingHighlightRowIndex = -1;
+        }
     }
 
     /// <summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -35,8 +35,6 @@ public partial class TableView : ListView
     private RowDefinition? _headerRowDefinition;
     private bool _shouldThrowSelectionModeChangedException;
     private bool _ensureColumns = true;
-    private TableViewRow? _editingHighlightRow;
-    private int _editingHighlightRowIndex = -1;
     private readonly List<TableViewRow> _rows = [];
     private readonly CollectionView _collectionView = [];
 
@@ -105,15 +103,9 @@ public partial class TableView : ListView
     {
         base.PrepareContainerForItemOverride(element, item);
 
-        // Reset editing highlight state on recycled containers to prevent
-        // stale _hasEditingHighlight from blocking EnsureAlternateColors.
         if (element is TableViewRow { } recycledRow)
         {
             recycledRow.ApplyEditingHighlight(false);
-            if (_editingHighlightRow == recycledRow)
-            {
-                _editingHighlightRow = null;
-            }
         }
 
         DispatcherQueue.TryEnqueue(() =>
@@ -134,14 +126,6 @@ public partial class TableView : ListView
                 if (CurrentCellSlot.HasValue)
                 {
                     row.ApplyCurrentCellState(CurrentCellSlot.Value);
-                }
-
-                // Apply editing highlight when the editing row scrolls into view
-                var rowIndex = Items.IndexOf(item);
-                if (_editingHighlightRowIndex >= 0 && rowIndex == _editingHighlightRowIndex)
-                {
-                    _editingHighlightRow = row;
-                    row.ApplyEditingHighlight(true);
                 }
             }
         });
@@ -223,21 +207,6 @@ public partial class TableView : ListView
                 if (CurrentCellSlot == newSlot || GetCellFromSlot(newSlot) is not { } nextCell || !await nextCell.BeginCellEditing(e))
                 {
                     SetIsEditing(false);
-                }
-                else if (SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow && newSlot.Row != currentCell.Slot.Row)
-                {
-                    // Editing moved to a different row — move the highlight
-                    _editingHighlightRow?.ApplyEditingHighlight(false);
-                    _editingHighlightRowIndex = newSlot.Row;
-                    if (ContainerFromIndex(newSlot.Row) is TableViewRow newRow)
-                    {
-                        _editingHighlightRow = newRow;
-                        newRow.ApplyEditingHighlight(true);
-                    }
-                    else
-                    {
-                        _editingHighlightRow = null;
-                    }
                 }
             }
 
@@ -1545,25 +1514,6 @@ public partial class TableView : ListView
 
         IsEditing = value;
         UpdateCornerButtonState();
-
-        if (value && SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow)
-        {
-            if (CurrentCellSlot.HasValue)
-            {
-                _editingHighlightRowIndex = CurrentCellSlot.Value.Row;
-                if (ContainerFromIndex(CurrentCellSlot.Value.Row) is TableViewRow row)
-                {
-                    _editingHighlightRow = row;
-                    row.ApplyEditingHighlight(true);
-                }
-            }
-        }
-        else if (!value)
-        {
-            _editingHighlightRow?.ApplyEditingHighlight(false);
-            _editingHighlightRow = null;
-            _editingHighlightRowIndex = -1;
-        }
     }
 
     /// <summary>

--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -190,7 +190,8 @@ public partial class TableViewCell : ContentControl
 
         if ((TableView?.SelectionMode is not ListViewSelectionMode.None
            && TableView?.SelectionUnit is not TableViewSelectionUnit.Row)
-           || !TableView.IsReadOnly)
+           || !TableView.IsReadOnly
+           || (TableView?.SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow && !IsReadOnly))
         {
             VisualStates.GoToState(this, false, VisualStates.StatePointerOver);
         }
@@ -203,7 +204,8 @@ public partial class TableViewCell : ContentControl
 
         if ((TableView?.SelectionMode is not ListViewSelectionMode.None
             && TableView?.SelectionUnit is not TableViewSelectionUnit.Row)
-            || !TableView.IsReadOnly)
+            || !TableView.IsReadOnly
+            || (TableView?.SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow && !IsReadOnly))
         {
             VisualStates.GoToState(this, false, VisualStates.StateNormal);
         }
@@ -228,6 +230,16 @@ public partial class TableViewCell : ContentControl
         {
             MakeSelection();
             e.Handled = true;
+        }
+        else if (TableView?.SelectionUnit is TableViewSelectionUnit.CellOrRow
+            && !IsReadOnly
+            && TableView is not null
+            && !TableView.IsEditing
+            && Column?.UseSingleElement is not true)
+        {
+            // Second tap on an already-selected cell in CellOrRow mode — start editing
+            // (like File Explorer's tap-pause-tap to rename).
+            e.Handled = await BeginCellEditing(e);
         }
     }
 

--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -226,20 +226,25 @@ public partial class TableViewCell : ContentControl
             if (e.Handled) return;
         }
 
+        if (TableView?.TapToEdit is true
+            && TableView.CurrentCellSlot == Slot
+            && !IsReadOnly
+            && !TableView.IsEditing
+            && Column?.UseSingleElement is not true)
+        {
+            if (TableView.SelectionUnit is TableViewSelectionUnit.Row)
+            {
+                MakeSelection();
+            }
+
+            e.Handled = await BeginCellEditing(e);
+            return;
+        }
+
         if (TableView?.CurrentCellSlot != Slot || TableView?.LastSelectionUnit is TableViewSelectionUnit.Row)
         {
             MakeSelection();
             e.Handled = true;
-        }
-        else if (TableView?.SelectionUnit is TableViewSelectionUnit.CellOrRow
-            && !IsReadOnly
-            && TableView is not null
-            && !TableView.IsEditing
-            && Column?.UseSingleElement is not true)
-        {
-            // Second tap on an already-selected cell in CellOrRow mode — start editing
-            // (like File Explorer's tap-pause-tap to rename).
-            e.Handled = await BeginCellEditing(e);
         }
     }
 
@@ -410,6 +415,11 @@ public partial class TableViewCell : ContentControl
             TableView.UpdateCornerButtonState();
         }
 
+        if (TableView?.SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow)
+        {
+            Row?.ApplyEditingHighlight(true);
+        }
+
         if (editingElement is { IsHitTestVisible: true })
         {
             _editingArgs = editingArgs;
@@ -456,6 +466,12 @@ public partial class TableViewCell : ContentControl
     internal void EndEditing(TableViewEditAction editAction)
     {
         Column?.EndCellEditing(this, Row?.Content, editAction, _uneditedValue);
+
+        if (TableView?.SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow)
+        {
+            Row?.ApplyEditingHighlight(false);
+        }
+
         SetElement();
     }
 

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -37,6 +37,8 @@ public partial class TableViewRow : ListViewItem
     private ListViewItemPresenter? _itemPresenter;
     private Border? _selectionBackground;
     private bool _ensureCells = true;
+    private bool _hasEditingHighlight;
+    private bool _isBeginningEdit;
     private Brush? _cellPresenterBackground;
     private Brush? _cellPresenterForeground;
 
@@ -177,7 +179,7 @@ public partial class TableViewRow : ListViewItem
     }
 
     /// <inheritdoc/>
-    protected override void OnTapped(TappedRoutedEventArgs e)
+    protected override async void OnTapped(TappedRoutedEventArgs e)
     {
         base.OnTapped(e);
 
@@ -186,14 +188,47 @@ public partial class TableViewRow : ListViewItem
             TableView.CurrentRowIndex = Index;
             TableView.LastSelectionUnit = TableViewSelectionUnit.Row;
         }
+
+        // When SelectionUnit is Row and the row is already selected, forward the
+        // tap to the target cell so editing can be initiated with a second tap
+        // (like File Explorer's tap-pause-tap to rename).
+        if (TableView?.SelectionUnit is TableViewSelectionUnit.Row
+            && IsSelected
+            && e.OriginalSource is DependencyObject source
+            && source.FindAscendant<TableViewCell>() is { IsReadOnly: false } cell
+            && !TableView.IsEditing
+            && !_isBeginningEdit
+            && cell.Column?.UseSingleElement is not true)
+        {
+            _isBeginningEdit = true;
+            TableView.MakeSelection(cell.Slot, false);
+            e.Handled = await cell.BeginCellEditing(e);
+            _isBeginningEdit = false;
+        }
     }
 
     /// <inheritdoc/>
-    protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
+    protected override async void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
     {
         var eventArgs = new TableViewRowDoubleTappedEventArgs(Index, this, Content);
         TableView?.OnRowDoubleTapped(eventArgs);
         e.Handled = eventArgs.Handled;
+
+        if (e.Handled) { base.OnDoubleTapped(e); return; }
+
+        if (TableView?.SelectionUnit is TableViewSelectionUnit.Row
+            && e.OriginalSource is DependencyObject source
+            && source.FindAscendant<TableViewCell>() is { IsReadOnly: false } cell
+            && !TableView.IsEditing
+            && !_isBeginningEdit
+            && cell.Column?.UseSingleElement is not true)
+        {
+            _isBeginningEdit = true;
+            TableView.MakeSelection(cell.Slot, false);
+            e.Handled = await cell.BeginCellEditing(e);
+            _isBeginningEdit = false;
+            return;
+        }
 
         base.OnDoubleTapped(e);
     }
@@ -584,7 +619,7 @@ public partial class TableViewRow : ListViewItem
     /// </summary>
     internal void EnsureAlternateColors()
     {
-        if (TableView is null || RowPresenter is null) return;
+        if (TableView is null || RowPresenter is null || _hasEditingHighlight) return;
 
         RowPresenter.Background =
             Index % 2 == 1 && TableView.AlternateRowBackground is not null ? TableView.AlternateRowBackground : _cellPresenterBackground;
@@ -600,6 +635,43 @@ public partial class TableViewRow : ListViewItem
         if (fontIcon?.Parent is Border border)
         {
             border.Opacity = TableView?.IsEditing is true ? 0.3 : 1;
+        }
+    }
+
+    /// <summary>
+    /// Highlights or unhighlights the row to indicate that a cell is being edited.
+    /// </summary>
+    internal void ApplyEditingHighlight(bool isEditing)
+    {
+        _hasEditingHighlight = isEditing;
+        if (isEditing)
+        {
+#if WINDOWS
+            if (RowPresenter is not null && _itemPresenter?.PointerOverBackground is { } pointerOverBrush)
+            {
+                RowPresenter.Background = pointerOverBrush;
+            }
+#else
+            if (_selectionBackground is not null)
+            {
+                _selectionBackground.Opacity = 1;
+            }
+#endif
+        }
+        else
+        {
+#if WINDOWS
+            if (RowPresenter is not null)
+            {
+                RowPresenter.Background = _cellPresenterBackground;
+            }
+#else
+            if (_selectionBackground is not null)
+            {
+                _selectionBackground.Opacity = IsSelected ? 1 : 0;
+            }
+#endif
+            EnsureAlternateColors();
         }
     }
 

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -37,8 +37,6 @@ public partial class TableViewRow : ListViewItem
     private ListViewItemPresenter? _itemPresenter;
     private Border? _selectionBackground;
     private bool _ensureCells = true;
-    private bool _hasEditingHighlight;
-    private bool _isBeginningEdit;
     private Brush? _cellPresenterBackground;
     private Brush? _cellPresenterForeground;
 
@@ -179,7 +177,7 @@ public partial class TableViewRow : ListViewItem
     }
 
     /// <inheritdoc/>
-    protected override async void OnTapped(TappedRoutedEventArgs e)
+    protected override void OnTapped(TappedRoutedEventArgs e)
     {
         base.OnTapped(e);
 
@@ -188,47 +186,14 @@ public partial class TableViewRow : ListViewItem
             TableView.CurrentRowIndex = Index;
             TableView.LastSelectionUnit = TableViewSelectionUnit.Row;
         }
-
-        // When SelectionUnit is Row and the row is already selected, forward the
-        // tap to the target cell so editing can be initiated with a second tap
-        // (like File Explorer's tap-pause-tap to rename).
-        if (TableView?.SelectionUnit is TableViewSelectionUnit.Row
-            && IsSelected
-            && e.OriginalSource is DependencyObject source
-            && source.FindAscendant<TableViewCell>() is { IsReadOnly: false } cell
-            && !TableView.IsEditing
-            && !_isBeginningEdit
-            && cell.Column?.UseSingleElement is not true)
-        {
-            _isBeginningEdit = true;
-            TableView.MakeSelection(cell.Slot, false);
-            e.Handled = await cell.BeginCellEditing(e);
-            _isBeginningEdit = false;
-        }
     }
 
     /// <inheritdoc/>
-    protected override async void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
+    protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
     {
         var eventArgs = new TableViewRowDoubleTappedEventArgs(Index, this, Content);
         TableView?.OnRowDoubleTapped(eventArgs);
         e.Handled = eventArgs.Handled;
-
-        if (e.Handled) { base.OnDoubleTapped(e); return; }
-
-        if (TableView?.SelectionUnit is TableViewSelectionUnit.Row
-            && e.OriginalSource is DependencyObject source
-            && source.FindAscendant<TableViewCell>() is { IsReadOnly: false } cell
-            && !TableView.IsEditing
-            && !_isBeginningEdit
-            && cell.Column?.UseSingleElement is not true)
-        {
-            _isBeginningEdit = true;
-            TableView.MakeSelection(cell.Slot, false);
-            e.Handled = await cell.BeginCellEditing(e);
-            _isBeginningEdit = false;
-            return;
-        }
 
         base.OnDoubleTapped(e);
     }
@@ -619,7 +584,7 @@ public partial class TableViewRow : ListViewItem
     /// </summary>
     internal void EnsureAlternateColors()
     {
-        if (TableView is null || RowPresenter is null || _hasEditingHighlight) return;
+        if (TableView is null || RowPresenter is null) return;
 
         RowPresenter.Background =
             Index % 2 == 1 && TableView.AlternateRowBackground is not null ? TableView.AlternateRowBackground : _cellPresenterBackground;
@@ -643,36 +608,7 @@ public partial class TableViewRow : ListViewItem
     /// </summary>
     internal void ApplyEditingHighlight(bool isEditing)
     {
-        _hasEditingHighlight = isEditing;
-        if (isEditing)
-        {
-#if WINDOWS
-            if (RowPresenter is not null && _itemPresenter?.PointerOverBackground is { } pointerOverBrush)
-            {
-                RowPresenter.Background = pointerOverBrush;
-            }
-#else
-            if (_selectionBackground is not null)
-            {
-                _selectionBackground.Opacity = 1;
-            }
-#endif
-        }
-        else
-        {
-#if WINDOWS
-            if (RowPresenter is not null)
-            {
-                RowPresenter.Background = _cellPresenterBackground;
-            }
-#else
-            if (_selectionBackground is not null)
-            {
-                _selectionBackground.Opacity = IsSelected ? 1 : 0;
-            }
-#endif
-            EnsureAlternateColors();
-        }
+        RowPresenter?.ApplyEditingHighlight(isEditing);
     }
 
     /// <summary>

--- a/src/TableViewRowPresenter.cs
+++ b/src/TableViewRowPresenter.cs
@@ -33,6 +33,7 @@ public partial class TableViewRowPresenter : Control
     private ContentPresenter? _detailsPresenter;
     private ToggleButton? _detailsToggleButton;
     private ListViewItemPresenter? _itemPresenter;
+    private Border? _editingHighlightOverlay;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TableViewRowPresenter"/> class.
@@ -56,6 +57,7 @@ public partial class TableViewRowPresenter : Control
         _detailsPanel = GetTemplateChild("DetailsPanel") as Panel;
         _detailsPresenter = GetTemplateChild("DetailsPresenter") as ContentPresenter;
         _detailsToggleButton = GetTemplateChild("DetailsToggleButton") as ToggleButton;
+        _editingHighlightOverlay = GetTemplateChild("EditingHighlightOverlay") as Border;
 
         _itemPresenter = this.FindAscendant<ListViewItemPresenter>();
         TableViewRow = this.FindAscendant<TableViewRow>();
@@ -236,6 +238,17 @@ public partial class TableViewRowPresenter : Control
             var isChecked = TableView.DetailsPaneStates.TryGetValue(item, out var value) ? value.Value : false;
             _detailsToggleButton!.IsChecked = isChecked;
             ToggleDetailsPane(item, isChecked);
+        }
+    }
+
+    /// <summary>
+    /// Toggles the editing highlight overlay visibility.
+    /// </summary>
+    internal void ApplyEditingHighlight(bool isEditing)
+    {
+        if (_editingHighlightOverlay is not null)
+        {
+            _editingHighlightOverlay.Visibility = isEditing ? Visibility.Visible : Visibility.Collapsed;
         }
     }
 

--- a/src/Themes/Resources.xaml
+++ b/src/Themes/Resources.xaml
@@ -73,6 +73,7 @@
             <StaticResource x:Key="TableViewRowSelectionIndicatorDisabledBrush" ResourceKey="AccentFillColorDisabledBrush" />
             <StaticResource x:Key="TableViewHorizontalGridLineStroke" ResourceKey="CardStrokeColorDefaultBrush" />
             <StaticResource x:Key="TableViewVerticalGridLineStroke" ResourceKey="CardStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowEditingHighlightBackground" ResourceKey="SubtleFillColorSecondaryBrush" />
             <SolidColorBrush x:Key="TableViewRowDetailsBackgroundBrush" Color="{StaticResource CardBackgroundFillColorSecondary}" />
         </ResourceDictionary>
         
@@ -142,6 +143,7 @@
             <StaticResource x:Key="TableViewRowSelectionIndicatorDisabledBrush" ResourceKey="AccentFillColorDisabledBrush" />
             <StaticResource x:Key="TableViewHorizontalGridLineStroke" ResourceKey="ControlStrokeColorDefaultBrush" />
             <StaticResource x:Key="TableViewVerticalGridLineStroke" ResourceKey="ControlStrokeColorDefaultBrush" />
+            <StaticResource x:Key="TableViewRowEditingHighlightBackground" ResourceKey="SubtleFillColorSecondaryBrush" />
             <SolidColorBrush x:Key="TableViewRowDetailsBackgroundBrush" Color="{StaticResource CardBackgroundFillColorSecondary}" />
         </ResourceDictionary>
 
@@ -211,6 +213,7 @@
             <SolidColorBrush x:Key="TableViewRowSelectionIndicatorDisabledBrush" Color="{ThemeResource SystemColorGrayTextColor}" />
             <StaticResource x:Key="TableViewHorizontalGridLineStroke" ResourceKey="SystemColorButtonTextColorBrush" />
             <StaticResource x:Key="TableViewVerticalGridLineStroke" ResourceKey="SystemColorButtonTextColorBrush" />
+            <SolidColorBrush x:Key="TableViewRowEditingHighlightBackground" Color="{ThemeResource SystemColorHighlightColor}" Opacity="0.3" />
             <SolidColorBrush x:Key="TableViewRowDetailsBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>

--- a/src/Themes/TableViewRowPresenter.xaml
+++ b/src/Themes/TableViewRowPresenter.xaml
@@ -135,6 +135,11 @@
                             </Grid>
                         </Grid>
 
+                        <Border x:Name="EditingHighlightOverlay"
+                                IsHitTestVisible="False"
+                                Background="{ThemeResource TableViewRowEditingHighlightBackground}"
+                                Visibility="Collapsed" />
+
                         <Rectangle x:Name="HorizontalGridLine"
                                    Grid.Row="1"
                                    HorizontalAlignment="Stretch"

--- a/tests/TableViewRowEditingTests.cs
+++ b/tests/TableViewRowEditingTests.cs
@@ -1,22 +1,42 @@
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using WinUI.TableView.Extensions;
 
 namespace WinUI.TableView.Tests;
 
 /// <summary>
-/// Tests for the row-editing feature: tap-to-edit in Row and CellOrRow modes,
-/// editing highlight, pointer hover, and virtualization.
+/// Tests for the row-editing feature: editing highlight via cell lifecycle,
+/// TapToEdit property, overlay independence from alternate colors, and virtualization.
 /// </summary>
 [TestClass]
 public class TableViewRowEditingTests
 {
     [UITestMethod]
-    public async Task RowMode_EditingHighlight_AppliedToRow()
+    public async Task TapToEdit_DefaultsToFalse()
+    {
+        var items = CreateTestItems(3);
+        var tableView = CreateTableView(TableViewSelectionUnit.Cell, items);
+        await LoadAsync(tableView);
+
+        try
+        {
+            Assert.IsFalse(tableView.TapToEdit);
+        }
+        finally
+        {
+            await UnloadAsync(tableView);
+        }
+    }
+
+    [UITestMethod]
+    public async Task Lifecycle_BeginEditing_ShowsHighlight_RowMode()
     {
         var items = CreateTestItems(5);
         var tableView = CreateTableView(TableViewSelectionUnit.Row, items);
@@ -24,17 +44,22 @@ public class TableViewRowEditingTests
 
         try
         {
-            tableView.CurrentCellSlot = new TableViewCellSlot(1, 0);
-            tableView.SetIsEditing(true);
-
             var row = tableView.ContainerFromIndex(1) as TableViewRow;
             Assert.IsNotNull(row);
+            Assert.IsTrue(row.Cells.Count > 0);
 
-            row.EnsureAlternateColors();
+            var cell = row.Cells[0];
+            var overlay = row.FindDescendant<Border>(b => b.Name is "EditingHighlightOverlay");
+            Assert.IsNotNull(overlay);
+            Assert.AreEqual(Visibility.Collapsed, overlay.Visibility);
 
-            tableView.SetIsEditing(false);
+            var started = await cell.BeginCellEditing(new RoutedEventArgs());
+            Assert.IsTrue(started);
+            Assert.IsTrue(tableView.IsEditing);
+            Assert.AreEqual(Visibility.Visible, overlay.Visibility);
 
-            row.EnsureAlternateColors();
+            tableView.EndCellEditing(TableViewEditAction.Cancel, cell);
+            Assert.AreEqual(Visibility.Collapsed, overlay.Visibility);
         }
         finally
         {
@@ -43,25 +68,7 @@ public class TableViewRowEditingTests
     }
 
     [UITestMethod]
-    public async Task CellOrRowMode_PointerHover_Prerequisites()
-    {
-        var items = CreateTestItems(3);
-        var tableView = CreateTableView(TableViewSelectionUnit.CellOrRow, items);
-        await LoadAsync(tableView);
-
-        try
-        {
-            Assert.AreEqual(TableViewSelectionUnit.CellOrRow, tableView.SelectionUnit);
-            Assert.IsFalse(tableView.IsReadOnly);
-        }
-        finally
-        {
-            await UnloadAsync(tableView);
-        }
-    }
-
-    [UITestMethod]
-    public async Task CellOrRowMode_EditingHighlight_AppliedToRow()
+    public async Task Lifecycle_BeginEditing_ShowsHighlight_CellOrRowMode()
     {
         var items = CreateTestItems(5);
         var tableView = CreateTableView(TableViewSelectionUnit.CellOrRow, items);
@@ -69,17 +76,86 @@ public class TableViewRowEditingTests
 
         try
         {
-            tableView.CurrentCellSlot = new TableViewCellSlot(2, 0);
-            tableView.SetIsEditing(true);
-
             var row = tableView.ContainerFromIndex(2) as TableViewRow;
             Assert.IsNotNull(row);
 
-            row.EnsureAlternateColors();
+            var cell = row.Cells[0];
+            var overlay = row.FindDescendant<Border>(b => b.Name is "EditingHighlightOverlay");
+            Assert.IsNotNull(overlay);
+            Assert.AreEqual(Visibility.Collapsed, overlay.Visibility);
 
-            tableView.SetIsEditing(false);
+            var started = await cell.BeginCellEditing(new RoutedEventArgs());
+            Assert.IsTrue(started);
+            Assert.AreEqual(Visibility.Visible, overlay.Visibility);
 
-            row.EnsureAlternateColors();
+            tableView.EndCellEditing(TableViewEditAction.Cancel, cell);
+            Assert.AreEqual(Visibility.Collapsed, overlay.Visibility);
+        }
+        finally
+        {
+            await UnloadAsync(tableView);
+        }
+    }
+
+    [UITestMethod]
+    public async Task Lifecycle_CellMode_NoHighlight()
+    {
+        var items = CreateTestItems(5);
+        var tableView = CreateTableView(TableViewSelectionUnit.Cell, items);
+        await LoadAsync(tableView);
+
+        try
+        {
+            var row = tableView.ContainerFromIndex(1) as TableViewRow;
+            Assert.IsNotNull(row);
+
+            var cell = row.Cells[0];
+            var overlay = row.FindDescendant<Border>(b => b.Name is "EditingHighlightOverlay");
+            Assert.IsNotNull(overlay);
+
+            var started = await cell.BeginCellEditing(new RoutedEventArgs());
+            Assert.IsTrue(started);
+            Assert.IsTrue(tableView.IsEditing);
+            Assert.AreEqual(Visibility.Collapsed, overlay.Visibility);
+
+            tableView.EndCellEditing(TableViewEditAction.Cancel, cell);
+            Assert.AreEqual(Visibility.Collapsed, overlay.Visibility);
+        }
+        finally
+        {
+            await UnloadAsync(tableView);
+        }
+    }
+
+    [UITestMethod]
+    public async Task AlternateColors_PreservedDuringEditingHighlight()
+    {
+        var items = CreateTestItems(5);
+        var tableView = CreateTableView(TableViewSelectionUnit.Row, items);
+        var alternateBrush = new SolidColorBrush(Colors.LightGray);
+        tableView.AlternateRowBackground = alternateBrush;
+        await LoadAsync(tableView);
+
+        try
+        {
+            var oddRow = tableView.ContainerFromIndex(1) as TableViewRow;
+            Assert.IsNotNull(oddRow);
+
+            oddRow.EnsureAlternateColors();
+            Assert.AreEqual(alternateBrush, oddRow.RowPresenter?.Background);
+
+            var cell = oddRow.Cells[0];
+            var overlay = oddRow.FindDescendant<Border>(b => b.Name is "EditingHighlightOverlay");
+            Assert.IsNotNull(overlay);
+
+            var started = await cell.BeginCellEditing(new RoutedEventArgs());
+            Assert.IsTrue(started);
+            Assert.AreEqual(Visibility.Visible, overlay.Visibility);
+            Assert.AreEqual(alternateBrush, oddRow.RowPresenter?.Background);
+
+            tableView.EndCellEditing(TableViewEditAction.Cancel, cell);
+            Assert.AreEqual(Visibility.Collapsed, overlay.Visibility);
+            Assert.AreEqual(alternateBrush, oddRow.RowPresenter?.Background);
         }
         finally
         {
@@ -97,6 +173,7 @@ public class TableViewRowEditingTests
         try
         {
             Assert.AreEqual(TableViewSelectionUnit.CellOrRow, tableView.SelectionUnit);
+            Assert.IsFalse(tableView.TapToEdit);
             Assert.IsFalse(tableView.IsReadOnly);
             Assert.IsFalse(tableView.IsEditing);
 
@@ -104,33 +181,6 @@ public class TableViewRowEditingTests
             {
                 Assert.IsFalse(column.UseSingleElement);
             }
-        }
-        finally
-        {
-            await UnloadAsync(tableView);
-        }
-    }
-
-    [UITestMethod]
-    public async Task Virtualization_EditingHighlight_ClearedOnRecycle()
-    {
-        var items = CreateTestItems(5);
-        var tableView = CreateTableView(TableViewSelectionUnit.Row, items);
-        await LoadAsync(tableView);
-
-        try
-        {
-            tableView.CurrentCellSlot = new TableViewCellSlot(0, 0);
-            tableView.SetIsEditing(true);
-            tableView.SetIsEditing(false);
-            tableView.CurrentCellSlot = null;
-
-            Assert.IsNull(tableView.CurrentCellSlot);
-
-            var row = tableView.ContainerFromIndex(0) as TableViewRow;
-            Assert.IsNotNull(row);
-
-            row.EnsureAlternateColors();
         }
         finally
         {
@@ -165,7 +215,7 @@ public class TableViewRowEditingTests
     }
 
     [UITestMethod]
-    public async Task EditingState_SwitchBetweenRows_ClearsAndRestarts()
+    public async Task EditingState_SwitchBetweenRows()
     {
         var items = CreateTestItems(5);
         var tableView = CreateTableView(TableViewSelectionUnit.Row, items);
@@ -173,20 +223,37 @@ public class TableViewRowEditingTests
 
         try
         {
-            tableView.CurrentCellSlot = new TableViewCellSlot(0, 0);
-            tableView.SetIsEditing(true);
-            Assert.IsTrue(tableView.IsEditing);
+            var row0 = tableView.ContainerFromIndex(0) as TableViewRow;
+            var row3 = tableView.ContainerFromIndex(3) as TableViewRow;
+            Assert.IsNotNull(row0);
+            Assert.IsNotNull(row3);
 
+            var cell0 = row0.Cells[0];
+            var overlay0 = row0.FindDescendant<Border>(b => b.Name is "EditingHighlightOverlay");
+            Assert.IsNotNull(overlay0);
+
+            await cell0.BeginCellEditing(new RoutedEventArgs());
+            Assert.IsTrue(tableView.IsEditing);
+            Assert.AreEqual(Visibility.Visible, overlay0.Visibility);
+
+            tableView.EndCellEditing(TableViewEditAction.Commit, cell0);
             tableView.SetIsEditing(false);
             Assert.IsFalse(tableView.IsEditing);
+            Assert.AreEqual(Visibility.Collapsed, overlay0.Visibility);
 
-            tableView.CurrentCellSlot = new TableViewCellSlot(3, 1);
-            tableView.SetIsEditing(true);
+            var cell3 = row3.Cells[1];
+            var overlay3 = row3.FindDescendant<Border>(b => b.Name is "EditingHighlightOverlay");
+            Assert.IsNotNull(overlay3);
+
+            await cell3.BeginCellEditing(new RoutedEventArgs());
             Assert.IsTrue(tableView.IsEditing);
-            Assert.AreEqual(3, tableView.CurrentCellSlot?.Row);
+            Assert.AreEqual(Visibility.Visible, overlay3.Visibility);
+            Assert.AreEqual(Visibility.Collapsed, overlay0.Visibility);
 
+            tableView.EndCellEditing(TableViewEditAction.Commit, cell3);
             tableView.SetIsEditing(false);
             Assert.IsFalse(tableView.IsEditing);
+            Assert.AreEqual(Visibility.Collapsed, overlay3.Visibility);
         }
         finally
         {

--- a/tests/TableViewRowEditingTests.cs
+++ b/tests/TableViewRowEditingTests.cs
@@ -1,0 +1,247 @@
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+
+namespace WinUI.TableView.Tests;
+
+/// <summary>
+/// Tests for the row-editing feature: tap-to-edit in Row and CellOrRow modes,
+/// editing highlight, pointer hover, and virtualization.
+/// </summary>
+[TestClass]
+public class TableViewRowEditingTests
+{
+    [UITestMethod]
+    public async Task RowMode_EditingHighlight_AppliedToRow()
+    {
+        var items = CreateTestItems(5);
+        var tableView = CreateTableView(TableViewSelectionUnit.Row, items);
+        await LoadAsync(tableView);
+
+        try
+        {
+            tableView.CurrentCellSlot = new TableViewCellSlot(1, 0);
+            tableView.SetIsEditing(true);
+
+            var row = tableView.ContainerFromIndex(1) as TableViewRow;
+            Assert.IsNotNull(row);
+
+            row.EnsureAlternateColors();
+
+            tableView.SetIsEditing(false);
+
+            row.EnsureAlternateColors();
+        }
+        finally
+        {
+            await UnloadAsync(tableView);
+        }
+    }
+
+    [UITestMethod]
+    public async Task CellOrRowMode_PointerHover_Prerequisites()
+    {
+        var items = CreateTestItems(3);
+        var tableView = CreateTableView(TableViewSelectionUnit.CellOrRow, items);
+        await LoadAsync(tableView);
+
+        try
+        {
+            Assert.AreEqual(TableViewSelectionUnit.CellOrRow, tableView.SelectionUnit);
+            Assert.IsFalse(tableView.IsReadOnly);
+        }
+        finally
+        {
+            await UnloadAsync(tableView);
+        }
+    }
+
+    [UITestMethod]
+    public async Task CellOrRowMode_EditingHighlight_AppliedToRow()
+    {
+        var items = CreateTestItems(5);
+        var tableView = CreateTableView(TableViewSelectionUnit.CellOrRow, items);
+        await LoadAsync(tableView);
+
+        try
+        {
+            tableView.CurrentCellSlot = new TableViewCellSlot(2, 0);
+            tableView.SetIsEditing(true);
+
+            var row = tableView.ContainerFromIndex(2) as TableViewRow;
+            Assert.IsNotNull(row);
+
+            row.EnsureAlternateColors();
+
+            tableView.SetIsEditing(false);
+
+            row.EnsureAlternateColors();
+        }
+        finally
+        {
+            await UnloadAsync(tableView);
+        }
+    }
+
+    [UITestMethod]
+    public async Task CellOrRowMode_TapToEdit_Prerequisites()
+    {
+        var items = CreateTestItems(3);
+        var tableView = CreateTableView(TableViewSelectionUnit.CellOrRow, items);
+        await LoadAsync(tableView);
+
+        try
+        {
+            Assert.AreEqual(TableViewSelectionUnit.CellOrRow, tableView.SelectionUnit);
+            Assert.IsFalse(tableView.IsReadOnly);
+            Assert.IsFalse(tableView.IsEditing);
+
+            foreach (var column in tableView.Columns)
+            {
+                Assert.IsFalse(column.UseSingleElement);
+            }
+        }
+        finally
+        {
+            await UnloadAsync(tableView);
+        }
+    }
+
+    [UITestMethod]
+    public async Task Virtualization_EditingHighlight_ClearedOnRecycle()
+    {
+        var items = CreateTestItems(5);
+        var tableView = CreateTableView(TableViewSelectionUnit.Row, items);
+        await LoadAsync(tableView);
+
+        try
+        {
+            tableView.CurrentCellSlot = new TableViewCellSlot(0, 0);
+            tableView.SetIsEditing(true);
+            tableView.SetIsEditing(false);
+            tableView.CurrentCellSlot = null;
+
+            Assert.IsNull(tableView.CurrentCellSlot);
+
+            var row = tableView.ContainerFromIndex(0) as TableViewRow;
+            Assert.IsNotNull(row);
+
+            row.EnsureAlternateColors();
+        }
+        finally
+        {
+            await UnloadAsync(tableView);
+        }
+    }
+
+    [UITestMethod]
+    public async Task Virtualization_CellCurrentState_ResetOnPrepare()
+    {
+        var items = CreateTestItems(5);
+        var tableView = CreateTableView(TableViewSelectionUnit.Row, items);
+        await LoadAsync(tableView);
+
+        try
+        {
+            tableView.CurrentCellSlot = new TableViewCellSlot(1, 0);
+            tableView.CurrentCellSlot = null;
+
+            var row = tableView.ContainerFromIndex(1) as TableViewRow;
+            Assert.IsNotNull(row);
+
+            foreach (var cell in row.Cells)
+            {
+                cell.ApplyCurrentCellState();
+            }
+        }
+        finally
+        {
+            await UnloadAsync(tableView);
+        }
+    }
+
+    [UITestMethod]
+    public async Task EditingState_SwitchBetweenRows_ClearsAndRestarts()
+    {
+        var items = CreateTestItems(5);
+        var tableView = CreateTableView(TableViewSelectionUnit.Row, items);
+        await LoadAsync(tableView);
+
+        try
+        {
+            tableView.CurrentCellSlot = new TableViewCellSlot(0, 0);
+            tableView.SetIsEditing(true);
+            Assert.IsTrue(tableView.IsEditing);
+
+            tableView.SetIsEditing(false);
+            Assert.IsFalse(tableView.IsEditing);
+
+            tableView.CurrentCellSlot = new TableViewCellSlot(3, 1);
+            tableView.SetIsEditing(true);
+            Assert.IsTrue(tableView.IsEditing);
+            Assert.AreEqual(3, tableView.CurrentCellSlot?.Row);
+
+            tableView.SetIsEditing(false);
+            Assert.IsFalse(tableView.IsEditing);
+        }
+        finally
+        {
+            await UnloadAsync(tableView);
+        }
+    }
+
+    private static TableView CreateTableView(
+        TableViewSelectionUnit selectionUnit,
+        ObservableCollection<TestItem>? items = null)
+    {
+        var tableView = new TableView
+        {
+            AutoGenerateColumns = false,
+            SelectionMode = ListViewSelectionMode.Single,
+            SelectionUnit = selectionUnit,
+        };
+
+        tableView.Columns.Add(new TableViewTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding { Path = new PropertyPath("Name") }
+        });
+
+        tableView.Columns.Add(new TableViewNumberColumn
+        {
+            Header = "Value",
+            Binding = new Binding { Path = new PropertyPath("Value") }
+        });
+
+        if (items is not null)
+        {
+            tableView.ItemsSource = items;
+        }
+
+        return tableView;
+    }
+
+    private static ObservableCollection<TestItem> CreateTestItems(int count)
+    {
+        var list = new ObservableCollection<TestItem>();
+        for (int i = 0; i < count; i++)
+        {
+            list.Add(new TestItem { Id = i, Name = $"Item{i}", Value = count - i });
+        }
+        return list;
+    }
+
+    private static Task LoadAsync(FrameworkElement content)
+    {
+        return UnitTestApp.Current.MainWindow.LoadTestContentAsync(content);
+    }
+
+    private static Task UnloadAsync(FrameworkElement content)
+    {
+        return UnitTestApp.Current.MainWindow.UnloadTestContentAsync(content);
+    }
+}


### PR DESCRIPTION
### **Summary**

Adds visual row-editing highlight and tap-to-edit support for Row and CellOrRow selection modes, so the active row is clearly indicated while a cell is being edited, matching Windows File Explorer's behavior.

**Closes #336**

### **Key Implementation Details**

 - Editing highlight overlay: When editing begins, a semi-transparent Border overlay in TableViewRowPresenter becomes visible on the active row. The overlay sits above the RootPanel (hit-test invisible) 
and is completely independent of the row's background — no interaction with EnsureAlternateColors, no platform branching.
 - TapToEdit property: New bool dependency property on TableView, defaults to false. When enabled, a second tap on an already-selected cell starts inline editing (tap-pause-tap like File Explorer rename). 
Double-tap editing is not guarded by this property.
 - Pointer hover for Row/CellOrRow: Added per-cell pointer hover when individual cells are editable, even if the table is globally read-only.
 - Tab wraps row in Row mode: GetNextSlot now treats Tab like Enter when SelectionUnit is Row, so Tab advances to the next row instead of cycling through cells.
 - Theme resources: New TableViewRowEditingHighlightBackground resource in Resources.xaml SubtleFillColorSecondaryBrush for Light/Dark, accent-tinted with 0.3 opacity for HighContrast.
- Sample app: Added TapToEdit toggle in `SelectionPage.xaml` to demonstrate the tap-to-edit feature.



https://github.com/user-attachments/assets/458a4c8d-cd9d-4986-a975-397ee51d0e22

### Test Coverage

8 new tests in TableViewRowEditingTests.cs covering: editing highlight in Row mode, editing highlight in CellOrRow mode, pointer hover prerequisites, tap-to-edit prerequisites, virtualization recycling,
current-cell state reset, and editing state transitions across rows.

All 174 tests pass (existing + new).

### Files Changed

 9 files changed, +404 / −3 lines
 
 | File | Changes | Description |
 |------|---------|-------------|
 | `src/TableView.cs` | +13 / −1 | Defensive highlight reset in `PrepareContainerForItemOverride`, Tab-wraps-row in `GetNextSlot` |
 | `src/TableView.Properties.cs` | +14 / −0 | `TapToEdit` dependency property and CLR property |
 | `src/TableViewCell.cs` | +30 / −2 | Highlight in `PrepareForEdit`/`EndEditing`, TapToEdit guard in `OnTapped`, CellOrRow pointer hover |
 | `src/TableViewRow.cs` | +8 / −0 | `ApplyEditingHighlight` delegates to presenter |
 | `src/TableViewRowPresenter.cs` | +13 / −0 | `EditingHighlightOverlay` template child, `ApplyEditingHighlight` method |
 | `src/Themes/TableViewRowPresenter.xaml` | +5 / −0 | `EditingHighlightOverlay` Border after `RootPanel` |
 | `src/Themes/Resources.xaml` | +3 / −0 | `TableViewRowEditingHighlightBackground` for Light, Dark, HighContrast |
 | `samples/.../SelectionPage.xaml` | +4 / −0 | TapToEdit toggle in sample app |
 | `tests/TableViewRowEditingTests.cs` | +314 (new) | 8 architecture-first UI tests |
