### PR TITLE
Fix filter flyout search behavior by using custom MenuFlyout control

### DIFF
--- a/src/Controls/TableViewFilterItemsControl.xaml.cs
+++ b/src/Controls/TableViewFilterItemsControl.xaml.cs
@@ -49,10 +49,7 @@ public partial class TableViewFilterItemsControl : UserControl
     /// </summary>
     internal void ClearSearchBox()
     {
-        if (searchBox is not null)
-        {
-            searchBox.Text = string.Empty;
-        }
+        searchBox?.Text = string.Empty;
     }
 
     private void OnSearchBoxTextChanged(object sender, TextChangedEventArgs e)
@@ -67,7 +64,8 @@ public partial class TableViewFilterItemsControl : UserControl
     {
         if (e.Key == VirtualKey.Enter && searchBox?.Text.Length > 0)
         {
-            ColumnHeader?.ExecuteOkCommand();
+            ColumnHeader?.HideFlyout();
+            ColumnHeader?.ApplyFilter();
 
             e.Handled = true;
         }
@@ -175,7 +173,19 @@ public partial class TableViewFilterItemsControl : UserControl
     /// <summary>
     /// Gets or sets the column header associated with the filter items control.
     /// </summary>
-    public TableViewColumnHeader? ColumnHeader { get; internal set; }
+    public TableViewColumnHeader? ColumnHeader
+    {
+        get;
+        set
+        {
+            if (value is { FilterItemsControl: null })
+            {
+                value.FilterItemsControl = this;
+            }
+
+            field = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the TableView associated with the filter items control.

--- a/src/TableViewColumnHeader.OptionComamnds.cs
+++ b/src/TableViewColumnHeader.OptionComamnds.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
-using WinUI.TableView.Extensions;
 using SD = WinUI.TableView.SortDirection;
 
 namespace WinUI.TableView;
@@ -11,9 +10,7 @@ partial class TableViewColumnHeader
     private readonly StandardUICommand _sortAscendingCommand = new() { Label = TableViewLocalizedStrings.SortAscending };
     private readonly StandardUICommand _sortDescendingCommand = new() { Label = TableViewLocalizedStrings.SortDescending };
     private readonly StandardUICommand _clearSortingCommand = new() { Label = TableViewLocalizedStrings.ClearSorting };
-    private readonly StandardUICommand _clearFilterCommand = new() { Label = TableViewLocalizedStrings.ClearFilter };
-    private readonly StandardUICommand _okCommand = new() { Label = TableViewLocalizedStrings.Ok };
-    private readonly StandardUICommand _cancelCommand = new() { Label = TableViewLocalizedStrings.Cancel };
+    private readonly StandardUICommand _clearFilterCommand = new() { Label = TableViewLocalizedStrings.ClearFilter };    
 
     /// <summary>
     /// Sets commands to option menu items.
@@ -30,15 +27,6 @@ partial class TableViewColumnHeader
             clearSortingMenuItem.Command = _clearSortingCommand;
         if (GetTemplateChild("ClearFilterMenuItem") is MenuFlyoutItem clearFilterMenuItem)
             clearFilterMenuItem.Command = _clearFilterCommand;
-        if (GetTemplateChild("ActionButtonsMenuItem") is MenuFlyoutItem actionButtonsMenuItem)
-        {
-            actionButtonsMenuItem.ApplyTemplate();
-
-            if (actionButtonsMenuItem.FindDescendant<Button>(b => b.Name is "OkButton") is { } okButton)
-                okButton.Command = _okCommand;
-            if (actionButtonsMenuItem.FindDescendant<Button>(b => b.Name is "CancelButton") is { } cancelButton)
-                cancelButton.Command = _cancelCommand;
-        }
     }
 
     /// <summary>
@@ -62,16 +50,7 @@ partial class TableViewColumnHeader
 
         _clearFilterCommand.ExecuteRequested += delegate { ClearFilter(); };
         _clearFilterCommand.CanExecuteRequested += (_, e) => e.CanExecute = Column?.IsFiltered is true;
-
-        _okCommand.ExecuteRequested += delegate { ExecuteOkCommand(); };
-
-        _cancelCommand.ExecuteRequested += delegate { HideFlyout(); };
+        
         _commandsInitialized = true;
-    }
-
-    internal void ExecuteOkCommand()
-    {
-        HideFlyout();
-        ApplyFilter();
     }
 }

