### PR TITLE
Make TableViewTemplateColumn use ClipboardContentBinding

### DIFF
--- a/src/Columns/TableViewBoundColumn.cs
+++ b/src/Columns/TableViewBoundColumn.cs
@@ -1,9 +1,5 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
-using System;
-using System.Linq.Expressions;
-using System.Reflection;
-using WinUI.TableView.Extensions;
 
 namespace WinUI.TableView;
 
@@ -13,31 +9,6 @@ namespace WinUI.TableView;
 public abstract class TableViewBoundColumn : TableViewColumn
 {
     private Binding _binding = new();
-    private Func<object, object?>? _funcCompiledPropertyPath;
-
-    /// <inheritdoc/>
-    public override object? GetCellContent(object? dataItem)
-    {
-        if (dataItem is null)
-            return null;
-
-        if (_funcCompiledPropertyPath is null && !string.IsNullOrWhiteSpace(PropertyPath))
-            _funcCompiledPropertyPath = dataItem.GetFuncCompiledPropertyPath(PropertyPath!);
-
-        if (_funcCompiledPropertyPath is not null)
-            dataItem = _funcCompiledPropertyPath(dataItem);
-
-        if (Binding?.Converter is not null)
-        {
-            dataItem = Binding.Converter.Convert(
-                dataItem,
-                typeof(object),
-                Binding.ConverterParameter,
-                Binding.ConverterLanguage);
-        }
-
-        return dataItem;
-    }
 
     /// <summary>
     /// Gets the property path for the binding.
@@ -70,13 +41,13 @@ public abstract class TableViewBoundColumn : TableViewColumn
     }
 
     /// <summary>
-    /// Gets or sets the data binding used to retrieve cell content when copying to the clipboard.
-    /// If no explicit clipboard binding is set, the column's <see cref="Binding"/> is returned as a fallback.
+    /// Gets or sets the optional data binding used to perform operations on cell content, for example sorting, filtering and exporting.
+    /// If no explicit operation binding is set, the column's <see cref="Binding"/> is returned as a fallback.
     /// </summary>
-    public override Binding? ClipboardContentBinding
+    public override Binding? OperationContentBinding
     {
-        get => base.ClipboardContentBinding ?? Binding;
-        set => base.ClipboardContentBinding = value;
+        get => base.OperationContentBinding ?? Binding;
+        set => base.OperationContentBinding = value;
     }
 
     /// <summary>

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -120,8 +120,13 @@ public abstract partial class TableViewColumn : DependencyObject
         if (dataItem is null)
             return null;
 
-        if (_funcCompiledPropertyPath is null && !string.IsNullOrWhiteSpace(ClipboardContentBindingPropertyPath))
-            _funcCompiledPropertyPath = dataItem.GetFuncCompiledPropertyPath(ClipboardContentBindingPropertyPath!);
+        if (_funcCompiledPropertyPath is null)
+        {
+            if (!string.IsNullOrWhiteSpace(ClipboardContentBindingPropertyPath))
+                _funcCompiledPropertyPath = dataItem.GetFuncCompiledPropertyPath(ClipboardContentBindingPropertyPath!);
+            else
+                return null;
+        }
 
         if (_funcCompiledPropertyPath is not null)
             dataItem = _funcCompiledPropertyPath(dataItem);

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -20,6 +20,8 @@ public abstract partial class TableViewColumn : DependencyObject
     private bool _isFiltered;
     private bool _isFrozen;
     private Func<object, object?>? _funcCompiledPropertyPath;
+    private Func<object, object?>? _funcCompiledClipboardPropertyPath;
+    private Binding? _clipboardContentBinding;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TableViewColumn"/> class with default conditional cell styles.
@@ -107,7 +109,25 @@ public abstract partial class TableViewColumn : DependencyObject
     /// <returns>The content of the cell.</returns>
     public virtual object? GetCellContent(object? dataItem)
     {
-        return default;
+        if (dataItem is null)
+            return null;
+
+        if (_funcCompiledPropertyPath is null && !string.IsNullOrWhiteSpace(OperationContentBindingPropertyPath))
+            _funcCompiledPropertyPath = dataItem.GetFuncCompiledPropertyPath(OperationContentBindingPropertyPath!);
+
+        if (_funcCompiledPropertyPath is not null)
+            dataItem = _funcCompiledPropertyPath(dataItem);
+
+        if (OperationContentBinding?.Converter is not null)
+        {
+            dataItem = OperationContentBinding.Converter.Convert(
+                dataItem,
+                typeof(object),
+                OperationContentBinding.ConverterParameter,
+                OperationContentBinding.ConverterLanguage);
+        }
+
+        return dataItem;
     }
 
     /// <summary>
@@ -120,16 +140,11 @@ public abstract partial class TableViewColumn : DependencyObject
         if (dataItem is null)
             return null;
 
