### PR TITLE
End editing on PointerPress

### DIFF
--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -133,7 +133,7 @@ public partial class TableView : ListView
     }
 
     /// <inheritdoc/>
-    protected override async void OnKeyDown(KeyRoutedEventArgs e)
+    protected override void OnKeyDown(KeyRoutedEventArgs e)
     {
         var shiftKey = KeyboardHelper.IsShiftKeyDown();
         var ctrlKey = KeyboardHelper.IsCtrlKeyDown();
@@ -144,19 +144,19 @@ public partial class TableView : ListView
             return;
         }
 
-        await HandleNavigations(e, shiftKey, ctrlKey);
+        HandleNavigations(e, shiftKey, ctrlKey);
     }
 
     /// <summary>
     /// Handles navigation keys.
     /// </summary>
-    private async Task HandleNavigations(KeyRoutedEventArgs e, bool shiftKey, bool ctrlKey)
+    private void HandleNavigations(KeyRoutedEventArgs e, bool shiftKey, bool ctrlKey)
     {
         var currentCell = CurrentCellSlot.HasValue ? GetCellFromSlot(CurrentCellSlot.Value) : default;
 
         if (e.Key is VirtualKey.F2 && currentCell is { IsReadOnly: false } && !IsEditing)
         {
-            e.Handled = await currentCell.BeginCellEditing(e);
+            e.Handled = currentCell.BeginCellEditing(e);
         }
         else if (e.Key is VirtualKey.Escape && currentCell is not null && IsEditing)
         {
@@ -192,7 +192,7 @@ public partial class TableView : ListView
             {
                 if (!EndCellEditing(TableViewEditAction.Commit, currentCell)) return;
 
-                if (CurrentCellSlot == newSlot || GetCellFromSlot(newSlot) is not { } nextCell || !await nextCell.BeginCellEditing(e))
+                if (CurrentCellSlot == newSlot || GetCellFromSlot(newSlot) is not { } nextCell || !nextCell.BeginCellEditing(e))
                 {
                     SetIsEditing(false);
                 }
@@ -283,7 +283,7 @@ public partial class TableView : ListView
         _scrollViewer = GetTemplateChild("ScrollViewer") as ScrollViewer;
         _headerRowDefinition = GetTemplateChild("HeaderRowDefinition") as RowDefinition;
         if (_scrollViewer is not null) _scrollViewer.Loaded += OnScrollViewerLoaded;
-        
+
         if (IsLoaded)
         {
             while (ItemsPanelRoot is null) await Task.Yield();
@@ -320,12 +320,12 @@ public partial class TableView : ListView
             Source = this
         });
     }
-    
+
     /// <summary>
     /// Handles the Loaded event of the TableView control.
     /// </summary>
     private void OnLoaded(object sender, RoutedEventArgs e)
-    {        
+    {
         EnsureAutoColumns();
     }
 

--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -287,7 +287,9 @@ public partial class TableViewCell : ContentControl
              TableView.CurrentCellSlot.HasValue &&
              TableView.GetCellFromSlot(TableView.CurrentCellSlot.Value) is { } currentCell)
         {
-            return !TableView.EndCellEditing(TableViewEditAction.Commit, currentCell);
+            if (!TableView.EndCellEditing(TableViewEditAction.Commit, currentCell)) return true;
+
+            TableView.SetIsEditing(false);
         }
 
         return false;

--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -214,7 +214,7 @@ public partial class TableViewCell : ContentControl
     {
         base.OnTapped(e);
 
-        if (TryEndCurrentCellEdit())
+        if (!TryEndCurrentCellEdit())
         {
             e.Handled = true;
             return;
@@ -232,7 +232,7 @@ public partial class TableViewCell : ContentControl
     {
         base.OnPointerPressed(e);
 
-        if (TryEndCurrentCellEdit())
+        if (!TryEndCurrentCellEdit())
         {
             e.Handled = true;
             return;
@@ -280,6 +280,11 @@ public partial class TableViewCell : ContentControl
         }
     }
 
+    /// <summary>
+    /// Tries to end the current edit operation, if any.
+    /// </summary>
+    /// <returns>True if an edit operation was successfully ended, or there is no edit operation.
+    /// False if the current edit operation can not be ended.</returns>
     private bool TryEndCurrentCellEdit()
     {
         if ((TableView?.IsEditing ?? false) &&
@@ -287,12 +292,12 @@ public partial class TableViewCell : ContentControl
              TableView.CurrentCellSlot.HasValue &&
              TableView.GetCellFromSlot(TableView.CurrentCellSlot.Value) is { } currentCell)
         {
-            if (!TableView.EndCellEditing(TableViewEditAction.Commit, currentCell)) return true;
+            if (!TableView.EndCellEditing(TableViewEditAction.Commit, currentCell)) return false;
 
             TableView.SetIsEditing(false);
         }
 
-        return false;
+        return true;
     }
 
     /// <summary>

--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -210,18 +210,14 @@ public partial class TableViewCell : ContentControl
     }
 
     /// <inheritdoc/>
-    protected override async void OnTapped(TappedRoutedEventArgs e)
+    protected override void OnTapped(TappedRoutedEventArgs e)
     {
         base.OnTapped(e);
 
-        if ((TableView?.IsEditing ?? false) &&
-             TableView.CurrentCellSlot != Slot &&
-             TableView.CurrentCellSlot.HasValue &&
-             TableView.GetCellFromSlot(TableView.CurrentCellSlot.Value) is { } currentCell)
+        if (TryEndCurrentCellEdit())
         {
-            e.Handled = !TableView.EndCellEditing(TableViewEditAction.Commit, currentCell);
-
-            if (e.Handled) return;
+            e.Handled = true;
+            return;
         }
 
         if (TableView?.CurrentCellSlot != Slot || TableView?.LastSelectionUnit is TableViewSelectionUnit.Row)
@@ -236,9 +232,15 @@ public partial class TableViewCell : ContentControl
     {
         base.OnPointerPressed(e);
 
+        if (TryEndCurrentCellEdit())
+        {
+            e.Handled = true;
+            return;
+        }
+
         if (!KeyboardHelper.IsShiftKeyDown() && TableView is not null)
         {
-            TableView.SelectionStartCellSlot = TableView.SelectionUnit is not TableViewSelectionUnit.Row || !IsReadOnly ? Slot : default; ;
+            TableView.SelectionStartCellSlot = TableView.SelectionUnit is not TableViewSelectionUnit.Row || !IsReadOnly ? Slot : default;
             TableView.SelectionStartRowIndex = Index;
             CapturePointer(e.Pointer);
         }
@@ -278,6 +280,19 @@ public partial class TableViewCell : ContentControl
         }
     }
 
+    private bool TryEndCurrentCellEdit()
+    {
+        if ((TableView?.IsEditing ?? false) &&
+             TableView.CurrentCellSlot != Slot &&
+             TableView.CurrentCellSlot.HasValue &&
+             TableView.GetCellFromSlot(TableView.CurrentCellSlot.Value) is { } currentCell)
+        {
+            return !TableView.EndCellEditing(TableViewEditAction.Commit, currentCell);
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Gets the height of the horizontal gridlines/>.
     /// </summary>
@@ -309,7 +324,7 @@ public partial class TableViewCell : ContentControl
     }
 
     /// <inheritdoc/>
-    protected override async void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
+    protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
     {
         var eventArgs = new TableViewCellDoubleTappedEventArgs(Slot, this, Row?.Content);
         TableView?.OnCellDoubleTapped(eventArgs);
@@ -321,7 +336,7 @@ public partial class TableViewCell : ContentControl
 
         if (!IsReadOnly && TableView is not null && !TableView.IsEditing && !Column?.UseSingleElement is true)
         {
-            e.Handled = await BeginCellEditing(e);
+            e.Handled = BeginCellEditing(e);
         }
         else
         {
@@ -370,7 +385,7 @@ public partial class TableViewCell : ContentControl
     /// <param name="editingArgs">The event data associated with the editing request. Cannot be null.</param>
     /// <returns>A task that represents the asynchronous operation. The task result is <see langword="true"/> if cell editing was
     /// successfully started; otherwise, <see langword="false"/> if the operation was canceled.</returns>
-    internal async Task<bool> BeginCellEditing(RoutedEventArgs editingArgs)
+    internal bool BeginCellEditing(RoutedEventArgs editingArgs)
     {
         var args = new TableViewBeginningEditEventArgs(this, Row?.Content, Column!, editingArgs);
         TableView?.OnBeginningEdit(args);


### PR DESCRIPTION
This is a fix for #350 

The current cell edit must be ended already in OnPointerPressed.
I'm not 100% sure if it also must be done in OnTapped, but I guess that when using touch, you don't get any Pointer events, but still Tap/DoubleTap so I extracted a method that could be called both from OnPointerPressed and OnTapped.

I also removed some redundant async method signatures.