--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -37,7 +37,7 @@ public partial class TableViewColumnHeader : ContentControl
     private TableView? _tableView;
     private TableViewHeaderRow? _headerRow;
     private Button? _optionsButton;
-    private MenuFlyout? _optionsFlyout;
+    private TableViewFilterMenuFlyout? _optionsFlyout;
     private MenuFlyoutItem? _filterItemsMenuItem;
     private ContentPresenter? _contentPresenter;
     private Rectangle? _v_gridLine;
@@ -46,8 +46,7 @@ public partial class TableViewColumnHeader : ContentControl
     private bool _resizePreviousStarted;
     private double _reorderStartingPosition;
     private bool _reorderStarted;
-    private RenderTargetBitmap? _dragVisuals;
-    private TableViewFilterItemsControl? _filterItemsControl;
+    private RenderTargetBitmap? _dragVisuals;    
 
     /// <summary>
     /// Initializes a new instance of the TableViewColumnHeader class.
@@ -156,9 +155,9 @@ public partial class TableViewColumnHeader : ContentControl
     /// <summary>
     /// Applies the filter for the column.
     /// </summary>
-    private void ApplyFilter()
+    internal void ApplyFilter()
     {
-        var shouldApplyFilter = _filterItemsControl?.ShouldApplyFilter ?? false;
+        var shouldApplyFilter = FilterItemsControl?.ShouldApplyFilter ?? false;
 
         if (!shouldApplyFilter && (Column?.IsFiltered ?? false))
         {
@@ -173,7 +172,7 @@ public partial class TableViewColumnHeader : ContentControl
 
     private ICollection<object?> GetSelectedValues()
     {
-        var filterItems = _filterItemsControl?.FilterItems ?? [];
+        var filterItems = FilterItemsControl?.FilterItems ?? [];
         var selectedValues = filterItems.Where(x => x.IsSelected).Select(x => x.Value);
         var firstItem = selectedValues.FirstOrDefault(x => x is not null);
         var firstItemType = firstItem?.GetType();
@@ -197,7 +196,7 @@ public partial class TableViewColumnHeader : ContentControl
     /// <summary>
     /// Hides the options flyout.
     /// </summary>
-    private void HideFlyout()
+    internal void HideFlyout()
     {
         _optionsFlyout?.Hide();
     }
@@ -231,19 +230,16 @@ public partial class TableViewColumnHeader : ContentControl
     {
         base.OnApplyTemplate();
 
-        _optionsFlyout?.Opening -= OnOptionsFlyoutOpening;
-        _optionsFlyout?.Closed -= OnOptionsFlyoutClosed;
         _optionsButton?.Tapped -= OnOptionsButtonTaped;
-        _filterItemsMenuItem?.PreviewKeyUp -= OnFilterItemsMenuItemPreviewKeyUp;
 
-        _filterItemsControl?.FilterItems = null;
-        _filterItemsControl?.TableView = null;
-        _filterItemsControl?.ColumnHeader = null;
-        _filterItemsControl = null;
+        FilterItemsControl?.FilterItems = null;
+        FilterItemsControl?.TableView = null;
+        FilterItemsControl?.ColumnHeader = null;
+        FilterItemsControl = null;
         _tableView = this.FindAscendant<TableView>();
         _headerRow = this.FindAscendant<TableViewHeaderRow>();
         _optionsButton = GetTemplateChild("OptionsButton") as Button;
-        _optionsFlyout = GetTemplateChild("OptionsFlyout") as MenuFlyout;
+        _optionsFlyout = GetTemplateChild("OptionsFlyout") as TableViewFilterMenuFlyout;
         _filterItemsMenuItem = GetTemplateChild("FilterItemsMenuItem") as MenuFlyoutItem;
         _contentPresenter = GetTemplateChild("ContentPresenter") as ContentPresenter;
         _v_gridLine = GetTemplateChild("VerticalGridLine") as Rectangle;
@@ -253,37 +249,14 @@ public partial class TableViewColumnHeader : ContentControl
             return;
         }
 
-        _optionsFlyout.Opening += OnOptionsFlyoutOpening;
-        _optionsFlyout.Closed += OnOptionsFlyoutClosed;
+        _optionsFlyout.TableView = _tableView;
+        _optionsFlyout.ColumnHeader = this;
+
         _optionsButton.Tapped += OnOptionsButtonTaped;
-
-        _filterItemsMenuItem?.ApplyTemplate();
-        _filterItemsControl = _filterItemsMenuItem?.FindDescendant<TableViewFilterItemsControl>();
-
-        _filterItemsControl?.TableView = _tableView;
-        _filterItemsControl?.ColumnHeader = this;
-
-        _filterItemsMenuItem?.PreviewKeyUp += OnFilterItemsMenuItemPreviewKeyUp;
 
         SetOptionCommands();
         SetFilterButtonVisibility();
         EnsureGridLines();
-    }
-
-    /// <summary>
-    /// Handles the Opening event for the options flyout.
-    /// </summary>
-    private async void OnOptionsFlyoutOpening(object? sender, object e)
-    {
-        _filterItemsControl?.Initialize();
-    }
-
-    /// <summary>
-    /// Handles the Closed event for the options flyout.
-    /// </summary>
-    private void OnOptionsFlyoutClosed(object? sender, object e)
-    {
-        _filterItemsControl?.ClearSearchBox();
     }
 
     /// <summary>
@@ -292,14 +265,6 @@ public partial class TableViewColumnHeader : ContentControl
     private void OnOptionsButtonTaped(object sender, TappedRoutedEventArgs e)
     {
         e.Handled = true;
-    }
-
-    /// <summary>
-    /// Handles the PreviewKeyUp event for the filter items menu item.
-    /// </summary>
-    private void OnFilterItemsMenuItemPreviewKeyUp(object sender, KeyRoutedEventArgs e)
-    {
-        e.Handled = e.Key is VirtualKey.Space;
     }
 
     /// <summary>
@@ -565,4 +530,9 @@ public partial class TableViewColumnHeader : ContentControl
     /// Gets a value indicating whether the cursor is in the sizing area.
     /// </summary>
     private bool IsSizingCursor => ProtectedCursor is InputSystemCursor { CursorShape: InputSystemCursorShape.SizeWestEast };
+
+    /// <summary>
+    /// Gets or sets the filter items control associated with the column header.
+    /// </summary>
+    internal TableViewFilterItemsControl? FilterItemsControl { get; set; }
 }

--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -38,7 +38,6 @@ public partial class TableViewColumnHeader : ContentControl
     private TableViewHeaderRow? _headerRow;
     private Button? _optionsButton;
     private TableViewFilterMenuFlyout? _optionsFlyout;
-    private MenuFlyoutItem? _filterItemsMenuItem;
     private ContentPresenter? _contentPresenter;
     private Rectangle? _v_gridLine;
     private bool _resizeStarted;
@@ -240,7 +239,6 @@ public partial class TableViewColumnHeader : ContentControl
         _headerRow = this.FindAscendant<TableViewHeaderRow>();
         _optionsButton = GetTemplateChild("OptionsButton") as Button;
         _optionsFlyout = GetTemplateChild("OptionsFlyout") as TableViewFilterMenuFlyout;
-        _filterItemsMenuItem = GetTemplateChild("FilterItemsMenuItem") as MenuFlyoutItem;
         _contentPresenter = GetTemplateChild("ContentPresenter") as ContentPresenter;
         _v_gridLine = GetTemplateChild("VerticalGridLine") as Rectangle;
 

--- a/src/TableViewFilterMenuFlyout.cs
+++ b/src/TableViewFilterMenuFlyout.cs
@@ -25,15 +25,9 @@ public partial class TableViewFilterMenuFlyout : Flyout
         Items = [];
         Opening += OnOpening;
         Closed += OnClosed;
-    }
 