-        if (_funcCompiledPropertyPath is null)
-        {
-            if (!string.IsNullOrWhiteSpace(ClipboardContentBindingPropertyPath))
-                _funcCompiledPropertyPath = dataItem.GetFuncCompiledPropertyPath(ClipboardContentBindingPropertyPath!);
-            else
-                return null;
-        }
+        if (_funcCompiledClipboardPropertyPath is null && !string.IsNullOrWhiteSpace(ClipboardContentBindingPropertyPath))
+            _funcCompiledClipboardPropertyPath = dataItem.GetFuncCompiledPropertyPath(ClipboardContentBindingPropertyPath!);
 
-        if (_funcCompiledPropertyPath is not null)
-            dataItem = _funcCompiledPropertyPath(dataItem);
+        if (_funcCompiledClipboardPropertyPath is not null)
+            dataItem = _funcCompiledClipboardPropertyPath(dataItem);
 
         if (ClipboardContentBinding?.Converter is not null)
         {
@@ -371,9 +386,24 @@ public abstract partial class TableViewColumn : DependencyObject
     }
 
     /// <summary>
-    /// Gets or sets the data binding used to retrieve cell content when copying to the clipboard.
+    /// Gets or sets the optional data binding used to perform operations on cell content, for example sorting, filtering and exporting.
     /// </summary>
-    public virtual Binding? ClipboardContentBinding { get; set; }
+    public virtual Binding? OperationContentBinding { get; set; }
+
+    /// <summary>
+    /// Gets the property path for the <see cref="OperationContentBinding"/>.
+    /// </summary>
+    internal string? OperationContentBindingPropertyPath => OperationContentBinding?.Path?.Path;
+
+    /// <summary>
+    /// Gets or sets the data binding used to retrieve cell content when copying to the clipboard.
+    /// If no explicit clipboard binding is set, the column's <see cref="OperationContentBinding"/> is returned as a fallback.
+    /// </summary>
+    public Binding? ClipboardContentBinding
+    {
+        get => _clipboardContentBinding ?? OperationContentBinding;
+        set => _clipboardContentBinding = value;
+    }
 
     /// <summary>
     /// Gets the property path for the <see cref="ClipboardContentBinding"/>.

--- a/src/Columns/TableViewTemplateColumn.cs
+++ b/src/Columns/TableViewTemplateColumn.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Data;
-using System;
-using WinUI.TableView.Extensions;
 
 namespace WinUI.TableView;
 
@@ -14,8 +11,6 @@ namespace WinUI.TableView;
 #endif
 public partial class TableViewTemplateColumn : TableViewColumn
 {
-    private Func<object, object?>? _funcCompiledPropertyPath;
-
     /// <summary>
     /// Initializes a new instance of the TableViewTemplateColumn class.
     /// </summary>
@@ -69,35 +64,6 @@ public partial class TableViewTemplateColumn : TableViewColumn
         cell.Content = GenerateElement(cell, dataItem);
     }
 
-    /// <inheritdoc/>
-    public override object? GetCellContent(object? dataItem)
-    {
-        if (dataItem is null)
-            return null;
-
-        if (_funcCompiledPropertyPath is null)
-        {
-            if (!string.IsNullOrWhiteSpace(OperationContentBindingPropertyPath))
-                _funcCompiledPropertyPath = dataItem.GetFuncCompiledPropertyPath(OperationContentBindingPropertyPath!);
-            else
-                return null;
-        }
-
-        if (_funcCompiledPropertyPath is not null)
-            dataItem = _funcCompiledPropertyPath(dataItem);
-
-        if (OperationContentBinding?.Converter is not null)
-        {
-            dataItem = OperationContentBinding.Converter.Convert(
-                dataItem,
-                typeof(object),
-                OperationContentBinding.ConverterParameter,
-                OperationContentBinding.ConverterLanguage);
-        }
-
-        return dataItem;
-    }
-
     /// <summary>
     /// Gets or sets the DataTemplate for the cell content.
     /// </summary>
