### PR TITLE
fix: Ensure cell measures on element set

### DIFF
--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -490,6 +490,8 @@ public partial class TableViewCell : ContentControl
             Focus(FocusState.Pointer);
         });
 #endif
+
+        DispatcherQueue.TryEnqueue(InvalidateMeasure);
     }
 
     /// <summary>


### PR DESCRIPTION
### Summary
This PR introduce changes to ensure the cell measure is invalidated after setting the element. This helps fix an auto-sizing issue that occurred when only a few items in view. 

https://github.com/w-ahmad/WinUI.TableView/discussions/367#discussioncomment-16999786