-    /// <summary>
-    /// Finalizes an instance of the <see cref="TableViewFilterMenuFlyout"/> class.
-    /// </summary>
-    ~TableViewFilterMenuFlyout()
-    {
-        Opening -= OnOpening;
-        Closed -= OnClosed;
+        _okCommand.ExecuteRequested += delegate { ExecuteOkCommand(); };
+        _cancelCommand.ExecuteRequested += delegate { Hide(); };
     }
 
     /// <inheritdoc/>
@@ -76,8 +70,6 @@ public partial class TableViewFilterMenuFlyout : Flyout
         _filterItemsControl = presenter.FindDescendant<TableViewFilterItemsControl>();
         _filterItemsControl?.TableView = TableView;
         _filterItemsControl?.ColumnHeader = ColumnHeader;
-        _okCommand.ExecuteRequested += delegate { ExecuteOkCommand(); };
-        _cancelCommand.ExecuteRequested += delegate { Hide(); };
 
         okButton?.Command = _okCommand;
         cancelButton?.Command = _cancelCommand;

--- a/src/TableViewFilterMenuFlyout.cs
+++ b/src/TableViewFilterMenuFlyout.cs
@@ -1,7 +1,8 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
+using System.Collections.Generic;
+using System.Linq;
 using WinUI.TableView.Controls;
 using WinUI.TableView.Extensions;
 