@@ -132,27 +98,6 @@ public partial class TableViewTemplateColumn : TableViewColumn
     {
         get => (DataTemplateSelector?)GetValue(EditingTemplateSelectorProperty);
         set => SetValue(EditingTemplateSelectorProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets the optional data binding used to perform operations on cell content, for example sorting, filtering and exporting.
-    /// Is not used in the CellTemplate or EditingTemplate.
-    /// </summary>
-    public Binding? OperationContentBinding { get; set; }
-
-    /// <summary>
-    /// Gets the property path for the <see cref="OperationContentBinding"/>.
-    /// </summary>
-    internal string? OperationContentBindingPropertyPath => OperationContentBinding?.Path?.Path;
-
-    /// <summary>
-    /// Gets or sets the data binding used to retrieve cell content when copying to the clipboard.
-    /// If no explicit clipboard binding is set, the column's <see cref="OperationContentBinding"/> is returned as a fallback.
-    /// </summary>
-    public override Binding? ClipboardContentBinding
-    {
-        get => base.ClipboardContentBinding ?? OperationContentBinding;
-        set => base.ClipboardContentBinding = value;
     }
 
     /// <summary>

--- a/src/Columns/TableViewTemplateColumn.cs
+++ b/src/Columns/TableViewTemplateColumn.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using System;
+using WinUI.TableView.Extensions;
 
 namespace WinUI.TableView;
 
@@ -11,6 +14,8 @@ namespace WinUI.TableView;
 #endif
 public partial class TableViewTemplateColumn : TableViewColumn
 {
+    private Func<object, object?>? _funcCompiledPropertyPath;
+
     /// <summary>
     /// Initializes a new instance of the TableViewTemplateColumn class.
     /// </summary>
@@ -67,7 +72,30 @@ public partial class TableViewTemplateColumn : TableViewColumn
     /// <inheritdoc/>
     public override object? GetCellContent(object? dataItem)
     {
-        return GetClipboardContent(dataItem);
+        if (dataItem is null)
+            return null;
+
+        if (_funcCompiledPropertyPath is null)
+        {
+            if (!string.IsNullOrWhiteSpace(OperationContentBindingPropertyPath))
+                _funcCompiledPropertyPath = dataItem.GetFuncCompiledPropertyPath(OperationContentBindingPropertyPath!);
+            else
+                return null;
+        }
+
+        if (_funcCompiledPropertyPath is not null)
+            dataItem = _funcCompiledPropertyPath(dataItem);
+
+        if (OperationContentBinding?.Converter is not null)
+        {
+            dataItem = OperationContentBinding.Converter.Convert(
+                dataItem,
+                typeof(object),
+                OperationContentBinding.ConverterParameter,
+                OperationContentBinding.ConverterLanguage);
+        }
+
+        return dataItem;
     }
 
     /// <summary>
@@ -104,6 +132,27 @@ public partial class TableViewTemplateColumn : TableViewColumn
     {
         get => (DataTemplateSelector?)GetValue(EditingTemplateSelectorProperty);
         set => SetValue(EditingTemplateSelectorProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the optional data binding used to perform operations on cell content, for example sorting, filtering and exporting.
+    /// Is not used in the CellTemplate or EditingTemplate.
+    /// </summary>
+    public Binding? OperationContentBinding { get; set; }
+
+    /// <summary>
+    /// Gets the property path for the <see cref="OperationContentBinding"/>.
+    /// </summary>
+    internal string? OperationContentBindingPropertyPath => OperationContentBinding?.Path?.Path;
+
+    /// <summary>
+    /// Gets or sets the data binding used to retrieve cell content when copying to the clipboard.
+    /// If no explicit clipboard binding is set, the column's <see cref="OperationContentBinding"/> is returned as a fallback.
+    /// </summary>
+    public override Binding? ClipboardContentBinding
+    {
+        get => base.ClipboardContentBinding ?? OperationContentBinding;
+        set => base.ClipboardContentBinding = value;
     }
 
     /// <summary>

--- a/src/Columns/TableViewTemplateColumn.cs
+++ b/src/Columns/TableViewTemplateColumn.cs
@@ -64,6 +64,12 @@ public partial class TableViewTemplateColumn : TableViewColumn
         cell.Content = GenerateElement(cell, dataItem);
     }
 
+    /// <inheritdoc/>
+    public override object? GetCellContent(object? dataItem)
+    {
+        return GetClipboardContent(dataItem);
+    }
+
     /// <summary>
     /// Gets or sets the DataTemplate for the cell content.
     /// </summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -283,7 +283,7 @@ public partial class TableView : ListView
         _scrollViewer = GetTemplateChild("ScrollViewer") as ScrollViewer;
         _headerRowDefinition = GetTemplateChild("HeaderRowDefinition") as RowDefinition;
         if (_scrollViewer is not null) _scrollViewer.Loaded += OnScrollViewerLoaded;
-        
+
         if (IsLoaded)
         {
             while (ItemsPanelRoot is null) await Task.Yield();
@@ -320,12 +320,12 @@ public partial class TableView : ListView
             Source = this
         });
     }
-    
+
     /// <summary>
     /// Handles the Loaded event of the TableView control.
     /// </summary>
     private void OnLoaded(object sender, RoutedEventArgs e)
-    {        
+    {
         EnsureAutoColumns();
     }
 
@@ -536,7 +536,7 @@ public partial class TableView : ListView
 
             for (var col = minColumn; col <= maxColumn; col++)
             {
-                if (Columns.VisibleColumns[col] is not TableViewBoundColumn column ||
+                if (Columns.VisibleColumns[col] is not TableViewColumn column ||
                    !slots.Contains(new TableViewCellSlot(row, col)))
                 {
                     stringBuilder.Append(separator);


### PR DESCRIPTION
This is a fix for #347

TableViewTemplateColumn now gets to use the ClipboardContentBinding.
If this property is not set, the result is as previous, the clipboard and export is empty for these columns. (If it weren't for the new "return null" in TableViewColumn.GetClipboardContent, the cell would return the datacontext type name)

I also fixed the same issue when exporting. Since there's no Binding property on template columns, I figured that a reasonable behavior would be to use the ClipboardContentBinding during export as well.