### PR TITLE
chore: Use C# 14 in library

### DIFF
--- a/src/ColumnFilterHandler.cs
+++ b/src/ColumnFilterHandler.cs
@@ -144,10 +144,7 @@ public class ColumnFilterHandler : IColumnFilterHandler
 
             foreach (var col in _tableView.Columns)
             {
-                if (col is not null)
-                {
-                    col.IsFiltered = false;
-                }
+                col?.IsFiltered = false;
             }
         }
     }

--- a/src/Columns/TableViewBoundColumn.cs
+++ b/src/Columns/TableViewBoundColumn.cs
@@ -8,8 +8,6 @@ namespace WinUI.TableView;
 /// </summary>
 public abstract class TableViewBoundColumn : TableViewColumn
 {
-   // private Binding _binding;//= new();
-
     /// <summary>
     /// Gets the property path for the binding.
     /// </summary>

--- a/src/Columns/TableViewBoundColumn.cs
+++ b/src/Columns/TableViewBoundColumn.cs
@@ -8,7 +8,7 @@ namespace WinUI.TableView;
 /// </summary>
 public abstract class TableViewBoundColumn : TableViewColumn
 {
-    private Binding _binding = new();
+   // private Binding _binding;//= new();
 
     /// <summary>
     /// Gets the property path for the binding.
@@ -20,10 +20,10 @@ public abstract class TableViewBoundColumn : TableViewColumn
     /// </summary>
     public virtual Binding Binding
     {
-        get => _binding;
+        get;
         set
         {
-            if (_binding != value)
+            if (field != value)
             {
                 if (value is not null)
                 {
@@ -35,10 +35,10 @@ public abstract class TableViewBoundColumn : TableViewColumn
                     }
                 }
 
-                _binding = value!;
+                field = value!;
             }
         }
-    }
+    } = new();
 
     /// <summary>
     /// Gets or sets the optional data binding used to perform operations on cell content, for example sorting, filtering and exporting.

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -14,14 +14,8 @@ namespace WinUI.TableView;
 [StyleTypedProperty(Property = nameof(CellStyle), StyleTargetType = typeof(TableViewCell))]
 public abstract partial class TableViewColumn : DependencyObject
 {
-    private TableViewColumnHeader? _headerControl;
-    private double _desiredWidth;
-    private SD? _sortDirection;
-    private bool _isFiltered;
-    private bool _isFrozen;
     private Func<object, object?>? _funcCompiledPropertyPath;
     private Func<object, object?>? _funcCompiledClipboardPropertyPath;
-    private Binding? _clipboardContentBinding;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TableViewColumn"/> class with default conditional cell styles.
@@ -244,11 +238,14 @@ public abstract partial class TableViewColumn : DependencyObject
     /// </summary>
     public TableViewColumnHeader? HeaderControl
     {
-        get => _headerControl;
+        get;
         internal set
         {
-            _headerControl = value;
-            EnsureHeaderStyle();
+            if (field != value)
+            {
+                field = value;
+                EnsureHeaderStyle();
+            }
         }
     }
 
@@ -322,12 +319,12 @@ public abstract partial class TableViewColumn : DependencyObject
     /// </summary>
     internal double DesiredWidth
     {
-        get => _desiredWidth;
+        get;
         set
         {
-            if (_desiredWidth != value)
+            if (field != value)
             {
-                _desiredWidth = value;
+                field = value;
                 OwningCollection?.HandleColumnPropertyChanged(this, nameof(DesiredWidth));
             }
         }
@@ -348,11 +345,14 @@ public abstract partial class TableViewColumn : DependencyObject
     /// </summary>
     public SD? SortDirection
     {
-        get => _sortDirection;
+        get;
         set
         {
-            _sortDirection = value;
-            OnSortDirectionChanged();
+            if (field != value)
+            {
+                field = value;
+                OnSortDirectionChanged();
+            }
         }
     }
 
@@ -361,11 +361,14 @@ public abstract partial class TableViewColumn : DependencyObject
     /// </summary>
     public bool IsFiltered
     {
-        get => _isFiltered;
+        get;
         set
         {
-            _isFiltered = value;
-            OnIsFilteredChanged();
+            if (field != value)
+            {
+                field = value;
+                OnIsFilteredChanged();
+            }
         }
     }
 
@@ -374,12 +377,12 @@ public abstract partial class TableViewColumn : DependencyObject
     /// </summary>
     public bool IsFrozen
     {
-        get => _isFrozen;
+        get;
         internal set
         {
-            if (_isFrozen != value)
+            if (field != value)
             {
-                _isFrozen = value;
+                field = value;
                 OwningCollection?.HandleColumnPropertyChanged(this, nameof(IsFrozen));
             }
         }
@@ -401,8 +404,8 @@ public abstract partial class TableViewColumn : DependencyObject
     /// </summary>
     public Binding? ClipboardContentBinding
     {
-        get => _clipboardContentBinding ?? OperationContentBinding;
-        set => _clipboardContentBinding = value;
+        get => field ?? OperationContentBinding;
+        set;
     }
 
     /// <summary>
@@ -436,10 +439,7 @@ public abstract partial class TableViewColumn : DependencyObject
     /// </summary>
     internal void EnsureHeaderStyle()
     {
-        if (_headerControl is not null)
-        {
-            _headerControl.Style = HeaderStyle ?? TableView?.ColumnHeaderStyle;
-        }
+        HeaderControl?.Style = HeaderStyle ?? TableView?.ColumnHeaderStyle;
     }
 
     /// <summary>

--- a/src/Columns/TableViewComboBoxColumn.cs
+++ b/src/Columns/TableViewComboBoxColumn.cs
@@ -15,9 +15,6 @@ namespace WinUI.TableView;
 #endif
 public partial class TableViewComboBoxColumn : TableViewBoundColumn
 {
-    private Binding? _textBinding;
-    private Binding? _selectedValueBinding;
-
     /// <summary>
     /// Generates a TextBlock element for the cell.
     /// </summary>
@@ -135,32 +132,26 @@ public partial class TableViewComboBoxColumn : TableViewBoundColumn
     /// <summary>
     /// Gets or sets the binding for the text property of the ComboBox.
     /// </summary>
-    public virtual Binding TextBinding
+    public virtual Binding? TextBinding
     {
-        get => _textBinding!;
+        get;
         set
         {
-            _textBinding = value;
-            if (_textBinding is not null)
-            {
-                _textBinding.Mode = BindingMode.TwoWay;
-            }
+            field = value;
+            field?.Mode = BindingMode.TwoWay;
         }
     }
 
     /// <summary>
     /// Gets or sets the binding for the selected value property of the ComboBox.
     /// </summary>
-    public virtual Binding SelectedValueBinding
+    public virtual Binding? SelectedValueBinding
     {
-        get => _selectedValueBinding!;
+        get;
         set
         {
-            _selectedValueBinding = value;
-            if (_selectedValueBinding is not null)
-            {
-                _selectedValueBinding.Mode = BindingMode.TwoWay;
-            }
+            field = value;
+            field?.Mode = BindingMode.TwoWay;
         }
     }
 

--- a/src/Controls/TableViewFilterItemsControl.xaml.cs
+++ b/src/Controls/TableViewFilterItemsControl.xaml.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Windows.System;
 

--- a/src/Controls/TableViewFilterItemsControl.xaml.cs
+++ b/src/Controls/TableViewFilterItemsControl.xaml.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.System;
 
@@ -16,7 +17,6 @@ namespace WinUI.TableView.Controls;
 public partial class TableViewFilterItemsControl : UserControl
 {
     private bool _canSetState = true;
-    private ICollection<TableViewFilterItem>? _filterItems;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TableViewFilterItemsControl"/> class.
@@ -93,8 +93,8 @@ public partial class TableViewFilterItemsControl : UserControl
         }
 
 
-        selectAllCheckBox.IsChecked = _filterItems?.All(x => x.IsSelected) ?? false ? true
-                                      : _filterItems?.All(x => !x.IsSelected) ?? false ? false
+        selectAllCheckBox.IsChecked = FilterItems?.All(x => x.IsSelected) ?? false ? true
+                                      : FilterItems?.All(x => !x.IsSelected) ?? false ? false
                                       : null;
     }
 
@@ -119,9 +119,9 @@ public partial class TableViewFilterItemsControl : UserControl
     /// </summary>
     private void AttachPropertyChangedHandlers()
     {
-        if (_filterItems?.Count > 0)
+        if (FilterItems?.Count > 0)
         {
-            foreach (var item in _filterItems)
+            foreach (var item in FilterItems)
             {
                 item.PropertyChanged += OnFilterItemPropertyChanged;
             }
@@ -133,9 +133,9 @@ public partial class TableViewFilterItemsControl : UserControl
     /// </summary>
     private void DetachPropertyChangedHandlers()
     {
-        if (_filterItems?.Count > 0)
+        if (FilterItems?.Count > 0)
         {
-            foreach (var item in _filterItems)
+            foreach (var item in FilterItems)
             {
                 item.PropertyChanged -= OnFilterItemPropertyChanged;
             }
@@ -160,14 +160,14 @@ public partial class TableViewFilterItemsControl : UserControl
     /// </summary>
     internal ICollection<TableViewFilterItem>? FilterItems
     {
-        get => _filterItems;
+        get;
         set
         {
-            if (_filterItems == value) return;
+            if (field == value) return;
 
             DetachPropertyChangedHandlers();
-            _filterItems = value;
-            filterItemsList.ItemsSource = _filterItems;
+            field = value;
+            filterItemsList.ItemsSource = field;
             AttachPropertyChangedHandlers();
             SetSelectAllCheckBoxState();
         }

--- a/src/ItemsSource/CollectionView.Properties.cs
+++ b/src/ItemsSource/CollectionView.Properties.cs
@@ -13,25 +13,25 @@ partial class CollectionView
     /// </summary>
     public IEnumerable Source
     {
-        get => _source;
+        get;
         set
         {
-            if (_source == value) return;
+            if (field == value) return;
 
-            DetachCollectionChangedHandlers(_source);
-            DetachPropertyChangedHandlers(_source);
+            DetachCollectionChangedHandlers(field);
+            DetachPropertyChangedHandlers(field);
 
-            _source = value;
+            field = value;
 
-            AttachCollectionChangedHandlers(_source);
-            AttachPropertyChangedHandlers(_source);
+            AttachCollectionChangedHandlers(field);
+            AttachPropertyChangedHandlers(field);
 
-            CreateItemsCopy(_source);
+            CreateItemsCopy(field);
 
             HandleSourceChanged();
             OnPropertyChanged();
         }
-    }
+    } = new List<object>();
 
     /// <summary>
     /// Gets a value indicating whether this CollectionView can filter its items.
@@ -81,7 +81,7 @@ partial class CollectionView
     /// <summary>
     /// Gets a value indicating whether there are more items to load.
     /// </summary>
-    public bool HasMoreItems => (_source as ISupportIncrementalLoading)?.HasMoreItems ?? false;
+    public bool HasMoreItems => (Source as ISupportIncrementalLoading)?.HasMoreItems ?? false;
 
     /// <summary>
     /// Gets a value indicating whether the current item is after the last item in the view.
@@ -101,23 +101,23 @@ partial class CollectionView
     /// <summary>
     /// Gets a value indicating whether the collection is read-only.
     /// </summary>
-    public bool IsReadOnly => _source == null || _source.IsReadOnly();
+    public bool IsReadOnly => Source == null || Source.IsReadOnly();
 
     /// <summary>
     /// Gets or sets a value indicating whether live shaping is enabled.
     /// </summary>
     public bool AllowLiveShaping
     {
-        get => _allowLiveShaping;
+        get;
         set
         {
-            if (_allowLiveShaping == value) return;
+            if (field == value) return;
 
-            _allowLiveShaping = value;
-            if (_allowLiveShaping)
-                AttachPropertyChangedHandlers(_source);
+            field = value;
+            if (field)
+                AttachPropertyChangedHandlers(Source);
             else
-                DetachPropertyChangedHandlers(_source);
+                DetachPropertyChangedHandlers(Source);
         }
     }
 }

--- a/src/ItemsSource/CollectionView.cs
+++ b/src/ItemsSource/CollectionView.cs
@@ -17,9 +17,7 @@ namespace WinUI.TableView;
 /// </summary>
 internal partial class CollectionView : ICollectionView, ISupportIncrementalLoading, INotifyPropertyChanged, IComparer<object?>
 {
-    private IEnumerable _source = new List<object>();
     private object[] _itemsCopy = []; // In case the source is ICollection, keep a copy of the items to keep track of removed items.
-    private bool _allowLiveShaping;
     private readonly List<object?> _view = [];
     private readonly ObservableCollection<FilterDescription> _filterDescriptions = [];
     private readonly ObservableCollection<SortDescription> _sortDescriptions = [];
@@ -171,12 +169,12 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
                 }
 
                 DetachPropertyChangedHandlers(_itemsCopy);
-                AttachPropertyChangedHandlers(_source);
+                AttachPropertyChangedHandlers(Source);
 
                 break;
         }
 
-        CreateItemsCopy(_source);
+        CreateItemsCopy(Source);
     }
 
     /// <summary>
@@ -237,7 +235,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
                 }
 
                 DetachPropertyChangedHandlers(e.OldItems);
-                AttachPropertyChangedHandlers(_source);
+                AttachPropertyChangedHandlers(Source);
 
                 break;
         }
@@ -266,7 +264,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
             }
             else if (viewIndex == -1 && filterResult)
             {
-                var index = _source.IndexOf(item);
+                var index = Source.IndexOf(item);
                 HandleItemAdded(index, item);
             }
         }
