### PR TITLE
Add option to select row or cell on context request

### DIFF
--- a/samples/WinUI.TableView.SampleApp/Pages/ContextFlyoutsPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/ContextFlyoutsPage.xaml
@@ -25,6 +25,7 @@
                               ItemsSource="{Binding Items}"
                               CellContextFlyoutOpening="OnCellContextFlyoutOpening"
                               RowContextFlyoutOpening="OnRowContextFlyoutOpening"
+                              ForceRowOrCellSelectionOnContextRequested="True"
                               AutoGeneratingColumn="{x:Bind local:ExampleModelColumnsHelper.OnAutoGeneratingColumns}">
                     <tv:TableView.RowContextFlyout>
                         <MenuFlyout>

--- a/samples/WinUI.TableView.SampleApp/Pages/ContextFlyoutsPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/ContextFlyoutsPage.xaml
@@ -80,7 +80,7 @@
                 <StackPanel MaxWidth="250" Spacing="16">
                     <ToggleSwitch
                      x:Name="ForceRowOrCellSelectionToggleSwitch"
-                     Header="Force Row or Cell to be selected on CellContextFlyoutOpening"
+                     Header="Force Row or Cell to be selected on ContextFlyoutOpening"
                      IsOn="True"
                      OffContent="False"
                      OnContent="True" />

--- a/samples/WinUI.TableView.SampleApp/Pages/ContextFlyoutsPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/ContextFlyoutsPage.xaml
@@ -25,7 +25,7 @@
                               ItemsSource="{Binding Items}"
                               CellContextFlyoutOpening="OnCellContextFlyoutOpening"
                               RowContextFlyoutOpening="OnRowContextFlyoutOpening"
-                              ForceRowOrCellSelectionOnContextRequested="True"
+                              ForceRowOrCellSelectionOnContextRequested="{x:Bind ForceRowOrCellSelectionToggleSwitch.IsOn, Mode=OneWay}"
                               AutoGeneratingColumn="{x:Bind local:ExampleModelColumnsHelper.OnAutoGeneratingColumns}">
                     <tv:TableView.RowContextFlyout>
                         <MenuFlyout>
@@ -76,12 +76,26 @@
                     </tv:TableView.CellContextFlyout>
                 </tv:TableView>
             </controls:SamplePresenter.Example>
+            <controls:SamplePresenter.Options>
+                <StackPanel MaxWidth="250" Spacing="16">
+                    <ToggleSwitch
+                     x:Name="ForceRowOrCellSelectionToggleSwitch"
+                     Header="Force Row or Cell to be selected on CellContextFlyoutOpening"
+                     IsOn="True"
+                     OffContent="False"
+                     OnContent="True" />
+                </StackPanel>
+            </controls:SamplePresenter.Options>
             <controls:SamplePresenter.Xaml>
                 <x:String xml:space="preserve">
 &lt;tv:TableView x:Name="tableView"
-    ItemsSource="{Binding Items}" /&gt;
+    ItemsSource="{Binding Items}"
+    ForceRowOrCellSelectionOnContextRequested="$(ForceRowOrCellSelect)" /&gt;
                 </x:String>
             </controls:SamplePresenter.Xaml>
+            <controls:SamplePresenter.Substitutions>
+                <controls:CodeSubstitution Key="ForceRowOrCellSelect" Value="{x:Bind tableView.ForceRowOrCellSelectionOnContextRequested, Mode=OneWay}" />
+            </controls:SamplePresenter.Substitutions>
         </controls:SamplePresenter>
     </Grid>
 </Page>

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -266,6 +266,12 @@ public partial class TableView
     /// </summary>
     public static readonly DependencyProperty ShowFilterItemsCountProperty = DependencyProperty.Register(nameof(ShowFilterItemsCount), typeof(bool), typeof(TableView), new PropertyMetadata(false));
 
