### PR TITLE
chore: Update Azure Static Web App workflow configuration

### DIFF
--- a/.github/workflows/azure-static-web-app.yml
+++ b/.github/workflows/azure-static-web-app.yml
@@ -4,17 +4,12 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
 
 jobs:
   build_and_deploy_job:
     env:
       DIST_PATH: samples/WinUI.TableView.SampleApp.Uno/bin/Release/net10.0-browserwasm/publish/wwwroot
       DotnetVersion: '10.0.100'
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     container: 'unoplatform/wasm-build:3.0'
     name: Build and Deploy Job
@@ -107,17 +102,3 @@ jobs:
           api_location: "" # Api source code path - optional
           output_location: "" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_LIVELY_GROUND_0D0F6A810 }}
-          action: "close"
-
-


### PR DESCRIPTION
### PR Summary
This pull request simplifies the GitHub Actions workflow for Azure Static Web Apps by removing special handling for pull request events. The workflow will now only trigger on pushes to the `main` branch, and the job to close pull requests has been removed.

Workflow trigger simplification:

* Removed the `pull_request` trigger and its event types from the workflow, so it now only runs on pushes to `main`.

Job removal:

* Deleted the `close_pull_request_job`, which previously handled closing deployments for pull requests when they were closed.