@@ -10,7 +11,7 @@ namespace WinUI.TableView;
 /// <summary>
 /// Represents the filter menu flyout for a TableViewColumnHeader.
 /// </summary>
-public partial class TableViewFilterMenuFlyout : MenuFlyout
+public partial class TableViewFilterMenuFlyout : Flyout
 {
     private TableViewFilterItemsControl? _filterItemsControl;
     private readonly StandardUICommand _okCommand = new() { Label = TableViewLocalizedStrings.Ok };
@@ -21,8 +22,9 @@ public partial class TableViewFilterMenuFlyout : MenuFlyout
     /// </summary>
     public TableViewFilterMenuFlyout()
     {
+        Items = [];
         Opening += OnOpening;
-        Closing += OnClosing;
+        Closed += OnClosed;
     }
 
     /// <summary>
@@ -31,13 +33,14 @@ public partial class TableViewFilterMenuFlyout : MenuFlyout
     ~TableViewFilterMenuFlyout()
     {
         Opening -= OnOpening;
-        Closing -= OnClosing;
+        Closed -= OnClosed;
     }
 
     /// <inheritdoc/>
     protected override Control CreatePresenter()
     {
         var presenter = base.CreatePresenter();
+        presenter.Style = FlyoutPresenterStyle;
         presenter.Loaded += OnPresenterLoaded;
 
         return presenter;
@@ -52,9 +55,9 @@ public partial class TableViewFilterMenuFlyout : MenuFlyout
     }
 
     /// <summary>
-    /// Handles the Closing event of the flyout, clearing the search box in the filter items control.
+    /// Handles the Closed event of the flyout, clearing the search box in the filter items control.
     /// </summary>
-    private void OnClosing(FlyoutBase sender, FlyoutBaseClosingEventArgs args)
+    private void OnClosed(object? sender, object e)
     {
         _filterItemsControl?.ClearSearchBox();
     }
@@ -64,9 +67,11 @@ public partial class TableViewFilterMenuFlyout : MenuFlyout
     /// </summary>
     private void OnPresenterLoaded(object sender, RoutedEventArgs e)
     {
-        var presenter = (MenuFlyoutPresenter)sender;
+        var presenter = (FlyoutPresenter)sender;
         var okButton = presenter.FindDescendant<Button>(b => b.Name is "OkButton");
         var cancelButton = presenter.FindDescendant<Button>(b => b.Name is "CancelButton");
+        var menuPresenter = presenter.FindDescendant<MenuFlyoutPresenter>();
+        menuPresenter?.ItemsSource = Items;
 
         _filterItemsControl = presenter.FindDescendant<TableViewFilterItemsControl>();
         _filterItemsControl?.TableView = TableView;
@@ -79,6 +84,19 @@ public partial class TableViewFilterMenuFlyout : MenuFlyout
 
         presenter.Loaded -= OnPresenterLoaded;
         _filterItemsControl?.Initialize();
+
+        foreach (var item in Items.OfType<MenuFlyoutItem>())
+        {
+            item.Tapped += OnMenuItemTapped;
+        }
+    }
+
+    /// <summary>
+    /// Handles the Tapped event of menu items.
+    /// </summary>
+    private void OnMenuItemTapped(object sender, TappedRoutedEventArgs e)
+    {
+        Hide();
     }
 
     /// <summary>
@@ -99,4 +117,9 @@ public partial class TableViewFilterMenuFlyout : MenuFlyout
     /// Gets or sets the TableViewColumnHeader associated with this filter menu flyout.
     /// </summary>
     public TableViewColumnHeader? ColumnHeader { get; set; }
+
+    /// <summary>
+    /// Gets or sets the collection of menu items to be displayed in the filter flyout.
+    /// </summary>
+    public IList<MenuFlyoutItemBase> Items { get; set; }
 }