+
+    /// <summary>
+    /// Identifies the <see cref="ForceRowOrCellSelectionOnContextRequested"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty ForceRowOrCellSelectionOnContextRequestedProperty = DependencyProperty.Register(nameof(ForceRowOrCellSelectionOnContextRequested), typeof(bool), typeof(TableView), new PropertyMetadata(false));
+
     /// <summary>
     /// Gets or sets a value indicating whether opening the column filter over header right-click is enabled.
     /// </summary>
@@ -329,6 +335,15 @@ public partial class TableView
     {
         get => (bool)GetValue(ShowFilterItemsCountProperty);
         set => SetValue(ShowFilterItemsCountProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value that indicates whether the TableView should force select the Row or Cell depending on the SelectionUnit
+    /// </summary>
+    public bool ForceRowOrCellSelectionOnContextRequested
+    {
+        get => (bool)GetValue(ForceRowOrCellSelectionOnContextRequestedProperty);
+        set => SetValue(ForceRowOrCellSelectionOnContextRequestedProperty, value);
     }
 
     /// <summary>

--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -65,6 +65,13 @@ public partial class TableViewCell : ContentControl
     {
         if (!e.TryGetPosition(sender, out var position)) return;
 #endif
+
+        // Select the row before showing the Context Menu
+        if (TableView is not null && !IsSelected)
+        {
+            TableView.MakeSelection(Slot, false);
+        }
+
         e.Handled = TableView?.ShowCellContext(this, position) is true;
     }
 

--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -66,7 +66,7 @@ public partial class TableViewCell : ContentControl
         if (!e.TryGetPosition(sender, out var position)) return;
 #endif
 
-        // Select the row before showing the Context Menu
+        // Select the cell before showing the Context Menu
         if (TableView is not null && TableView.ForceRowOrCellSelectionOnContextRequested && !IsSelected)
         {
             TableView.MakeSelection(Slot, false);

--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -67,7 +67,7 @@ public partial class TableViewCell : ContentControl
 #endif
 
         // Select the row before showing the Context Menu
-        if (TableView is not null && !IsSelected)
+        if (TableView is not null && TableView.ForceRowOrCellSelectionOnContextRequested && !IsSelected)
         {
             TableView.MakeSelection(Slot, false);
         }

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -76,7 +76,7 @@ public partial class TableViewRow : ListViewItem
         // Select the row before showing the Context Menu
         if (TableView is not null && TableView.ForceRowOrCellSelectionOnContextRequested && !IsSelected)
         {
-            TableView.MakeSelection(new TableViewCellSlot(Index, 0), false);
+            TableView.MakeSelection(new TableViewCellSlot(Index, -1), false);
         }
 
         e.Handled = TableView?.ShowRowContext(this, position) is true;

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -72,6 +72,13 @@ public partial class TableViewRow : ListViewItem
     {
         if (!e.TryGetPosition(sender, out var position)) return;
 #endif
+
+        // Select the row before showing the Context Menu
+        if (TableView is not null && !IsSelected)
+        {
+            TableView.MakeSelection(new TableViewCellSlot(Index, 0), false);
+        }
+
         e.Handled = TableView?.ShowRowContext(this, position) is true;
     }
 

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -74,7 +74,7 @@ public partial class TableViewRow : ListViewItem
 #endif
 
         // Select the row before showing the Context Menu
-        if (TableView is not null && !IsSelected)
+        if (TableView is not null && TableView.ForceRowOrCellSelectionOnContextRequested && !IsSelected)
         {
             TableView.MakeSelection(new TableViewCellSlot(Index, 0), false);
         }


### PR DESCRIPTION
This fixes or solves #293 

Add a new property called `ForceRowOrCellSelectionOnContextRequested` that is a boolean to force select the row or cell if enabled


## Demo
https://github.com/user-attachments/assets/93848e67-fd94-4cce-8538-fad3752f221c

# Demo side example pane:
<img width="1093" height="823" alt="image" src="https://github.com/user-attachments/assets/e77d67fa-1d77-454b-a71a-1296572dcdf6" />
<img width="1083" height="791" alt="image" src="https://github.com/user-attachments/assets/299b33cb-dc40-4267-9194-16230bdec3e5" />


