### PR TITLE
feat: Support inline cell templates in template columns

### DIFF
--- a/src/Columns/TableViewTemplateColumn.cs
+++ b/src/Columns/TableViewTemplateColumn.cs
@@ -9,6 +9,7 @@ namespace WinUI.TableView;
 #if WINDOWS
 [WinRT.GeneratedBindableCustomProperty]
 #endif
+[ContentProperty(Name = nameof(CellTemplate))]
 public partial class TableViewTemplateColumn : TableViewColumn
 {
     /// <summary>

--- a/src/Columns/TableViewTemplateColumn.cs
+++ b/src/Columns/TableViewTemplateColumn.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
 
 namespace WinUI.TableView;
 


### PR DESCRIPTION
### PR Summary
Implemented support for defining TableViewTemplateColumn cell templates directly as the content. 

### Example
- Before:
``` xaml
<tv:TableViewTemplateColumn Header="ID">
    <tv:TableViewTemplateColumn.CellTemplate>
        <DataTemplate x:DataType="local:ExampleModel">
            <TextBlock Text="{Binding Id}" />
        </DataTemplate>
    </tv:TableViewTemplateColumn.CellTemplate>
</tv:TableViewTemplateColumn>
```
- After: 
``` xaml
<tv:TableViewTemplateColumn Header="ID">
    <DataTemplate x:DataType="local:ExampleModel">
        <TextBlock Text="{Binding Id}" />
    </DataTemplate>
</tv:TableViewTemplateColumn>
```