--- a/src/TableViewFilterMenuFlyout.cs
+++ b/src/TableViewFilterMenuFlyout.cs
@@ -1,0 +1,102 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
+using WinUI.TableView.Controls;
+using WinUI.TableView.Extensions;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Represents the filter menu flyout for a TableViewColumnHeader.
+/// </summary>
+public partial class TableViewFilterMenuFlyout : MenuFlyout
+{
+    private TableViewFilterItemsControl? _filterItemsControl;
+    private readonly StandardUICommand _okCommand = new() { Label = TableViewLocalizedStrings.Ok };
+    private readonly StandardUICommand _cancelCommand = new() { Label = TableViewLocalizedStrings.Cancel };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableViewFilterMenuFlyout"/> class.
+    /// </summary>
+    public TableViewFilterMenuFlyout()
+    {
+        Opening += OnOpening;
+        Closing += OnClosing;
+    }
+
+    /// <summary>
+    /// Finalizes an instance of the <see cref="TableViewFilterMenuFlyout"/> class.
+    /// </summary>
+    ~TableViewFilterMenuFlyout()
+    {
+        Opening -= OnOpening;
+        Closing -= OnClosing;
+    }
+
+    /// <inheritdoc/>
+    protected override Control CreatePresenter()
+    {
+        var presenter = base.CreatePresenter();
+        presenter.Loaded += OnPresenterLoaded;
+
+        return presenter;
+    }
+
+    /// <summary>
+    /// Handles the Opening event of the flyout, initializing the filter items control.
+    /// </summary>
+    private void OnOpening(object? sender, object e)
+    {
+        _filterItemsControl?.Initialize();
+    }
+
+    /// <summary>
+    /// Handles the Closing event of the flyout, clearing the search box in the filter items control.
+    /// </summary>
+    private void OnClosing(FlyoutBase sender, FlyoutBaseClosingEventArgs args)
+    {
+        _filterItemsControl?.ClearSearchBox();
+    }
+
+    /// <summary>
+    /// Handles the Loaded event of the MenuFlyoutPresenter.
+    /// </summary>
+    private void OnPresenterLoaded(object sender, RoutedEventArgs e)
+    {
+        var presenter = (MenuFlyoutPresenter)sender;
+        var okButton = presenter.FindDescendant<Button>(b => b.Name is "OkButton");
+        var cancelButton = presenter.FindDescendant<Button>(b => b.Name is "CancelButton");
+
+        _filterItemsControl = presenter.FindDescendant<TableViewFilterItemsControl>();
+        _filterItemsControl?.TableView = TableView;
+        _filterItemsControl?.ColumnHeader = ColumnHeader;
+        _okCommand.ExecuteRequested += delegate { ExecuteOkCommand(); };
+        _cancelCommand.ExecuteRequested += delegate { Hide(); };
+
+        okButton?.Command = _okCommand;
+        cancelButton?.Command = _cancelCommand;
+
+        presenter.Loaded -= OnPresenterLoaded;
+        _filterItemsControl?.Initialize();
+    }
+
+    /// <summary>
+    /// Executes the OK command, applying the filter and hiding the flyout.
+    /// </summary>
+    private void ExecuteOkCommand()
+    {
+        Hide();
+        ColumnHeader?.ApplyFilter();
+    }
+
+    /// <summary>
+    /// Gets or sets the TableView associated with this filter menu flyout.
+    /// </summary>
+    public TableView? TableView { get; set; }
+
+    /// <summary>
+    /// Gets or sets the TableViewColumnHeader associated with this filter menu flyout.
+    /// </summary>
+    public TableViewColumnHeader? ColumnHeader { get; set; }
+}