@@ -328,7 +326,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
             }
             else
             {
-                _view.AddRange(_source.OfType<object>());
+                _view.AddRange(Source.OfType<object>());
             }
 
             if (SortDescriptions.Count > 0)
@@ -362,7 +360,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
         var viewHash = new HashSet<object?>(_view);
         var viewIndex = 0;
         var i = 0;
-        foreach (var item in _source)
+        foreach (var item in Source)
         {
             if (viewHash.Contains(item))
             {
@@ -418,7 +416,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
         }
         else if (FilterDescriptions.Any())
         {
-            if (_source == null)
+            if (Source == null)
             {
                 HandleSourceChanged();
                 return false;
@@ -506,7 +504,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     {
         if (IsReadOnly) throw new NotSupportedException("Collection is read-only.");
 
-        _source.Add(item);
+        Source.Add(item);
     }
 
     /// <summary>
@@ -516,7 +514,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     {
         if (IsReadOnly) throw new NotSupportedException("Collection is read-only.");
 
-        _source.Clear();
+        Source.Clear();
     }
 
     /// <summary>
@@ -558,7 +556,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     {
         if (IsReadOnly) throw new NotSupportedException("Collection is read-only.");
 
-        _source.Insert(index, item);
+        Source.Insert(index, item);
     }
 
     /// <summary>
@@ -626,7 +624,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     {
         if (IsReadOnly) throw new NotSupportedException("Collection is read-only.");
 
-        _source.Remove(item);
+        Source.Remove(item);
 
         return true;
     }
@@ -661,7 +659,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     /// <returns>An asynchronous operation that returns the result of the load operation.</returns>
     public IAsyncOperation<LoadMoreItemsResult>? LoadMoreItemsAsync(uint count)
     {
-        return (_source as ISupportIncrementalLoading)?.LoadMoreItemsAsync(count);
+        return (Source as ISupportIncrementalLoading)?.LoadMoreItemsAsync(count);
     }
 
     /// <summary>

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -367,6 +367,11 @@ public partial class TableView
     internal ConditionalWeakTable<object, TValue<bool>> DetailsPaneStates { get; } = [];
 
     /// <summary>
+    /// Gets or sets the header row of the TableView.
+    /// </summary>
+    internal TableViewHeaderRow? HeaderRow { get; set; }
+
+    /// <summary>
     /// Gets or sets the filter handler for the TableView.
     /// </summary>
     public IColumnFilterHandler FilterHandler { get; set; }
@@ -719,9 +724,9 @@ public partial class TableView
     /// <summary>
     /// Gets or sets the data template selector for the row header.
     /// </summary>
-    public DataTemplateSelector RowHeaderTemplateSelector
+    public DataTemplateSelector? RowHeaderTemplateSelector
     {
-        get => (DataTemplateSelector)GetValue(RowHeaderTemplateSelectorProperty);
+        get => (DataTemplateSelector?)GetValue(RowHeaderTemplateSelectorProperty);
         set => SetValue(RowHeaderTemplateSelectorProperty, value);
     }
 
@@ -755,9 +760,9 @@ public partial class TableView
     /// <summary>
     /// Gets or sets the data template selector for the row details.
     /// </summary>
-    public DataTemplateSelector RowDetailsTemplateSelector
+    public DataTemplateSelector? RowDetailsTemplateSelector
     {
-        get => (DataTemplateSelector)GetValue(RowDetailsTemplateSelectorProperty);
+        get => (DataTemplateSelector?)GetValue(RowDetailsTemplateSelectorProperty);
         set => SetValue(RowDetailsTemplateSelectorProperty, value);
     }
 
@@ -834,7 +839,7 @@ public partial class TableView
     {
         if (d is TableView tableView)
         {
-            tableView._headerRow?.SetExportOptionsVisibility();
+            tableView.HeaderRow?.SetExportOptionsVisibility();
         }
     }
 
@@ -890,9 +895,9 @@ public partial class TableView
     /// </summary>
     private static void OnCanFilterColumnsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is TableView tableView && tableView._headerRow is not null)
+        if (d is TableView tableView && tableView.HeaderRow is not null)
         {
-            foreach (var header in tableView._headerRow.Headers)
+            foreach (var header in tableView.HeaderRow.Headers)
             {
                 header.SetFilterButtonVisibility();
             }
@@ -904,9 +909,9 @@ public partial class TableView
     /// </summary>
     private static void OnMinColumnWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is TableView table && table._headerRow is not null)
+        if (d is TableView table && table.HeaderRow is not null)
         {
-            table._headerRow.CalculateHeaderWidths();
+            table.HeaderRow.CalculateHeaderWidths();
         }
     }
 
@@ -915,9 +920,9 @@ public partial class TableView
     /// </summary>
     private static void OnMaxColumnWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is TableView table && table._headerRow is not null)
