### PR TITLE
Enable macOS and Linux build

### DIFF
--- a/samples/WinUI.TableView.SampleApp.Uno/WinUI.TableView.SampleApp.Uno.csproj
+++ b/samples/WinUI.TableView.SampleApp.Uno/WinUI.TableView.SampleApp.Uno.csproj
@@ -8,6 +8,7 @@
     </TargetFrameworks>
 
     <OutputType>Exe</OutputType>
+    <OutputType Condition="'$(TargetFramework)'=='$(NetVersion)-desktop'">WinExe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>
     <AssemblyName>WinUI.TableView.SampleApp</AssemblyName>
 

--- a/src/WinUI.TableView.csproj
+++ b/src/WinUI.TableView.csproj
@@ -5,15 +5,15 @@
       net9.0;
       net10.0;
     </TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">
-      $(TargetFrameworks);
-      net8.0-windows10.0.19041.0;
-      net9.0-windows10.0.19041.0;
-      net10.0-windows10.0.19041.0;
-    </TargetFrameworks>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable> 
     <IsAOTCompatible>true</IsAOTCompatible>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">
+      net8.0-windows10.0.19041.0;
+      net9.0-windows10.0.19041.0;
+      net10.0-windows10.0.19041.0;
+      $(TargetFrameworks);
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'windows'">

--- a/src/WinUI.TableView.csproj
+++ b/src/WinUI.TableView.csproj
@@ -1,12 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>
-      net8.0-windows10.0.19041.0;
-      net9.0-windows10.0.19041.0;
-      net10.0-windows10.0.19041.0;
       net8.0;
       net9.0;
       net10.0;
+    </TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">
+      $(TargetFrameworks);
+      net8.0-windows10.0.19041.0;
+      net9.0-windows10.0.19041.0;
+      net10.0-windows10.0.19041.0;
     </TargetFrameworks>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable> 


### PR DESCRIPTION
WinUI 3 projects can only be built on Windows (limitation of WinAppSDK), but since this project also targets Uno Platform, it makes some sense to lift the limitation for macOS and Linux users.

Here some MSBuild tricks are applied so that the core project can be compiled properly on non-Windows platforms, so that no one needs to install Windows if they want to play out or contribute to this project.