--- a/src/Themes/TableViewColumnHeader.xaml
+++ b/src/Themes/TableViewColumnHeader.xaml
@@ -186,7 +186,14 @@
                                                                                              IsDefaultShadowEnabled="False"
                                                                                              Margin="{TemplateBinding Padding}"
                                                                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                                                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                                                                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                                                                            <MenuFlyoutPresenter.Resources>
+                                                                                <Style TargetType="MenuFlyoutItem"
+                                                                                       BasedOn="{StaticResource DefaultMenuFlyoutItemStyle}">
+                                                                                    <Setter Property="Padding" Value="{StaticResource MenuFlyoutItemThemePaddingNarrow}" />
+                                                                                </Style>
+                                                                            </MenuFlyoutPresenter.Resources>
+                                                                        </MenuFlyoutPresenter>
 
                                                                         <controls:TableViewFilterItemsControl Grid.Row="1" />
 

--- a/src/Themes/TableViewColumnHeader.xaml
+++ b/src/Themes/TableViewColumnHeader.xaml
@@ -130,8 +130,62 @@
                                     </Grid>
 
                                     <Button.Flyout>
-                                        <MenuFlyout x:Name="OptionsFlyout"
+                                        <local:TableViewFilterMenuFlyout x:Name="OptionsFlyout"
                                                     Placement="Bottom">
+                                            <local:TableViewFilterMenuFlyout.MenuFlyoutPresenterStyle>
+                                                <Style TargetType="MenuFlyoutPresenter"
+                                                       BasedOn="{StaticResource DefaultMenuFlyoutPresenterStyle}">
+                                                    <Setter Property="Template">
+                                                        <Setter.Value>
+                                                            <ControlTemplate TargetType="MenuFlyoutPresenter">
+                                                                <Border Background="{TemplateBinding Background}"
+                                                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                                                        BackgroundSizing="InnerBorderEdge">
+                                                                    <Grid>
+                                                                        <Grid.RowDefinitions>
+                                                                            <RowDefinition Height="Auto" />
+                                                                            <RowDefinition Height="*" />
+                                                                            <RowDefinition Height="Auto" />
+                                                                        </Grid.RowDefinitions>
+                                                                        <ScrollViewer x:Name="MenuFlyoutPresenterScrollViewer"
+                                                                                      Margin="{TemplateBinding Padding}"
+                                                                                      MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.FlyoutContentMinWidth}"
+                                                                                      HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                                                                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                                                                      VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                                                                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                                                                      IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                                                                                      IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                                                                                      ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
+                                                                                      AutomationProperties.AccessibilityView="Raw">
+                                                                            <ItemsPresenter />
+                                                                        </ScrollViewer>
+
+                                                                        <controls:TableViewFilterItemsControl Grid.Row="1" />
+                                                                        
+                                                                        <Grid Grid.Row="2"
+                                                                              Margin="12,4"
+                                                                              ColumnSpacing="16">
+                                                                            <Grid.ColumnDefinitions>
+                                                                                <ColumnDefinition Width="*" />
+                                                                                <ColumnDefinition Width="*" />
+                                                                            </Grid.ColumnDefinitions>
+                                                                            <Button x:Name="OkButton"
+                                                                                    HorizontalAlignment="Stretch"
+                                                                                    Style="{StaticResource AccentButtonStyle}" />
+                                                                            <Button x:Name="CancelButton"
+                                                                                    Grid.Column="1"
+                                                                                    HorizontalAlignment="Stretch" />
+                                                                        </Grid>
+                                                                    </Grid>
+                                                                </Border>
+                                                            </ControlTemplate>
+                                                        </Setter.Value>
+                                                    </Setter>
+                                                </Style>
+                                            </local:TableViewFilterMenuFlyout.MenuFlyoutPresenterStyle>
                                             <MenuFlyoutItem x:Name="SortAscendingMenuItem">
                                                 <MenuFlyoutItem.Icon>
                                                     <FontIcon Glyph="&#xf0ad;" />