+        if (d is TableView table && table.HeaderRow is not null)
         {
-            table._headerRow.CalculateHeaderWidths();
+            table.HeaderRow.CalculateHeaderWidths();
         }
     }
 
@@ -1000,9 +1005,9 @@ public partial class TableView
     /// </summary>
     private static void OnHorizontalOffsetChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is TableView { _headerRow: { } } tableView)
+        if (d is TableView { HeaderRow: { } } tableView)
         {
-            tableView._headerRow.InvalidateArrange();
+            tableView.HeaderRow.InvalidateArrange();
 
             foreach (var row in tableView._rows)
             {

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -367,11 +367,6 @@ public partial class TableView
     internal ConditionalWeakTable<object, TValue<bool>> DetailsPaneStates { get; } = [];
 
     /// <summary>
-    /// Gets or sets the header row of the TableView.
-    /// </summary>
-    internal TableViewHeaderRow? HeaderRow { get; set; }
-
-    /// <summary>
     /// Gets or sets the filter handler for the TableView.
     /// </summary>
     public IColumnFilterHandler FilterHandler { get; set; }
@@ -839,7 +834,7 @@ public partial class TableView
     {
         if (d is TableView tableView)
         {
-            tableView.HeaderRow?.SetExportOptionsVisibility();
+            tableView._headerRow?.SetExportOptionsVisibility();
         }
     }
 
@@ -895,9 +890,9 @@ public partial class TableView
     /// </summary>
     private static void OnCanFilterColumnsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is TableView tableView && tableView.HeaderRow is not null)
+        if (d is TableView tableView && tableView._headerRow is not null)
         {
-            foreach (var header in tableView.HeaderRow.Headers)
+            foreach (var header in tableView._headerRow.Headers)
             {
                 header.SetFilterButtonVisibility();
             }
@@ -909,9 +904,9 @@ public partial class TableView
     /// </summary>
     private static void OnMinColumnWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is TableView table && table.HeaderRow is not null)
+        if (d is TableView table && table._headerRow is not null)
         {
-            table.HeaderRow.CalculateHeaderWidths();
+            table._headerRow.CalculateHeaderWidths();
         }
     }
 
@@ -920,9 +915,9 @@ public partial class TableView
     /// </summary>
     private static void OnMaxColumnWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is TableView table && table.HeaderRow is not null)
+        if (d is TableView table && table._headerRow is not null)
         {
-            table.HeaderRow.CalculateHeaderWidths();
+            table._headerRow.CalculateHeaderWidths();
         }
     }
 
@@ -1005,9 +1000,9 @@ public partial class TableView
     /// </summary>
     private static void OnHorizontalOffsetChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is TableView { HeaderRow: { } } tableView)
+        if (d is TableView { _headerRow: { } } tableView)
         {
-            tableView.HeaderRow.InvalidateArrange();
+            tableView._headerRow.InvalidateArrange();
 
             foreach (var row in tableView._rows)
             {

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -31,7 +31,6 @@ namespace WinUI.TableView;
 [StyleTypedProperty(Property = nameof(CellStyle), StyleTargetType = typeof(TableViewCell))]
 public partial class TableView : ListView
 {
-    private TableViewHeaderRow? _headerRow;
     private ScrollViewer? _scrollViewer;
     private RowDefinition? _headerRowDefinition;
     private bool _shouldThrowSelectionModeChangedException;
@@ -335,10 +334,10 @@ public partial class TableView : ListView
     {
         base.OnApplyTemplate();
 
-        _headerRow = GetTemplateChild("HeaderRow") as TableViewHeaderRow;
+        HeaderRow = GetTemplateChild("HeaderRow") as TableViewHeaderRow;
         _scrollViewer = GetTemplateChild("ScrollViewer") as ScrollViewer;
         _headerRowDefinition = GetTemplateChild("HeaderRowDefinition") as RowDefinition;
-        if (_scrollViewer is not null) _scrollViewer.Loaded += OnScrollViewerLoaded;
+        _scrollViewer?.Loaded += OnScrollViewerLoaded;
 
         if (IsLoaded)
         {
@@ -359,15 +358,9 @@ public partial class TableView : ListView
         var xScrollBar = _scrollViewer?.FindDescendant<ScrollBar>(sb => sb.Name is "HorizontalScrollBar2");
         var yScrollBar = _scrollViewer?.FindDescendant<ScrollBar>(sb => sb.Name is "VerticalScrollBar");
 
-        if (scrollPresenter is not null)
-        {
-            scrollPresenter.PointerWheelChanged += OnScrollContentPresenterPointerWheelChanged;
-        }
+        scrollPresenter?.PointerWheelChanged += OnScrollContentPresenterPointerWheelChanged;
 
-        if (yScrollBar is not null)
-        {
-            yScrollBar.ValueChanged += (_, _) => SetValue(VerticalOffsetProperty, yScrollBar.Value);
-        }
+        yScrollBar?.ValueChanged += (_, _) => SetValue(VerticalOffsetProperty, yScrollBar.Value);
 
         xScrollBar?.SetBinding(RangeBase.ValueProperty, new Binding
         {
@@ -507,8 +500,8 @@ public partial class TableView : ListView
     {
         // Skip TableView copy logic when a cell editor already handles Ctrl+C.
         // TextBox, PasswordBox, and RichEditBox all implement their own copy behavior.
-        var focused = FocusManager.GetFocusedElement() as FrameworkElement;
-        if (focused is TextBox || focused is PasswordBox || focused is RichEditBox)
+        var focused = FocusManager.GetFocusedElement(XamlRoot!) as FrameworkElement;
+        if (focused is TextBox or PasswordBox or RichEditBox)
         {
             return;
         }
@@ -520,7 +513,7 @@ public partial class TableView : ListView
         {
             return;
         }
-        
+
         var content = GetSelectedClipboardContent(includeHeaders);
 
         if (string.IsNullOrWhiteSpace(content))
@@ -533,7 +526,7 @@ public partial class TableView : ListView
         {
             var package = new DataPackage();
             package.SetText(content);
-            
+
             Clipboard.SetContent(package);
         }
         catch (Exception ex)
@@ -898,7 +891,11 @@ public partial class TableView : ListView
     /// <summary>
     /// Gets a storage file for saving the CSV.
     /// </summary>
-    private async Task<StorageFile> GetStorageFile()
+    private
+#if !WINDOWS
+    static
+#endif
+    async Task<StorageFile> GetStorageFile()
     {
         var savePicker = new FileSavePicker();
         savePicker.FileTypeChoices.Add("CSV (Comma delimited)", [".csv"]);
@@ -938,10 +935,7 @@ public partial class TableView : ListView
 
         foreach (var column in Columns.Where(c => c.SortDirection is not null))
         {
-            if (column is not null)
-            {
-                column.SortDirection = null;
-            }
+            column?.SortDirection = null;
         }
     }
 
@@ -1468,7 +1462,7 @@ public partial class TableView : ListView
         base.SelectionMode = SelectionUnit is TableViewSelectionUnit.Cell ? ListViewSelectionMode.None : SelectionMode;
 
         UpdateHorizontalScrollBarMargin();
-        _headerRow?.SetHeadersVisibility();
+        HeaderRow?.SetHeadersVisibility();
 
         foreach (var row in _rows)
         {
@@ -1485,7 +1479,7 @@ public partial class TableView : ListView
     /// </summary>
     private void EnsureGridLines()
     {
-        _headerRow?.EnsureGridLines();
+        HeaderRow?.EnsureGridLines();
 
         foreach (var row in _rows)
         {
@@ -1603,7 +1597,7 @@ public partial class TableView : ListView
     /// </summary>
     internal void UpdateCornerButtonState()
     {
-        _headerRow?.SetCornerButtonState();
+        HeaderRow?.SetCornerButtonState();
 
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {
@@ -1639,7 +1633,7 @@ public partial class TableView : ListView
             _headerRowDefinition.Height = areColumnHeadersVisible ? GridLength.Auto : new(0);
         }
 
-        _headerRow?.SetHeadersVisibility();
+        HeaderRow?.SetHeadersVisibility();
 
         foreach (var row in _rows)
         {

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -31,6 +31,7 @@ namespace WinUI.TableView;
 [StyleTypedProperty(Property = nameof(CellStyle), StyleTargetType = typeof(TableViewCell))]
 public partial class TableView : ListView
 {
+    private TableViewHeaderRow? _headerRow;
     private ScrollViewer? _scrollViewer;
     private RowDefinition? _headerRowDefinition;
     private bool _shouldThrowSelectionModeChangedException;
@@ -334,7 +335,7 @@ public partial class TableView : ListView
     {
         base.OnApplyTemplate();
 
-        HeaderRow = GetTemplateChild("HeaderRow") as TableViewHeaderRow;
+        _headerRow = GetTemplateChild("HeaderRow") as TableViewHeaderRow;
         _scrollViewer = GetTemplateChild("ScrollViewer") as ScrollViewer;
         _headerRowDefinition = GetTemplateChild("HeaderRowDefinition") as RowDefinition;
         _scrollViewer?.Loaded += OnScrollViewerLoaded;
@@ -1462,7 +1463,7 @@ public partial class TableView : ListView
         base.SelectionMode = SelectionUnit is TableViewSelectionUnit.Cell ? ListViewSelectionMode.None : SelectionMode;
 
         UpdateHorizontalScrollBarMargin();
-        HeaderRow?.SetHeadersVisibility();
+        _headerRow?.SetHeadersVisibility();
 
         foreach (var row in _rows)
         {
@@ -1479,7 +1480,7 @@ public partial class TableView : ListView
     /// </summary>
     private void EnsureGridLines()
     {
-        HeaderRow?.EnsureGridLines();
+        _headerRow?.EnsureGridLines();
 
         foreach (var row in _rows)
         {
@@ -1597,7 +1598,7 @@ public partial class TableView : ListView
     /// </summary>
     internal void UpdateCornerButtonState()
     {
-        HeaderRow?.SetCornerButtonState();
+        _headerRow?.SetCornerButtonState();
 
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {
@@ -1633,7 +1634,7 @@ public partial class TableView : ListView
             _headerRowDefinition.Height = areColumnHeadersVisible ? GridLength.Auto : new(0);
         }
 
-        HeaderRow?.SetHeadersVisibility();
+        _headerRow?.SetHeadersVisibility();
 
         foreach (var row in _rows)
         {

--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -28,7 +28,6 @@ namespace WinUI.TableView;
 #endif
 public partial class TableViewCell : ContentControl
 {
-    private TableViewColumn? _column;
     private ScrollViewer? _scrollViewer;
     private ContentPresenter? _contentPresenter;
     private Border? _selectionBorder;
@@ -614,12 +613,12 @@ public partial class TableViewCell : ContentControl
     /// </summary>
     public TableViewColumn? Column
     {
-        get => _column;
+        get;
         internal set
         {
-            if (_column != value)
+            if (field != value)
             {
-                _column = value;
+                field = value;
                 OnColumnChanged();
             }
         }

--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -65,10 +65,7 @@ public partial class TableViewColumnHeader : ContentControl
     /// </summary>
     private void OnWidthChanged(DependencyObject sender, DependencyProperty dp)
     {
-        if (Column is not null)
-        {
-            Column.ActualWidth = Width;
-        }
+        Column?.ActualWidth = Width;
     }
 
     /// <summary>
@@ -181,6 +178,8 @@ public partial class TableViewColumnHeader : ContentControl
         var firstItem = selectedValues.FirstOrDefault(x => x is not null);
         var firstItemType = firstItem?.GetType();
 
+#pragma warning disable IDE0306 // Simplify collection initialization
+#pragma warning disable IDE0028 // Simplify collection initialization
         return firstItemType switch
         {
             Type t when t == typeof(int) => new ObjectBackedTypedSet<int?>(selectedValues),
@@ -191,6 +190,8 @@ public partial class TableViewColumnHeader : ContentControl
 
             _ => [.. selectedValues],
         };
+#pragma warning restore IDE0028 // Simplify collection initialization
+#pragma warning restore IDE0306 // Simplify collection initialization
     }
 
     /// <summary>
@@ -230,29 +231,14 @@ public partial class TableViewColumnHeader : ContentControl
     {
         base.OnApplyTemplate();
 
-        if (_optionsFlyout is not null)
-        {
-            _optionsFlyout.Opening -= OnOptionsFlyoutOpening;
-            _optionsFlyout.Closed -= OnOptionsFlyoutClosed;
-        }
+        _optionsFlyout?.Opening -= OnOptionsFlyoutOpening;
+        _optionsFlyout?.Closed -= OnOptionsFlyoutClosed;
+        _optionsButton?.Tapped -= OnOptionsButtonTaped;
+        _filterItemsMenuItem?.PreviewKeyUp -= OnFilterItemsMenuItemPreviewKeyUp;
 
-        if (_optionsButton is not null)
-        {
-            _optionsButton.Tapped -= OnOptionsButtonTaped;
-        }
-
-        if (_filterItemsMenuItem is not null)
-        {
-            _filterItemsMenuItem.PreviewKeyUp -= OnFilterItemsMenuItemPreviewKeyUp;
-        }
-
-        if (_filterItemsControl is not null)
-        {
-            _filterItemsControl.FilterItems = null;
-            _filterItemsControl.TableView = null;
-            _filterItemsControl.ColumnHeader = null;
-            _filterItemsControl = null;
-        }
+        _filterItemsControl?.FilterItems = null;
+        _filterItemsControl?.TableView = null;
+        _filterItemsControl?.ColumnHeader = null;
 
         _tableView = this.FindAscendant<TableView>();
         _headerRow = this.FindAscendant<TableViewHeaderRow>();
@@ -271,19 +257,13 @@ public partial class TableViewColumnHeader : ContentControl
         _optionsFlyout.Closed += OnOptionsFlyoutClosed;
         _optionsButton.Tapped += OnOptionsButtonTaped;
 
-        if (_filterItemsMenuItem is not null)
-        {
-            _filterItemsMenuItem.ApplyTemplate();
-            _filterItemsControl = _filterItemsMenuItem.FindDescendant<TableViewFilterItemsControl>();
+        _filterItemsMenuItem?.ApplyTemplate();
+        _filterItemsControl = _filterItemsMenuItem?.FindDescendant<TableViewFilterItemsControl>();
 
-            if (_filterItemsControl is not null)
-            {
-                _filterItemsControl.TableView = _tableView;
-                _filterItemsControl.ColumnHeader = this;
-            }
+        _filterItemsControl?.TableView = _tableView;
+        _filterItemsControl?.ColumnHeader = this;
 
-            _filterItemsMenuItem.PreviewKeyUp += OnFilterItemsMenuItemPreviewKeyUp;
-        }
+        _filterItemsMenuItem?.PreviewKeyUp += OnFilterItemsMenuItemPreviewKeyUp;
 
         SetOptionCommands();
         SetFilterButtonVisibility();
@@ -361,19 +341,13 @@ public partial class TableViewColumnHeader : ContentControl
     /// </summary>
     internal void SetFilterButtonVisibility()
     {
-        if (_optionsButton is not null)
-        {
-            _optionsButton.Visibility = CanFilter ? Visibility.Visible : Visibility.Collapsed;
-        }
+        _optionsButton?.Visibility = CanFilter ? Visibility.Visible : Visibility.Collapsed;
 
-        if (_contentPresenter is not null)
-        {
-            _contentPresenter.Margin = CanFilter ? new Thickness(
+        _contentPresenter?.Margin = CanFilter ? new Thickness(
                 Padding.Left,
                 Padding.Top,
                 Padding.Right + 8,
                 0) : Padding;
-        }
     }
 
     /// <summary>

--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -239,7 +239,7 @@ public partial class TableViewColumnHeader : ContentControl
         _filterItemsControl?.FilterItems = null;
         _filterItemsControl?.TableView = null;
         _filterItemsControl?.ColumnHeader = null;
-
+        _filterItemsControl = null;
         _tableView = this.FindAscendant<TableView>();
         _headerRow = this.FindAscendant<TableViewHeaderRow>();
         _optionsButton = GetTemplateChild("OptionsButton") as Button;

--- a/src/TableViewFilterItem.cs
+++ b/src/TableViewFilterItem.cs
@@ -10,8 +10,6 @@ public partial class TableViewFilterItem : INotifyPropertyChanged
     /// <inheritdoc/>
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    private bool _isSelected;
-
     /// <summary>
     /// Initializes a new instance of the FilterItem class.
     /// </summary>
@@ -32,10 +30,10 @@ public partial class TableViewFilterItem : INotifyPropertyChanged
     /// </summary>
     public bool IsSelected
     {
-        get => _isSelected;
+        get;
         set
         {
-            _isSelected = value;
+            field = value;
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
         }
     }

--- a/src/TableViewHeaderRow.OptionComamnds.cs
+++ b/src/TableViewHeaderRow.OptionComamnds.cs
@@ -25,15 +25,8 @@ partial class TableViewHeaderRow
     {
         var visibility = TableView?.ShowExportOptions is true ? Visibility.Visible : Visibility.Collapsed;
 
-        if (_exportAllMenuItem is not null)
-        {
-            _exportAllMenuItem.Visibility = visibility;
-        }
-
-        if (_exportSelectedMenuItem is not null)
-        {
-            _exportSelectedMenuItem.Visibility = visibility;
-        }
+        _exportAllMenuItem?.Visibility = visibility;
+        _exportSelectedMenuItem?.Visibility = visibility;
     }
 
     /// <summary>

--- a/src/TableViewHeaderRow.cs
+++ b/src/TableViewHeaderRow.cs
@@ -42,7 +42,6 @@ public partial class TableViewHeaderRow : Control
     private TranslateTransform? _columnDropIndicatorTransform;
     private Image? _dragHeaderImage;
     private bool _calculatingHeaderWidths;
-    private DispatcherTimer? _timer;
     private int _dropColumnIndex;
     private bool _isValidDropTarget;
     private readonly Dictionary<DependencyProperty, long> _callbackTokens = [];
@@ -60,16 +59,9 @@ public partial class TableViewHeaderRow : Control
     {
         base.OnApplyTemplate();
 
-        if (_selectAllButton is not null)
-        {
-            _selectAllButton.Tapped -= OnSelectAllButtonClicked;
-        }
-
-        if (_selectAllCheckBox is not null)
-        {
-            _selectAllCheckBox.Checked -= OnSelectAllCheckBoxChecked;
-            _selectAllCheckBox.Unchecked -= OnSelectAllCheckBoxUnchecked;
-        }
+        _selectAllButton?.Tapped -= OnSelectAllButtonClicked;
+        _selectAllCheckBox?.Checked -= OnSelectAllCheckBoxChecked;
+        _selectAllCheckBox?.Unchecked -= OnSelectAllCheckBoxUnchecked;
 
         _cornerButtonPanel = GetTemplateChild("CornerButtonPanel") as Panel;
         _optionsButton = GetTemplateChild("optionsButton") as Button;
@@ -88,16 +80,9 @@ public partial class TableViewHeaderRow : Control
             return;
         }
 
-        if (_selectAllButton is not null)
-        {
-            _selectAllButton.Tapped += OnSelectAllButtonClicked;
-        }
-
-        if (_selectAllCheckBox is not null)
-        {
-            _selectAllCheckBox.Checked += OnSelectAllCheckBoxChecked;
-            _selectAllCheckBox.Unchecked += OnSelectAllCheckBoxUnchecked;
-        }
+        _selectAllButton?.Tapped += OnSelectAllButtonClicked;
+        _selectAllCheckBox?.Checked += OnSelectAllCheckBoxChecked;
+        _selectAllCheckBox?.Unchecked += OnSelectAllCheckBoxUnchecked;
 
         if (TableView.Columns is not null)
         {
@@ -215,35 +200,6 @@ public partial class TableViewHeaderRow : Control
             {
                 CalculateHeaderWidths();
             }
-        }
-        else if (e.PropertyName is nameof(TableViewColumn.DesiredWidth))
-        {
-            if (_timer is null)
-            {
-                _timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
-                _timer.Tick += OnTimerTick;
-            }
-
-            _timer.Stop();
-            _timer.Start();
-        }
-    }
-
-    /// <summary>
-    /// Handles the timer tick event.
-    /// </summary>
-    private void OnTimerTick(object? sender, object e)
-    {
-        if (!_calculatingHeaderWidths)
-        {
-            CalculateHeaderWidths();
-        }
-
-        if (_timer is not null)
-        {
-            _timer.Stop();
-            _timer.Tick -= OnTimerTick;
-            _timer = null;
         }
     }
 
@@ -595,25 +551,13 @@ public partial class TableViewHeaderRow : Control
             x -= _columnDropIndicator.ActualWidth / 2;
             _dropColumnIndex += midPoint > position ? -1 : 0;
             _columnDropIndicator.Visibility = Visibility.Visible;
-
-            if (_columnDropIndicatorTransform is not null)
-            {
-                _columnDropIndicatorTransform.X = x;
-            }
-
-            if (_dragHeaderImage is not null)
-            {
-                _dragHeaderImage.Source = headerVisuals;
-            }
+            _columnDropIndicatorTransform?.X = x;
+            _dragHeaderImage?.Source = headerVisuals;
         }
         else
         {
             _isValidDropTarget = false;
-
-            if (_columnDropIndicator is not null)
-            {
-                _columnDropIndicator.Visibility = Visibility.Collapsed;
-            }
+            _columnDropIndicator?.Visibility = Visibility.Collapsed;
         }
     }
 

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -32,8 +32,6 @@ public partial class TableViewRow : ListViewItem
     private Thickness _focusVisualMargin = new(1);
     private readonly Thickness _selectionBackgroundMargin = new(4, 2, 4, 2);
     private readonly Thickness _selectionIndicatorMargin = new(4, 0, 0, 0);
-
-    private TableView? _tableView;
     private ListViewItemPresenter? _itemPresenter;
     private Border? _selectionBackground;
     private bool _ensureCells = true;
@@ -147,7 +145,7 @@ public partial class TableViewRow : ListViewItem
         }
 
         RowPresenter?.InvalidateMeasure(); // The cells presenter does not measure every time.
-        _tableView?.EnsureAlternateRowColors();
+        TableView?.EnsureAlternateRowColors();
     }
 
     /// <inheritdoc/>
@@ -627,13 +625,13 @@ public partial class TableViewRow : ListViewItem
     /// </summary>
     public TableView? TableView
     {
-        get => _tableView;
+        get;
         internal set
         {
-            if (_tableView != value)
+            if (field != value)
             {
                 OnTableViewChanging();
-                _tableView = value;
+                field = value;
                 OnTableViewChanged();
             }
         }

--- a/src/TableViewRowPresenter.cs
+++ b/src/TableViewRowPresenter.cs
@@ -48,20 +48,14 @@ public partial class TableViewRowPresenter : Control
     {
         base.OnApplyTemplate();
 
-        if (_detailsToggleButton is not null)
-        {
-            _detailsToggleButton.Tapped -= OnDetailsToggleButtonTapped;
-        }
+        _detailsToggleButton?.Tapped -= OnDetailsToggleButtonTapped;
 
-        if (_detailsPanel is not null)
-        {
-            _detailsPanel.SizeChanged -= OnDetailsPanelSizeChanged;
+        _detailsPanel?.SizeChanged -= OnDetailsPanelSizeChanged;
 
-            if (_detailsPanelVisibilityCallbackToken is long token)
-            {
-                _detailsPanel.UnregisterPropertyChangedCallback(VisibilityProperty, token);
-                _detailsPanelVisibilityCallbackToken = null;
-            }
+        if (_detailsPanelVisibilityCallbackToken is long token)
+        {
+            _detailsPanel?.UnregisterPropertyChangedCallback(VisibilityProperty, token);
+            _detailsPanelVisibilityCallbackToken = null;
         }
 
         _rowHeader = GetTemplateChild("RowHeader") as TableViewRowHeader;
@@ -77,17 +71,10 @@ public partial class TableViewRowPresenter : Control
         _itemPresenter = this.FindAscendant<ListViewItemPresenter>();
         TableViewRow = this.FindAscendant<TableViewRow>();
         TableView = TableViewRow?.TableView;
+        _rowHeader?.TableView = TableView;
+        _rowHeader?.TableViewRow = TableViewRow;
 
-        if (_rowHeader is not null)
-        {
-            _rowHeader.TableView = TableView;
-            _rowHeader.TableViewRow = TableViewRow;
-        }
-
-        if (_detailsToggleButton is not null)
-        {
-            _detailsToggleButton.Tapped += OnDetailsToggleButtonTapped;
-        }
+        _detailsToggleButton?.Tapped += OnDetailsToggleButtonTapped;
 
         if (_detailsPanel is not null)
         {
@@ -266,7 +253,7 @@ public partial class TableViewRowPresenter : Control
         if (TableView?.RowDetailsVisibilityMode is TableViewRowDetailsVisibilityMode.VisibleWhenExpanded &&
             _detailsToggleButton is not null && TableView is not null && item is not null)
         {
-            var isChecked = TableView.DetailsPaneStates.TryGetValue(item, out var value) ? value.Value : false;
+            var isChecked = TableView.DetailsPaneStates.TryGetValue(item, out var value) && value.Value;
             _detailsToggleButton!.IsChecked = isChecked;
             ToggleDetailsPane(item, isChecked);
         }

--- a/src/WinUI.TableView.csproj
+++ b/src/WinUI.TableView.csproj
@@ -5,7 +5,7 @@
       net9.0;
       net10.0;
     </TargetFrameworks>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable> 
     <IsAOTCompatible>true</IsAOTCompatible>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
### Summary 
Refactored property backing fields to use C# 14's field keyword, reducing boilerplate and improving clarity. Updated null checks and event handler logic with null-conditional operators. Made several properties nullable where appropriate.