@@ -143,36 +197,9 @@
                                                 </MenuFlyoutItem.Icon>
                                             </MenuFlyoutItem>
                                             <MenuFlyoutItem x:Name="ClearSortingMenuItem" />
-                                            <MenuFlyoutSeparator />
+                                            <MenuFlyoutSeparator x:Name="MenuFlyoutSeparator" />
                                             <MenuFlyoutItem x:Name="ClearFilterMenuItem" />                                            
-                                            <MenuFlyoutItem x:Name="FilterItemsMenuItem">
-                                                <MenuFlyoutItem.Template>
-                                                    <ControlTemplate TargetType="MenuFlyoutItem">
-                                                        <controls:TableViewFilterItemsControl />
-                                                    </ControlTemplate>
-                                                </MenuFlyoutItem.Template>
-                                            </MenuFlyoutItem>
-                                            <MenuFlyoutSeparator />
-                                            <MenuFlyoutItem x:Name="ActionButtonsMenuItem">
-                                                <MenuFlyoutItem.Template>
-                                                    <ControlTemplate TargetType="MenuFlyoutItem">
-                                                        <Grid Margin="12,4"
-                                                              ColumnSpacing="16">
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="*" />
-                                                                <ColumnDefinition Width="*" />
-                                                            </Grid.ColumnDefinitions>
-                                                            <Button x:Name="OkButton"
-                                                                    HorizontalAlignment="Stretch"
-                                                                    Style="{StaticResource AccentButtonStyle}" />
-                                                            <Button x:Name="CancelButton"
-                                                                    Grid.Column="1"
-                                                                    HorizontalAlignment="Stretch" />
-                                                        </Grid>
-                                                    </ControlTemplate>
-                                                </MenuFlyoutItem.Template>
-                                            </MenuFlyoutItem>
-                                        </MenuFlyout>
+                                        </local:TableViewFilterMenuFlyout>
                                     </Button.Flyout>
                                 </Button>
                             </Grid>

--- a/src/Themes/TableViewColumnHeader.xaml
+++ b/src/Themes/TableViewColumnHeader.xaml
@@ -6,7 +6,7 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
+
     <Style x:Key="DefaultTableViewColumnHeaderStyle"
            TargetType="local:TableViewColumnHeader">
         <Setter Property="FontWeight"
@@ -131,13 +131,42 @@
 
                                     <Button.Flyout>
                                         <local:TableViewFilterMenuFlyout x:Name="OptionsFlyout"
-                                                    Placement="Bottom">
-                                            <local:TableViewFilterMenuFlyout.MenuFlyoutPresenterStyle>
-                                                <Style TargetType="MenuFlyoutPresenter"
-                                                       BasedOn="{StaticResource DefaultMenuFlyoutPresenterStyle}">
-                                                    <Setter Property="Template">
+                                                                         Placement="Bottom">
+                                            <local:TableViewFilterMenuFlyout.Items>
+                                                <MenuFlyoutItem x:Name="SortAscendingMenuItem">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xf0ad;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem x:Name="SortDescendingMenuItem">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xf0ae;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem x:Name="ClearSortingMenuItem" />
+                                                <MenuFlyoutSeparator x:Name="MenuFlyoutSeparator" />
+                                                <MenuFlyoutItem x:Name="ClearFilterMenuItem" />
+                                            </local:TableViewFilterMenuFlyout.Items>
+                                            <local:TableViewFilterMenuFlyout.FlyoutPresenterStyle>
+                                                <Style TargetType="FlyoutPresenter"
+                                                       BasedOn="{StaticResource DefaultFlyoutPresenterStyle}">                                                    
+                                                    <Setter Property="Background" Value="{ThemeResource FlyoutPresenterBackground}" />
+                                                    <Setter Property="BorderBrush" Value="{ThemeResource MenuFlyoutPresenterBorderBrush}" />
+                                                    <Setter Property="BorderThickness" Value="{ThemeResource MenuFlyoutPresenterBorderThemeThickness}" />
+                                                    <Setter Property="Padding" Value="{StaticResource MenuFlyoutPresenterThemePadding}" />
+                                                    <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
+                                                    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+                                                    <Setter Property="ScrollViewer.VerticalScrollMode" Value="Disabled" />
+                                                    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
+                                                    <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
+                                                    <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
+                                                    <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
+                                                    <Setter Property="MinWidth" Value="{ThemeResource FlyoutThemeMinWidth}" />
+                                                    <Setter Property="MinHeight" Value="{StaticResource MenuFlyoutThemeMinHeight}" />
+                                                    <Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
+                                                    <Setter Property="Template">                                                        
                                                         <Setter.Value>
-                                                            <ControlTemplate TargetType="MenuFlyoutPresenter">
+                                                            <ControlTemplate TargetType="FlyoutPresenter">
                                                                 <Border Background="{TemplateBinding Background}"
                                                                         BorderBrush="{TemplateBinding BorderBrush}"
                                                                         BorderThickness="{TemplateBinding BorderThickness}"
@@ -149,22 +178,18 @@
                                                                             <RowDefinition Height="*" />
                                                                             <RowDefinition Height="Auto" />
                                                                         </Grid.RowDefinitions>
-                                                                        <ScrollViewer x:Name="MenuFlyoutPresenterScrollViewer"
-                                                                                      Margin="{TemplateBinding Padding}"
-                                                                                      MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.FlyoutContentMinWidth}"
-                                                                                      HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-                                                                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                                                                      VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-                                                                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                                                                                      IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
-                                                                                      IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-                                                                                      ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
-                                                                                      AutomationProperties.AccessibilityView="Raw">
-                                                                            <ItemsPresenter />
-                                                                        </ScrollViewer>
+                                                                        <MenuFlyoutPresenter Background="Transparent"
+                                                                                             SystemBackdrop="{x:Null}"
+                                                                                             Padding="0"
+                                                                                             CornerRadius="0"
+                                                                                             BorderThickness="0"
+                                                                                             IsDefaultShadowEnabled="False"
+                                                                                             Margin="{TemplateBinding Padding}"
+                                                                                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                                                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
 
                                                                         <controls:TableViewFilterItemsControl Grid.Row="1" />
-                                                                        
+
                                                                         <Grid Grid.Row="2"
                                                                               Margin="12,4"
                                                                               ColumnSpacing="16">
@@ -185,20 +210,7 @@
                                                         </Setter.Value>
                                                     </Setter>
                                                 </Style>
-                                            </local:TableViewFilterMenuFlyout.MenuFlyoutPresenterStyle>
-                                            <MenuFlyoutItem x:Name="SortAscendingMenuItem">
-                                                <MenuFlyoutItem.Icon>
-                                                    <FontIcon Glyph="&#xf0ad;" />
-                                                </MenuFlyoutItem.Icon>
-                                            </MenuFlyoutItem>
-                                            <MenuFlyoutItem x:Name="SortDescendingMenuItem">
-                                                <MenuFlyoutItem.Icon>
-                                                    <FontIcon Glyph="&#xf0ae;" />
-                                                </MenuFlyoutItem.Icon>
-                                            </MenuFlyoutItem>
-                                            <MenuFlyoutItem x:Name="ClearSortingMenuItem" />
-                                            <MenuFlyoutSeparator x:Name="MenuFlyoutSeparator" />
-                                            <MenuFlyoutItem x:Name="ClearFilterMenuItem" />                                            
+                                            </local:TableViewFilterMenuFlyout.FlyoutPresenterStyle>                                                                               
                                         </local:TableViewFilterMenuFlyout>
                                     </Button.Flyout>
                                 </Button>


### PR DESCRIPTION
### Summary

This PR refactors the filter flyout implementation used by `TableViewColumnHeader` by introducing a dedicated `TableViewFilterMenuFlyout` class. The goal is to encapsulate filter-related UI and behavior within the flyout itself, reducing complexity in `TableViewColumnHeader` and improving maintainability.

This change also addresses issue #137 by replacing the existing flyout implementation with a custom flyout that manages its own lifecycle, commands, and filter interactions.


https://github.com/user-attachments/assets/800e9018-81aa-457c-acc1-af6fcc72cc20

