### PR TITLE
feat: Add clipboard paste support

### DIFF
--- a/samples/WinUI.TableView.SampleApp/MainPage.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/MainPage.xaml.cs
@@ -108,6 +108,7 @@ public sealed partial class MainPage : Page
                 "Filtering" => typeof(FilteringPage),
                 "Customize Filter Flyout" => typeof(CustomizeFilterPage),
                 "External Filtering" => typeof(ExternalFilteringPage),
+                "Clipboard Actions" => typeof(ClipboardActionsPage),
                 "Editing" => typeof(EditingPage),
                 "Sorting" => typeof(SortingPage),
                 "Custom Sorting" => typeof(CustomizeSortingPage),

--- a/samples/WinUI.TableView.SampleApp/Pages/ClipboardActionsPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/ClipboardActionsPage.xaml
@@ -12,7 +12,7 @@
     <Grid>
         <controls:SamplePresenter Header="Clipboard Actions">
             <controls:SamplePresenter.Description>
-                <x:String xml:space="preserve">Use Ctrl+C, Ctrl+Shift+V or the corner options menu to copy the current selection.
+                <x:String xml:space="preserve">Use Ctrl+C, Ctrl+Shift+C or the corner options menu to copy the current selection.
 Paste tab-delimited data from Excel with Ctrl+V or the same menu.</x:String>
             </controls:SamplePresenter.Description>
             <controls:SamplePresenter.Example>

--- a/samples/WinUI.TableView.SampleApp/Pages/ClipboardActionsPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/ClipboardActionsPage.xaml
@@ -17,15 +17,35 @@ Paste tab-delimited data from Excel with Ctrl+V or the same menu.</x:String>
             </controls:SamplePresenter.Description>
             <controls:SamplePresenter.Example>
                 <tv:TableView x:Name="tableView"
+                              CanCopy="{x:Bind canCopyToggle.IsOn, Mode=TwoWay}"
+                              CanPaste="{x:Bind canPasteToggle.IsOn, Mode=TwoWay}"
                               ItemsSource="{Binding Items}"
                               AutoGeneratingColumn="{x:Bind local:ExampleModelColumnsHelper.OnAutoGeneratingColumns}" />
             </controls:SamplePresenter.Example>
+            <controls:SamplePresenter.Options>
+                <StackPanel Spacing="8">
+                    <ToggleSwitch x:Name="canCopyToggle"
+                                  Header="Can Copy"
+                                  IsOn="True" />
+                    <ToggleSwitch x:Name="canPasteToggle"
+                                  Header="Can Paste"
+                                  IsOn="True" />
+                </StackPanel>
+            </controls:SamplePresenter.Options>
             <controls:SamplePresenter.Xaml>
                 <x:String xml:space="preserve">
 &lt;tv:TableView x:Name="tableView"
+    CanCopy="$(CanCopy)"
+    CanPaste="$(CanPaste)"
     ItemsSource="{Binding Items}" />
                 </x:String>
             </controls:SamplePresenter.Xaml>
+            <controls:SamplePresenter.Substitutions>
+                <controls:CodeSubstitution Key="CanCopy"
+                                           Value="{x:Bind tableView.CanCopy, Mode=OneWay}" />
+                <controls:CodeSubstitution Key="CanPaste"
+                                           Value="{x:Bind tableView.CanPaste, Mode=OneWay}" />
+            </controls:SamplePresenter.Substitutions>
         </controls:SamplePresenter>
     </Grid>
 </Page>

--- a/samples/WinUI.TableView.SampleApp/Pages/ClipboardActionsPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/ClipboardActionsPage.xaml
@@ -1,0 +1,31 @@
+<Page x:Class="WinUI.TableView.SampleApp.Pages.ClipboardActionsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:controls="using:WinUI.TableView.SampleApp.Controls"
+      xmlns:local="using:WinUI.TableView.SampleApp"
+      xmlns:tv="using:WinUI.TableView"
+      d:DataContext="{d:DesignInstance Type=local:ExampleViewModel}"
+      mc:Ignorable="d">
+
+    <Grid>
+        <controls:SamplePresenter Header="Clipboard Actions">
+            <controls:SamplePresenter.Description>
+                <x:String xml:space="preserve">Use Ctrl+C, Ctrl+Shift+V or the corner options menu to copy the current selection.
+Paste tab-delimited data from Excel with Ctrl+V or the same menu.</x:String>
+            </controls:SamplePresenter.Description>
+            <controls:SamplePresenter.Example>
+                <tv:TableView x:Name="tableView"
+                              ItemsSource="{Binding Items}"
+                              AutoGeneratingColumn="{x:Bind local:ExampleModelColumnsHelper.OnAutoGeneratingColumns}" />
+            </controls:SamplePresenter.Example>
+            <controls:SamplePresenter.Xaml>
+                <x:String xml:space="preserve">
+&lt;tv:TableView x:Name="tableView"
+    ItemsSource="{Binding Items}" />
+                </x:String>
+            </controls:SamplePresenter.Xaml>
+        </controls:SamplePresenter>
+    </Grid>
+</Page>

--- a/samples/WinUI.TableView.SampleApp/Pages/ClipboardActionsPage.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/Pages/ClipboardActionsPage.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System.Collections.ObjectModel;
+using Windows.ApplicationModel.DataTransfer;
+
+namespace WinUI.TableView.SampleApp.Pages;
+
+public sealed partial class ClipboardActionsPage : Page
+{
+    public ClipboardActionsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -15,9 +15,9 @@ namespace WinUI.TableView;
 [StyleTypedProperty(Property = nameof(CellStyle), StyleTargetType = typeof(TableViewCell))]
 public abstract partial class TableViewColumn : DependencyObject
 {
-    private Func<object, object?>? _funcCompiledPropertyPath;
-    private Func<object, object?>? _funcCompiledClipboardPropertyPath;
-    private Action<object, object?>? _compliedValueSetter;
+    private Func<object, object?>? _compliedValueGetter;
+    private Func<object, object?>? _compliedClipboardValueGetter;
+    private Action<object, object?>? _compliedClipboardValueSetter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TableViewColumn"/> class with default conditional cell styles.
@@ -108,11 +108,11 @@ public abstract partial class TableViewColumn : DependencyObject
         if (dataItem is null)
             return null;
 
-        if (_funcCompiledPropertyPath is null && !string.IsNullOrWhiteSpace(OperationContentBindingPropertyPath))
-            _funcCompiledPropertyPath = dataItem.GetFuncCompiledPropertyPath(OperationContentBindingPropertyPath!);
+        if (_compliedValueGetter is null && !string.IsNullOrWhiteSpace(OperationContentBindingPropertyPath))
+            _compliedValueGetter = dataItem.GetCompiledValueGetter(OperationContentBindingPropertyPath!);
 
-        if (_funcCompiledPropertyPath is not null)
-            dataItem = _funcCompiledPropertyPath(dataItem);
+        if (_compliedValueGetter is not null)
+            dataItem = _compliedValueGetter(dataItem);
 
         if (OperationContentBinding?.Converter is not null)
         {
@@ -136,11 +136,11 @@ public abstract partial class TableViewColumn : DependencyObject
         if (dataItem is null)
             return null;
 
-        if (_funcCompiledClipboardPropertyPath is null && !string.IsNullOrWhiteSpace(ClipboardContentBindingPropertyPath))
-            _funcCompiledClipboardPropertyPath = dataItem.GetFuncCompiledPropertyPath(ClipboardContentBindingPropertyPath!);
+        if (_compliedClipboardValueGetter is null && !string.IsNullOrWhiteSpace(ClipboardContentBindingPropertyPath))
+            _compliedClipboardValueGetter = dataItem.GetCompiledValueGetter(ClipboardContentBindingPropertyPath!);
 
-        if (_funcCompiledClipboardPropertyPath is not null)
-            dataItem = _funcCompiledClipboardPropertyPath(dataItem);
+        if (_compliedClipboardValueGetter is not null)
+            dataItem = _compliedClipboardValueGetter(dataItem);
 
         if (ClipboardContentBinding?.Converter is not null)
         {
@@ -167,8 +167,8 @@ public abstract partial class TableViewColumn : DependencyObject
 
         try
         {
-            if (_compliedValueSetter is null && !string.IsNullOrWhiteSpace(ClipboardContentBindingPropertyPath))
-                _compliedValueSetter = dataItem.GetCompiledValueSetter(ClipboardContentBindingPropertyPath!);
+            if (_compliedClipboardValueSetter is null && !string.IsNullOrWhiteSpace(ClipboardContentBindingPropertyPath))
+                _compliedClipboardValueSetter = dataItem.GetCompiledValueSetter(ClipboardContentBindingPropertyPath!);
 
             if (ClipboardContentBinding?.Converter is not null)
             {
@@ -179,7 +179,7 @@ public abstract partial class TableViewColumn : DependencyObject
                     ClipboardContentBinding.ConverterLanguage);
             }
 
-            _compliedValueSetter?.Invoke(dataItem, value);
+            _compliedClipboardValueSetter?.Invoke(dataItem, value);
             return true;
         }
         catch (Exception ex)

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -170,6 +170,9 @@ public abstract partial class TableViewColumn : DependencyObject
             if (_compliedClipboardValueSetter is null && !string.IsNullOrWhiteSpace(ClipboardContentBindingPropertyPath))
                 _compliedClipboardValueSetter = dataItem.GetCompiledValueSetter(ClipboardContentBindingPropertyPath!);
 
+            if (_compliedClipboardValueSetter is null)
+                return false;
+
             if (ClipboardContentBinding?.Converter is not null)
             {
                 value = ClipboardContentBinding.Converter.ConvertBack(
@@ -179,7 +182,7 @@ public abstract partial class TableViewColumn : DependencyObject
                     ClipboardContentBinding.ConverterLanguage);
             }
 
-            _compliedClipboardValueSetter?.Invoke(dataItem, value);
+            _compliedClipboardValueSetter(dataItem, value);
             return true;
         }
         catch (Exception ex)

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -2,6 +2,7 @@
 using Microsoft.UI.Xaml.Data;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using WinUI.TableView.Extensions;
 using SD = WinUI.TableView.SortDirection;
 
@@ -16,6 +17,7 @@ public abstract partial class TableViewColumn : DependencyObject
 {
     private Func<object, object?>? _funcCompiledPropertyPath;
     private Func<object, object?>? _funcCompiledClipboardPropertyPath;
+    private Action<object, object?>? _compliedValueSetter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TableViewColumn"/> class with default conditional cell styles.
@@ -150,6 +152,41 @@ public abstract partial class TableViewColumn : DependencyObject
         }
 
         return dataItem;
+    }
+
+    /// <summary>
+    /// Sets the content from the clipboard to the specified data item.
+    /// </summary>
+    /// <param name="dataItem">The data item.</param>
+    /// <param name="value">The value to set.</param>
+    /// <returns><see langword="true"/> if the value was set; otherwise, <see langword="false"/>.</returns>
+    public virtual bool SetClipboardContent(object? dataItem, object? value)
+    {
+        if (dataItem is null)
+            return false;
+
+        try
+        {
+            if (_compliedValueSetter is null && !string.IsNullOrWhiteSpace(ClipboardContentBindingPropertyPath))
+                _compliedValueSetter = dataItem.GetCompiledValueSetter(ClipboardContentBindingPropertyPath!);
+
+            if (ClipboardContentBinding?.Converter is not null)
+            {
+                value = ClipboardContentBinding.Converter.ConvertBack(
+                    value,
+                    typeof(object),
+                    ClipboardContentBinding.ConverterParameter,
+                    ClipboardContentBinding.ConverterLanguage);
+            }
+
+            _compliedValueSetter?.Invoke(dataItem, value);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"TableViewColumn: SetClipboardContent failed: {ex}");
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/EventArgs/TableViewPasteFromClipboardEventArgs.cs
+++ b/src/EventArgs/TableViewPasteFromClipboardEventArgs.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Provides data for the <see cref="TableView.PasteFromClipboard"/> event.
+/// </summary>
+public class TableViewPasteFromClipboardEventArgs : HandledEventArgs
+{
+    
+}

--- a/src/Extensions/ObjectExtensions.cs
+++ b/src/Extensions/ObjectExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -39,6 +41,471 @@ internal static partial class ObjectExtensions
         {
             return null;
         }
+    }
+
+    internal static Action<object, object?>? GetCompiledValueSetter(this object dataItem, string bindingPath)
+    {
+        try
+        {
+            var parameterObj = Expression.Parameter(typeof(object), "obj");
+            var parameterValue = Expression.Parameter(typeof(object), "value");
+
+            var expressionTree = BuildPropertyPathSetterExpressionTree(
+                parameterObj,
+                parameterValue,
+                bindingPath,
+                dataItem);
+
+            var lambda = Expression.Lambda<Action<object, object?>>(
+                expressionTree,
+                parameterObj,
+                parameterValue);
+
+            return lambda.Compile();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static Expression BuildPropertyPathSetterExpressionTree(ParameterExpression parameterObj, ParameterExpression parameterValue, string bindingPath, object dataItem)
+    {
+        var matches = PropertyPathRegex().Matches(bindingPath);
+
+        if (matches.Count == 0)
+            throw new ArgumentException("Binding path is empty.", nameof(bindingPath));
+
+        Expression current = parameterObj;
+
+        var actualType = dataItem.GetType();
+
+        if (current.Type != actualType && !actualType.IsValueType)
+            current = Expression.Convert(current, actualType);
+
+        // Navigate to the parent object of the final path segment.
+        for (int i = 0; i < matches.Count - 1; i++)
+        {
+            var part = matches[i].Value;
+
+            current = part.StartsWith('[') && part.EndsWith(']')
+                ? BuildIndexerGetterExpression(current, part)
+                : BuildPropertyGetterExpression(current, part);
+
+            var lambdaTemp = Expression.Lambda<Func<object, object?>>(
+                EnsureObjectCompatibleResult(current),
+                parameterObj);
+
+            var currentValue = lambdaTemp.Compile()(dataItem);
+
+            if (currentValue is null)
+                throw new ArgumentException($"Cannot build setter. Path segment '{part}' evaluates to null.");
+
+            var runtimeType = currentValue.GetType();
+
+            if (current.Type != runtimeType)
+                current = Expression.Convert(current, runtimeType);
+        }
+
+        var finalPart = matches[^1].Value;
+
+        return finalPart.StartsWith('[') && finalPart.EndsWith(']')
+            ? BuildIndexerSetterExpression(current, finalPart, parameterValue)
+            : BuildPropertySetterExpression(current, finalPart, parameterValue);
+    }
+
+    private static Expression BuildPropertyGetterExpression(Expression current, string propertyName)
+    {
+        var propertyInfo = current.Type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new ArgumentException($"Property '{propertyName}' not found on type '{current.Type.Name}'.");
+
+        return Expression.Property(current, propertyInfo);
+    }
+
+    private static Expression BuildIndexerGetterExpression(Expression current, string indexerPart)
+    {
+        var indices = GetIndices(indexerPart[1..^1]);
+
+        if (current.Type.IsArray)
+        {
+            if (!indices.All(index => index is int))
+                throw new ArgumentException($"Arrays only support integer indexing: {indexerPart}");
+
+            return AddArrayAccessWithBoundsCheck(current, [.. indices.Select(index => (int)index)]);
+        }
+
+        return AddIndexerAccessWithSafetyChecks(current, indices);
+    }
+
+    private static Expression BuildPropertySetterExpression(Expression current, string propertyName, Expression value)
+    {
+        var propertyInfo = current.Type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+        ?? throw new ArgumentException($"Property '{propertyName}' not found on type '{current.Type.Name}'.");
+
+        if (!propertyInfo.CanWrite)
+            throw new ArgumentException($"Property '{propertyName}' is read-only.");
+
+        var target = Expression.Property(current, propertyInfo);
+
+        return BuildConvertedAssignExpression(target, value, propertyInfo.PropertyType);
+    }
+
+    private static Expression BuildIndexerSetterExpression(Expression current, string indexerPart, Expression value)
+    {
+        var indices = GetIndices(indexerPart[1..^1]);
+
+        if (current.Type.IsArray)
+            return BuildArraySetterExpression(current, indices, value);
+
+        return BuildObjectIndexerSetterExpression(current, indices, value);
+    }
+
+    private static Expression BuildArraySetterExpression(Expression current, object[] indices, Expression value)
+    {
+        if (!indices.All(index => index is int))
+            throw new ArgumentException("Arrays only support integer indexers.");
+
+        var arrayType = current.Type;
+        var elementType = arrayType.GetElementType()!;
+        var rank = arrayType.GetArrayRank();
+
+        if (indices.Length != rank)
+            throw new ArgumentException($"Array rank mismatch. Expected {rank} index(es).");
+
+        var arrayVar = Expression.Parameter(arrayType, "array");
+        var assignArray = Expression.Assign(arrayVar, current);
+
+        var indexExpressions = indices
+            .Cast<int>()
+            .Select(index => Expression.Constant(index))
+            .ToArray();
+
+        Expression? boundsCheck = null;
+
+        var getLengthMethod = typeof(Array).GetMethod(nameof(Array.GetLength))!;
+
+        for (var i = 0; i < indexExpressions.Length; i++)
+        {
+            var index = (int)indices[i];
+
+            if (index < 0)
+                throw new ArgumentOutOfRangeException(nameof(indices));
+
+            var length = Expression.Call(arrayVar, getLengthMethod, Expression.Constant(i));
+            var check = Expression.LessThan(indexExpressions[i], length);
+
+            boundsCheck = boundsCheck is null
+                ? check
+                : Expression.AndAlso(boundsCheck, check);
+        }
+
+        var assignValue = BuildConvertedAssignExpression(
+            Expression.ArrayAccess(arrayVar, indexExpressions),
+            value,
+            elementType);
+
+        return Expression.Block(
+            [arrayVar],
+            assignArray,
+            Expression.IfThen(boundsCheck!, assignValue));
+    }
+
+    private static Expression BuildObjectIndexerSetterExpression(Expression current, object[] indices, Expression value)
+    {
+        if (indices.Length == 1)
+        {
+            var dictionaryInterface = current.Type.GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType &&
+                                     i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+
+            if (dictionaryInterface is not null)
+            {
+                var args = dictionaryInterface.GetGenericArguments();
+                var keyType = args[0];
+                var valueType = args[1];
+
+                if (!keyType.IsAssignableFrom(indices[0].GetType()))
+                    return Expression.Empty();
+
+                var indexer = dictionaryInterface.GetProperty("Item")!;
+
+                var target = Expression.Property(Expression.Convert(current, dictionaryInterface),
+                    indexer,
+                    Expression.Constant(indices[0], keyType));
+
+                return BuildConvertedAssignExpression(target, value, valueType);
+            }
+        }
+
+        var indexerTypes = indices.Select(index => index.GetType()).ToArray();
+
+        var indexerProperty = current.Type.GetProperty("Item", indexerTypes)
+            ?? throw new ArgumentException($"Indexer not found on type '{current.Type.Name}'.");
+
+        if (!indexerProperty.CanWrite)
+            throw new ArgumentException($"Indexer on type '{current.Type.Name}' is read-only.");
+
+        var indexExpressions = indices
+            .Select(index => Expression.Constant(index, index.GetType()))
+            .ToArray();
+
+        // Add bounds checking for IList/ICollection types with integer indexers
+        if (indices.Length == 1 && indices[0] is int intIndex)
+        {
+            var listInterface = current.Type.GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType &&
+                                (i.GetGenericTypeDefinition() == typeof(IList<>) ||
+                                 i.GetGenericTypeDefinition() == typeof(ICollection<>)));
+
+            if (listInterface != null ||
+                typeof(IList).IsAssignableFrom(current.Type) ||
+                typeof(ICollection).IsAssignableFrom(current.Type))
+            {
+                var countProperty = current.Type.GetProperty("Count");
+
+                if (countProperty != null)
+                {
+                    var collectionVar = Expression.Parameter(current.Type, "collection");
+                    var assignCollection = Expression.Assign(collectionVar, current);
+
+                    var countExpr = Expression.Property(collectionVar, countProperty);
+                    var indexExpr = Expression.Constant(intIndex);
+
+                    // Check if index >= 0 && index < Count
+                    var boundsCheck = Expression.AndAlso(
+                        Expression.GreaterThanOrEqual(indexExpr, Expression.Constant(0)),
+                        Expression.LessThan(indexExpr, countExpr));
+
+                    var assignValue = BuildConvertedAssignExpression(
+                        Expression.Property(collectionVar, indexerProperty, indexExpressions),
+                        value,
+                        indexerProperty.PropertyType);
+
+                    return Expression.Block(
+                        [collectionVar],
+                        assignCollection,
+                        Expression.IfThen(boundsCheck, assignValue));
+                }
+            }
+        }
+
+        return BuildConvertedAssignExpression(
+            Expression.Property(current, indexerProperty, indexExpressions),
+            value,
+            indexerProperty.PropertyType);
+    }
+
+    private static Expression BuildConvertedAssignExpression(Expression target, Expression value, Type targetType)
+    {
+        var convertedValue = Expression.Variable(typeof(object), "convertedValue");
+        var error = Expression.Variable(typeof(string), "error");
+
+        var tryConvertMethod = typeof(ObjectExtensions)
+            .GetMethod(
+                nameof(TryConvertValue),
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        var tryConvertCall = Expression.Call(
+            tryConvertMethod,
+            value,
+            Expression.Constant(targetType),
+            convertedValue,
+            error);
+
+        return Expression.Block(
+            [convertedValue, error],
+            Expression.IfThen(
+                tryConvertCall,
+                Expression.Assign(
+                    target,
+                    Expression.Convert(convertedValue, targetType))));
+    }
+
+    private static bool TryConvertValue(object? value, Type targetType, out object? convertedValue, out string? error)
+    {
+        if (targetType == typeof(object))
+        {
+            error = null;
+            convertedValue = value;
+            return true;
+        }
+
+        if (value is string || value is null)
+            return TryConvertToTargetType(value as string, targetType, out convertedValue, out error);
+
+        return TryConvertObject(value, targetType, out convertedValue, out error);
+    }
+
+    private static bool TryConvertToTargetType(string? stringValue, Type targetType, out object? convertedValue, out string? error)
+    {
+        error = null;
+        convertedValue = null;
+
+        var underlyingType = Nullable.GetUnderlyingType(targetType);
+        var actualTargetType = underlyingType ?? targetType;
+
+        if (actualTargetType == typeof(string))
+        {
+            convertedValue = stringValue ?? string.Empty;
+            return true;
+        }
+
+        if (stringValue is null)
+        {
+            if (underlyingType is not null || !targetType.IsValueType)
+            {
+                return true;
+            }
+
+            error = $"The target type '{targetType.Name}' does not accept null values.";
+            return false;
+        }
+
+        if (stringValue.Length == 0)
+        {
+            if (underlyingType is not null || !targetType.IsValueType)
+            {
+                return true;
+            }
+
+            error = $"The target type '{targetType.Name}' does not accept empty values.";
+            return false;
+        }
+
+        try
+        {
+            if (actualTargetType == typeof(bool))
+            {
+                if (bool.TryParse(stringValue, out var boolValue))
+                {
+                    convertedValue = boolValue;
+                    return true;
+                }
+
+                if (stringValue == "1" || stringValue.Equals("yes", StringComparison.OrdinalIgnoreCase))
+                {
+                    convertedValue = true;
+                    return true;
+                }
+
+                if (stringValue == "0" || stringValue.Equals("no", StringComparison.OrdinalIgnoreCase))
+                {
+                    convertedValue = false;
+                    return true;
+                }
+            }
+            else if (actualTargetType == typeof(DateOnly))
+            {
+                convertedValue = DateOnly.Parse(stringValue, CultureInfo.CurrentCulture);
+                return true;
+            }
+            else if (actualTargetType == typeof(TimeOnly))
+            {
+                convertedValue = TimeOnly.Parse(stringValue, CultureInfo.CurrentCulture);
+                return true;
+            }
+            else if (actualTargetType == typeof(DateTime))
+            {
+                convertedValue = DateTime.Parse(stringValue, CultureInfo.CurrentCulture);
+                return true;
+            }
+            else if (actualTargetType == typeof(DateTimeOffset))
+            {
+                convertedValue = DateTimeOffset.Parse(stringValue, CultureInfo.CurrentCulture);
+                return true;
+            }
+            else if (actualTargetType == typeof(TimeSpan))
+            {
+                convertedValue = TimeSpan.Parse(stringValue, CultureInfo.CurrentCulture);
+                return true;
+            }
+            else if (actualTargetType == typeof(Guid))
+            {
+                convertedValue = Guid.Parse(stringValue);
+                return true;
+            }
+            else if (actualTargetType == typeof(Uri))
+            {
+                convertedValue = new Uri(stringValue, UriKind.RelativeOrAbsolute);
+                return true;
+            }
+            else if (actualTargetType.IsEnum)
+            {
+                convertedValue = Enum.Parse(actualTargetType, stringValue, ignoreCase: true);
+                return true;
+            }
+
+            var converter = TypeDescriptor.GetConverter(actualTargetType);
+            if (converter.CanConvertFrom(typeof(string)))
+            {
+                convertedValue = converter.ConvertFrom(null, CultureInfo.CurrentCulture, stringValue);
+                return true;
+            }
+
+            convertedValue = Convert.ChangeType(stringValue, actualTargetType, CultureInfo.CurrentCulture);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"Unable to convert '{stringValue}' to '{actualTargetType.Name}': {ex.Message}";
+            return false;
+        }
+    }
+
+    private static bool TryConvertObject(object? value, Type targetType, out object? convertedValue, out string? error)
+    {
+        error = null;
+        convertedValue = null;
+
+        if (value is null)
+        {
+            if (!targetType.IsValueType || Nullable.GetUnderlyingType(targetType) is not null)
+            {
+                return true;
+            }
+
+            error = $"The target type '{targetType.Name}' does not accept null values.";
+            return false;
+        }
+
+        var actualTargetType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        if (actualTargetType.IsInstanceOfType(value))
+        {
+            convertedValue = value;
+            return true;
+        }
+
+        try
+        {
+            convertedValue = Convert.ChangeType(value, actualTargetType, CultureInfo.CurrentCulture);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"Unable to convert '{value}' to '{actualTargetType.Name}': {ex.Message}";
+            return false;
+        }
+    }
+
+    private static Expression ConvertValueExpression(Expression value, Type targetType)
+    {
+        if (targetType == typeof(object))
+            return value;
+
+        var nullableType = Nullable.GetUnderlyingType(targetType);
+
+        if (nullableType is not null)
+        {
+            return Expression.Condition(
+                Expression.Equal(value, Expression.Constant(null)),
+                Expression.Constant(null, targetType),
+                Expression.Convert(value, targetType));
+        }
+
+        if (!targetType.IsValueType)
+            return Expression.Convert(value, targetType);
+
+        return Expression.Convert(value, targetType);
     }
 
     /// <summary>

--- a/src/Extensions/ObjectExtensions.cs
+++ b/src/Extensions/ObjectExtensions.cs
@@ -25,7 +25,7 @@ internal static partial class ObjectExtensions
     /// <param name="dataItem">The data item instance to use for runtime type evaluation.</param>
     /// <param name="bindingPath">The binding path to access, e.g. "[0].SubPropertyArray[0].SubSubProperty".</param>
     /// <returns>A compiled function that takes an instance and returns the property value, or null if the property path is invalid.</returns>
-    internal static Func<object, object?>? GetFuncCompiledPropertyPath(this object dataItem, string bindingPath)
+    internal static Func<object, object?>? GetCompiledValueGetter(this object dataItem, string bindingPath)
     {
         try
         {

--- a/src/ItemsSource/SortDescription.cs
+++ b/src/ItemsSource/SortDescription.cs
@@ -10,7 +10,7 @@ namespace WinUI.TableView;
 /// </summary>
 public class SortDescription
 {
-    private Func<object, object?>? _funcCompiled;
+    private Func<object, object?>? _compiledValueGetter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SortDescription"/> class that describes
@@ -42,10 +42,10 @@ public class SortDescription
         
         if (ValueDelegate is not null) return ValueDelegate(item);
         
-        if (_funcCompiled is null && !string.IsNullOrWhiteSpace(PropertyName))
-            _funcCompiled = item.GetFuncCompiledPropertyPath(PropertyName!);
+        if (_compiledValueGetter is null && !string.IsNullOrWhiteSpace(PropertyName))
+            _compiledValueGetter = item.GetCompiledValueGetter(PropertyName!);
             
-        return _funcCompiled?.Invoke(item);
+        return _compiledValueGetter?.Invoke(item);
 }
 
     /// <summary>

--- a/src/Strings/de-DE/WinUI.TableView.resw
+++ b/src/Strings/de-DE/WinUI.TableView.resw
@@ -180,4 +180,10 @@
   <data name="Copy" xml:space="preserve">
     <value>Kopieren</value>
   </data>
+  <data name="Paste" xml:space="preserve">
+    <value>Einfügen</value>
+  </data>
+  <data name="PasteCommandDescription" xml:space="preserve">
+    <value>Fügt den Inhalt der Zwischenablage in die Zellen ein.</value>
+  </data>
 </root>

--- a/src/Strings/en-US/WinUI.TableView.resw
+++ b/src/Strings/en-US/WinUI.TableView.resw
@@ -184,6 +184,6 @@
     <value>Paste</value>
   </data>
   <data name="PasteCommandDescription" xml:space="preserve">
-    <value>Paste clipboard content into the selected cells.</value>
+    <value>Paste clipboard content into the cells.</value>
   </data>
 </root>

--- a/src/Strings/en-US/WinUI.TableView.resw
+++ b/src/Strings/en-US/WinUI.TableView.resw
@@ -180,4 +180,10 @@
   <data name="Copy" xml:space="preserve">
     <value>Copy</value>
   </data>
+  <data name="Paste" xml:space="preserve">
+    <value>Paste</value>
+  </data>
+  <data name="PasteCommandDescription" xml:space="preserve">
+    <value>Paste clipboard content into the selected cells.</value>
+  </data>
 </root>

--- a/src/Strings/es-ES/WinUI.TableView.resw
+++ b/src/Strings/es-ES/WinUI.TableView.resw
@@ -180,4 +180,10 @@
   <data name="TimePickerPlaceholder" xml:space="preserve">
     <value>Seleccionar una hora</value>
   </data>
+  <data name="Paste" xml:space="preserve">
+    <value>Pegar</value>
+  </data>
+  <data name="PasteCommandDescription" xml:space="preserve">
+    <value>Pega el contenido del portapapeles en las celdas.</value>
+  </data>
 </root>

--- a/src/Strings/ja-JP/WinUI.TableView.resw
+++ b/src/Strings/ja-JP/WinUI.TableView.resw
@@ -188,4 +188,10 @@
   <data name="Copy" xml:space="preserve">
     <value>コピー</value>
   </data>
+  <data name="Paste" xml:space="preserve">
+    <value>貼り付け</value>
+  </data>
+  <data name="PasteCommandDescription" xml:space="preserve">
+    <value>クリップボードのコンテンツをセルに貼り付けます。</value>
+  </data>
 </root>

--- a/src/Strings/pt-BR/WinUI.TableView.resw
+++ b/src/Strings/pt-BR/WinUI.TableView.resw
@@ -180,4 +180,10 @@
   <data name="Copy" xml:space="preserve">
     <value>Copiar</value>
   </data>
+  <data name="Paste" xml:space="preserve">
+    <value>Colar</value>
+  </data>
+  <data name="PasteCommandDescription" xml:space="preserve">
+    <value>Cola o conteúdo da área de transferência nas células.</value>
+  </data>
 </root>

--- a/src/Strings/ru-RU/WinUI.TableView.resw
+++ b/src/Strings/ru-RU/WinUI.TableView.resw
@@ -180,4 +180,10 @@
   <data name="Copy" xml:space="preserve">
     <value>Копировать</value>
   </data>
+  <data name="Paste" xml:space="preserve">
+    <value>Вставить</value>
+  </data>
+  <data name="PasteCommandDescription" xml:space="preserve">
+    <value>Вставить содержимое буфера обмена в ячейки.</value>
+  </data>
 </root>

--- a/src/Strings/sk-SK/WinUI.TableView.resw
+++ b/src/Strings/sk-SK/WinUI.TableView.resw
@@ -180,4 +180,10 @@
   <data name="Copy" xml:space="preserve">
     <value>Kopírovať</value>
   </data>
+  <data name="Paste" xml:space="preserve">
+    <value>Prilepiť</value>
+  </data>
+  <data name="PasteCommandDescription" xml:space="preserve">
+    <value>Prilepiť obsah schránky do buniek.</value>
+  </data>
 </root>

--- a/src/Strings/zh-CN/WinUI.TableView.resw
+++ b/src/Strings/zh-CN/WinUI.TableView.resw
@@ -180,4 +180,10 @@
   <data name="Copy" xml:space="preserve">
     <value>复制</value>
   </data>
+  <data name="Paste" xml:space="preserve">
+    <value>粘贴</value>
+  </data>
+  <data name="PasteCommandDescription" xml:space="preserve">
+    <value>将剪贴板内容粘贴到单元格中。</value>
+  </data>
 </root>

--- a/src/Strings/zh-TW/WinUI.TableView.resw
+++ b/src/Strings/zh-TW/WinUI.TableView.resw
@@ -180,4 +180,10 @@
   <data name="Copy" xml:space="preserve">
     <value>複製</value>
   </data>
+  <data name="Paste" xml:space="preserve">
+    <value>貼上</value>
+  </data>
+  <data name="PasteCommandDescription" xml:space="preserve">
+    <value>將剪貼簿內容貼上到儲存格中。</value>
+  </data>
 </root>

--- a/src/TableView.Events.cs
+++ b/src/TableView.Events.cs
@@ -66,6 +66,20 @@ partial class TableView
     }
 
     /// <summary>
+    /// Event triggered when pasting clipboard content into the TableView.
+    /// </summary>
+    public event EventHandler<TableViewPasteFromClipboardEventArgs>? PasteFromClipboard;
+
+    /// <summary>
+    /// Called before the <see cref="PasteFromClipboard"/> event occurs.
+    /// </summary>
+    /// <param name="args">Handleable event args.</param>
+    protected virtual void OnPasteFromClipboard(TableViewPasteFromClipboardEventArgs args)
+    {
+        PasteFromClipboard?.Invoke(this, args);
+    }
+
+    /// <summary>
     /// Event triggered when the IsReadOnly property changes.
     /// </summary>
     public event DependencyPropertyChangedEventHandler? IsReadOnlyChanged;

--- a/src/TableView.Paste.cs
+++ b/src/TableView.Paste.cs
@@ -38,6 +38,7 @@ public partial class TableView
     /// </summary>
     private async void PasteFromClipboardAsync()
     {
+        var previousAllowLiveShaping = _collectionView.AllowLiveShaping;
         try
         {
             var content = Clipboard.GetContent();
@@ -59,10 +60,11 @@ public partial class TableView
                     RefreshView();
             }
 
-            _collectionView.AllowLiveShaping = true;
+            _collectionView.AllowLiveShaping = previousAllowLiveShaping;
         }
         catch (Exception ex)
         {
+            _collectionView.AllowLiveShaping = previousAllowLiveShaping;
             Debug.WriteLine($"TableView: Clipboard.GetText failed: {ex}");
         }
     }
@@ -109,9 +111,11 @@ public partial class TableView
                 var column = Columns.VisibleColumns[columnIndex];
                 var value = values[valueIndex];
 
-                if (column.IsReadOnly) continue;
+                if (!column.IsReadOnly)
+                {
+                    pastedAnyValue |= column.SetClipboardContent(item, value);
+                }
 
-                pastedAnyValue = column.SetClipboardContent(item, value);
                 columnIndex++;
             }
         }

--- a/src/TableView.Paste.cs
+++ b/src/TableView.Paste.cs
@@ -21,19 +21,22 @@ public partial class TableView
     /// <returns>True if the paste operation was initiated successfully; otherwise, false.</returns>
     internal bool TryStartPasteFromClipboard()
     {
-        if (!CanHandlePasteRequest())
+        var args = new TableViewPasteFromClipboardEventArgs();
+        OnPasteFromClipboard(args);
+
+        if (args.Handled || !CanHandlePasteRequest())
         {
             return false;
         }
 
-        PasteFromClipboard();
+        PasteFromClipboardAsync();
         return true;
     }
 
     /// <summary>
     /// Handles the actual paste operation from the clipboard.
     /// </summary>
-    private async void PasteFromClipboard()
+    private async void PasteFromClipboardAsync()
     {
         try
         {
@@ -143,15 +146,15 @@ public partial class TableView
     /// Determines whether the TableView can handle a paste request based on its current state.
     /// </summary>
     /// <returns>True if the TableView can handle the paste request; otherwise, false.</returns>
-    private bool CanHandlePasteRequest()
+    internal bool CanHandlePasteRequest()
     {
-        if (IsReadOnly || IsEditing || Columns.VisibleColumns.Count == 0 || Items.Count == 0)
+        var focused = FocusManager.GetFocusedElement(XamlRoot!) as FrameworkElement;
+        if (focused is TextBox or PasswordBox or RichEditBox)
         {
             return false;
         }
 
-        var focused = FocusManager.GetFocusedElement(XamlRoot!) as FrameworkElement;
-        return focused is not TextBox and not PasswordBox and not RichEditBox;
+        return CanPaste && !IsReadOnly && !IsEditing && Columns.VisibleColumns.Count != 0 && Items.Count != 0;
     }
 
     /// <summary>

--- a/src/TableView.Paste.cs
+++ b/src/TableView.Paste.cs
@@ -1,0 +1,225 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Windows.ApplicationModel.DataTransfer;
+using WinUI.TableView.Helpers;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Provides clipboard paste functionality for the TableView control, allowing users to paste tabular data from the clipboard into the table.
+/// </summary>
+public partial class TableView
+{
+    /// <summary>
+    /// Attempts to initiate a paste operation from the clipboard. 
+    /// </summary>
+    /// <returns>True if the paste operation was initiated successfully; otherwise, false.</returns>
+    internal bool TryStartPasteFromClipboard()
+    {
+        if (!CanHandlePasteRequest())
+        {
+            return false;
+        }
+
+        PasteFromClipboard();
+        return true;
+    }
+
+    /// <summary>
+    /// Handles the actual paste operation from the clipboard.
+    /// </summary>
+    private async void PasteFromClipboard()
+    {
+        try
+        {
+            var content = Clipboard.GetContent();
+            if (!content.Contains(StandardDataFormats.Text))
+            {
+                Debug.WriteLine("TableView: Clipboard does not contain text data to paste.");
+                return;
+            }
+
+            _collectionView.AllowLiveShaping = false;
+
+            var text = await content.GetTextAsync();
+            var pastedAnyValue = PasteClipboardTextInternal(text);
+
+            if (pastedAnyValue)
+            {
+                // Refresh the view to ensure any changes are reflected in the UI
+                if (SortDescriptions.Count > 0 || FilterDescriptions.Count > 0)
+                    RefreshView();
+            }
+
+            _collectionView.AllowLiveShaping = true;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"TableView: Clipboard.GetText failed: {ex}");
+        }
+    }
+
+    /// <summary>
+    /// Processes the clipboard text and pastes it into the table starting from the determined anchor cell.
+    /// </summary>
+    /// <param name="text">The text content from the clipboard to be pasted into the table.</param>
+    /// <returns>True if any value was successfully pasted; otherwise, false.</returns>
+    private bool PasteClipboardTextInternal(string? text)
+    {
+        var rows = ParseClipboardText(text);
+        if (rows.Count == 0)
+        {
+            return false;
+        }
+
+        if (!TryGetPasteAnchor(out var anchor))
+        {
+            Debug.WriteLine("TableView: Paste requires a current cell or a selected row/cell.");
+            return false;
+        }
+
+        var pastedAnyValue = false;
+        for (var rowOffset = 0; rowOffset < rows.Count; rowOffset++)
+        {
+            var rowIndex = anchor.Row + rowOffset;
+            if (rowIndex < 0 || rowIndex >= Items.Count)
+            {
+                break;
+            }
+
+            if (Items[rowIndex] is not object item)
+            {
+                continue;
+            }
+
+            var values = rows[rowOffset];
+            var columnIndex = anchor.Column;
+            for (var valueIndex = 0; valueIndex < values.Length; valueIndex++)
+            {
+                if (columnIndex >= Columns.VisibleColumns.Count) break;
+
+                var column = Columns.VisibleColumns[columnIndex];
+                var value = values[valueIndex];
+
+                if (column.IsReadOnly) continue;
+
+                pastedAnyValue = column.SetClipboardContent(item, value);
+                columnIndex++;
+            }
+        }
+
+        return pastedAnyValue;
+    }
+
+    /// <summary>
+    /// Parses the clipboard text into a list of rows, where each row is an array of values.
+    /// </summary>
+    /// <param name="text">The text content from the clipboard to be parsed.</param>
+    /// <returns>A list of rows, where each row is an array of values.</returns>
+    private static IReadOnlyList<string[]> ParseClipboardText(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return [];
+        }
+
+        var normalizedText = text.ReplaceLineEndings("\n");
+        var rows = normalizedText.Split('\n');
+
+        if (rows.Length > 0 && rows[^1].Length == 0)
+        {
+            rows = rows[..^1];
+        }
+
+        return [.. rows.Select(row => row.Split('\t'))];
+    }
+
+    /// <summary>
+    /// Determines whether the TableView can handle a paste request based on its current state.
+    /// </summary>
+    /// <returns>True if the TableView can handle the paste request; otherwise, false.</returns>
+    private bool CanHandlePasteRequest()
+    {
+        if (IsReadOnly || IsEditing || Columns.VisibleColumns.Count == 0 || Items.Count == 0)
+        {
+            return false;
+        }
+
+        var focused = FocusManager.GetFocusedElement(XamlRoot!) as FrameworkElement;
+        return focused is not TextBox and not PasswordBox and not RichEditBox;
+    }
+
+    /// <summary>
+    /// Attempts to determine the anchor cell for pasting based on the current state of the TableView.
+    /// </summary>
+    /// <param name="anchor">The determined anchor cell for pasting.</param>
+    /// <returns>True if a valid paste anchor is found; otherwise, false.</returns>
+    private bool TryGetPasteAnchor(out TableViewCellSlot anchor)
+    {
+        if (CurrentCellSlot is { } currentCell && IsValidPasteAnchor(currentCell))
+        {
+            anchor = currentCell;
+            return true;
+        }
+
+        if (SelectedCells.Count > 0)
+        {
+            anchor = SelectedCells.OrderBy(slot => slot.Row)
+                                  .ThenBy(slot => slot.Column)
+                                  .First();
+            return true;
+        }
+
+        var rowIndex = SelectedRanges.Any()
+            ? SelectedRanges.Min(range => range.FirstIndex)
+            : CurrentRowIndex;
+
+        if (rowIndex is >= 0)
+        {
+            var columnIndex = GetFirstWritableVisibleColumnIndex();
+            if (columnIndex >= 0)
+            {
+                anchor = new TableViewCellSlot(rowIndex.Value, columnIndex);
+                return true;
+            }
+        }
+
+        anchor = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Validates whether the given TableViewCellSlot is a valid anchor for pasting.
+    /// </summary>
+    /// <param name="slot">The TableViewCellSlot to validate.</param>
+    /// <returns>True if the slot is a valid paste anchor; otherwise, false.</returns>
+    private bool IsValidPasteAnchor(TableViewCellSlot slot)
+    {
+        return slot.Row >= 0
+            && slot.Row < Items.Count
+            && slot.Column >= 0
+            && slot.Column < Columns.VisibleColumns.Count;
+    }
+
+    /// <summary>
+    /// Finds the index of the first visible column that is writable (not read-.
+    /// </summary>
+    /// <returns>The index of the first writable visible column, or -1 if none are found.</returns>
+    private int GetFirstWritableVisibleColumnIndex()
+    {
+        for (var i = 0; i < Columns.VisibleColumns.Count; i++)
+        {
+            if (Columns.VisibleColumns[i] is { IsReadOnly: false, ClipboardContentBinding: { } })
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -267,6 +267,34 @@ public partial class TableView
     public static readonly DependencyProperty ShowFilterItemsCountProperty = DependencyProperty.Register(nameof(ShowFilterItemsCount), typeof(bool), typeof(TableView), new PropertyMetadata(false));
 
     /// <summary>
+    /// Identifies the <see cref="CanCopy"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty CanCopyProperty = DependencyProperty.Register(nameof(CanCopy), typeof(bool), typeof(TableView), new PropertyMetadata(true));
+
+    /// <summary>
+    /// Identifies the <see cref="CanPaste"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty CanPasteProperty = DependencyProperty.Register(nameof(CanPaste), typeof(bool), typeof(TableView), new PropertyMetadata(true));
+
+    /// <summary>
+    /// Gets or sets a value that indicates whether users can copy selected cells or rows to the clipboard.
+    /// </summary>
+    public bool CanCopy
+    {
+        get => (bool)GetValue(CanCopyProperty);
+        set => SetValue(CanCopyProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value that indicates whether users can paste clipboard data into the TableView.
+    /// </summary>
+    public bool CanPaste
+    {
+        get => (bool)GetValue(CanPasteProperty);
+        set => SetValue(CanPasteProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets a value indicating whether opening the column filter over header right-click is enabled.
     /// </summary>
     public bool UseRightClickForColumnFilter

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -326,6 +326,10 @@ public partial class TableView : ListView
             CopyToClipboardInternal(shiftKey);
             return true;
         }
+        else if (key == VirtualKey.V && ctrlKey && !shiftKey)
+        {
+            return TryStartPasteFromClipboard();
+        }
 
         return false;
     }

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -514,7 +514,7 @@ public partial class TableView : ListView
         var args = new TableViewCopyToClipboardEventArgs(includeHeaders);
         OnCopyToClipboard(args);
 
-        if (args.Handled)
+        if (!CanCopy || args.Handled)
         {
             return;
         }

--- a/src/TableViewHeaderRow.OptionComamnds.cs
+++ b/src/TableViewHeaderRow.OptionComamnds.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Windows.ApplicationModel.DataTransfer;
 
 namespace WinUI.TableView;
 
@@ -39,17 +40,17 @@ partial class TableViewHeaderRow
 
         if (GetTemplateChild("SelectAllMenuItem") is MenuFlyoutItem selectAllMenuItem)
             selectAllMenuItem.Command = _selectAllCommand;
-        if (GetTemplateChild("ClearSelectionMenuItem") is MenuFlyoutItem clearSelectionMenuItem) 
+        if (GetTemplateChild("ClearSelectionMenuItem") is MenuFlyoutItem clearSelectionMenuItem)
             clearSelectionMenuItem.Command = _deselectAllCommand;
-        if (GetTemplateChild("CopyMenuItem") is MenuFlyoutItem copyMenuItem) 
+        if (GetTemplateChild("CopyMenuItem") is MenuFlyoutItem copyMenuItem)
             copyMenuItem.Command = _copyCommand;
         if (GetTemplateChild("PasteMenuItem") is MenuFlyoutItem pasteMenuItem)
             pasteMenuItem.Command = _pasteCommand;
-        if (GetTemplateChild("CopyWithHeadersMenuItem") is MenuFlyoutItem copyWithHeadersMenuItem) 
+        if (GetTemplateChild("CopyWithHeadersMenuItem") is MenuFlyoutItem copyWithHeadersMenuItem)
             copyWithHeadersMenuItem.Command = _copyWithHeadersCommand;
-        if (GetTemplateChild("ClearSortingMenuItem") is MenuFlyoutItem clearSortingMenuItem) 
+        if (GetTemplateChild("ClearSortingMenuItem") is MenuFlyoutItem clearSortingMenuItem)
             clearSortingMenuItem.Command = _clearSortingCommand;
-        if (GetTemplateChild("ClearFilterMenuItem") is MenuFlyoutItem clearFilterMenuItem) 
+        if (GetTemplateChild("ClearFilterMenuItem") is MenuFlyoutItem clearFilterMenuItem)
             clearFilterMenuItem.Command = _clearFilterCommand;
         if (GetTemplateChild("ExportAllMenuItem") is MenuFlyoutItem exportAllMenuItem)
         {
@@ -91,7 +92,7 @@ partial class TableViewHeaderRow
 
         _copyWithHeadersCommand.Description = TableViewLocalizedStrings.CopyWithHeadersCommandDescription;
         _copyWithHeadersCommand.ExecuteRequested += delegate { TableView?.CopyToClipboardInternal(true); };
-        _copyWithHeadersCommand.CanExecuteRequested += CanExecuteCopyWithHeadersCommand;
+        _copyWithHeadersCommand.CanExecuteRequested += CanExecuteCopyCommand;
 
         _clearSortingCommand.ExecuteRequested += delegate { TableView?.ClearAllSortingWithEvent(); };
         _clearSortingCommand.CanExecuteRequested += CanExecuteClearSortingCommand;
@@ -129,19 +130,20 @@ partial class TableViewHeaderRow
 
     private void CanExecuteCopyCommand(XamlUICommand sender, CanExecuteRequestedEventArgs e)
     {
-        e.CanExecute = TableView?.SelectedItems.Count > 0 || TableView?.SelectedCells.Count > 0 || TableView?.CurrentCellSlot.HasValue is true;
-    }
-
-    private void CanExecuteCopyWithHeadersCommand(XamlUICommand sender, CanExecuteRequestedEventArgs e)
-    {
-        e.CanExecute = TableView?.SelectedItems.Count > 0 || TableView?.SelectedCells.Count > 0 || TableView?.CurrentCellSlot.HasValue is true;
+        e.CanExecute = TableView?.CanCopy is true
+            && (TableView?.SelectedItems.Count > 0 || TableView?.SelectedCells.Count > 0 || TableView?.CurrentCellSlot.HasValue is true);
     }
 
     private void CanExecutePasteCommand(XamlUICommand sender, CanExecuteRequestedEventArgs e)
     {
-        e.CanExecute = TableView?.IsEditing is false
-            && TableView?.IsReadOnly is false
-            && (TableView?.SelectedItems.Count > 0 || TableView?.SelectedCells.Count > 0 || TableView?.CurrentCellSlot.HasValue is true);
+        e.CanExecute = false;
+        var canExecute = TableView?.CanPaste is true && TableView?.IsEditing is false && TableView?.IsReadOnly is false;
+
+        if (canExecute)
+        {
+            var content = Clipboard.GetContent();
+            e.CanExecute = canExecute && content.Contains(StandardDataFormats.Text);
+        }
     }
 
     private void CanExecuteClearSortingCommand(XamlUICommand sender, CanExecuteRequestedEventArgs e)

--- a/src/TableViewHeaderRow.OptionComamnds.cs
+++ b/src/TableViewHeaderRow.OptionComamnds.cs
@@ -12,6 +12,7 @@ partial class TableViewHeaderRow
     private readonly StandardUICommand _selectAllCommand = new(StandardUICommandKind.SelectAll) { Label = TableViewLocalizedStrings.SelectAll };
     private readonly StandardUICommand _deselectAllCommand = new() { Label = TableViewLocalizedStrings.DeselectAll };
     private readonly StandardUICommand _copyCommand = new(StandardUICommandKind.Copy) { Label = TableViewLocalizedStrings.Copy };
+    private readonly StandardUICommand _pasteCommand = new(StandardUICommandKind.Paste) { Label = TableViewLocalizedStrings.Paste };
     private readonly StandardUICommand _copyWithHeadersCommand = new() { Label = TableViewLocalizedStrings.CopyWithHeaders };
     private readonly StandardUICommand _clearSortingCommand = new() { Label = TableViewLocalizedStrings.ClearSorting };
     private readonly StandardUICommand _clearFilterCommand = new() { Label = TableViewLocalizedStrings.ClearFilter };
@@ -42,6 +43,8 @@ partial class TableViewHeaderRow
             clearSelectionMenuItem.Command = _deselectAllCommand;
         if (GetTemplateChild("CopyMenuItem") is MenuFlyoutItem copyMenuItem) 
             copyMenuItem.Command = _copyCommand;
+        if (GetTemplateChild("PasteMenuItem") is MenuFlyoutItem pasteMenuItem)
+            pasteMenuItem.Command = _pasteCommand;
         if (GetTemplateChild("CopyWithHeadersMenuItem") is MenuFlyoutItem copyWithHeadersMenuItem) 
             copyWithHeadersMenuItem.Command = _copyWithHeadersCommand;
         if (GetTemplateChild("ClearSortingMenuItem") is MenuFlyoutItem clearSortingMenuItem) 
@@ -81,6 +84,10 @@ partial class TableViewHeaderRow
         _copyCommand.Description = TableViewLocalizedStrings.CopyCommandDescription;
         _copyCommand.ExecuteRequested += ExecuteCopyCommand;
         _copyCommand.CanExecuteRequested += CanExecuteCopyCommand;
+
+        _pasteCommand.Description = TableViewLocalizedStrings.PasteCommandDescription;
+        _pasteCommand.ExecuteRequested += delegate { TableView?.TryStartPasteFromClipboard(); };
+        _pasteCommand.CanExecuteRequested += CanExecutePasteCommand;
 
         _copyWithHeadersCommand.Description = TableViewLocalizedStrings.CopyWithHeadersCommandDescription;
         _copyWithHeadersCommand.ExecuteRequested += delegate { TableView?.CopyToClipboardInternal(true); };
@@ -128,6 +135,13 @@ partial class TableViewHeaderRow
     private void CanExecuteCopyWithHeadersCommand(XamlUICommand sender, CanExecuteRequestedEventArgs e)
     {
         e.CanExecute = TableView?.SelectedItems.Count > 0 || TableView?.SelectedCells.Count > 0 || TableView?.CurrentCellSlot.HasValue is true;
+    }
+
+    private void CanExecutePasteCommand(XamlUICommand sender, CanExecuteRequestedEventArgs e)
+    {
+        e.CanExecute = TableView?.IsEditing is false
+            && TableView?.IsReadOnly is false
+            && (TableView?.SelectedItems.Count > 0 || TableView?.SelectedCells.Count > 0 || TableView?.CurrentCellSlot.HasValue is true);
     }
 
     private void CanExecuteClearSortingCommand(XamlUICommand sender, CanExecuteRequestedEventArgs e)

--- a/src/TableViewLocalizedStrings.cs
+++ b/src/TableViewLocalizedStrings.cs
@@ -24,6 +24,8 @@ internal partial class TableViewLocalizedStrings
         ClearSorting = GetValue(nameof(ClearSorting));
         Copy = GetValue(nameof(Copy));
         CopyCommandDescription = GetValue(nameof(CopyCommandDescription));
+        Paste = GetValue(nameof(Paste));
+        PasteCommandDescription = GetValue(nameof(PasteCommandDescription));
         CopyWithHeaders = GetValue(nameof(CopyWithHeaders));
         CopyWithHeadersCommandDescription = GetValue(nameof(CopyWithHeadersCommandDescription));
         DatePickerPlaceholder = GetValue(nameof(DatePickerPlaceholder));
@@ -70,6 +72,8 @@ internal partial class TableViewLocalizedStrings
     public static string ClearSorting { get; set; }
     public static string Copy { get; set; }
     public static string CopyCommandDescription { get; set; }
+    public static string Paste { get; set; }
+    public static string PasteCommandDescription { get; set; }
     public static string CopyWithHeaders { get; set; }
     public static string CopyWithHeadersCommandDescription { get; set; }
     public static string DatePickerPlaceholder { get; set; }

--- a/src/Themes/TableViewHeaderRow.xaml
+++ b/src/Themes/TableViewHeaderRow.xaml
@@ -142,6 +142,14 @@
                                                                      ScopeOwner="{TemplateBinding TableView}" />
                                             </MenuFlyoutItem.KeyboardAccelerators>
                                         </MenuFlyoutItem>
+                                        <MenuFlyoutItem x:Name="PasteMenuItem"
+                                                        Icon="Paste">
+                                            <MenuFlyoutItem.KeyboardAccelerators>
+                                                <KeyboardAccelerator Key="V"
+                                                                     Modifiers="Control"
+                                                                     ScopeOwner="{TemplateBinding TableView}" />
+                                            </MenuFlyoutItem.KeyboardAccelerators>
+                                        </MenuFlyoutItem>
                                         <MenuFlyoutItem x:Name="CopyWithHeadersMenuItem">
                                             <MenuFlyoutItem.KeyboardAccelerators>
                                                 <KeyboardAccelerator Key="C"

--- a/tests/ObjectExtensionsTests.cs
+++ b/tests/ObjectExtensionsTests.cs
@@ -11,21 +11,21 @@ namespace WinUI.TableView.Tests;
 public class ObjectExtensionsTests
 {
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessSimpleProperty()
+    public void GetCompiledValueGetter_ShouldAccessSimpleProperty()
     {
         var testItem = new TestItem { Number = 7 };
-        var func = testItem.GetFuncCompiledPropertyPath("Number");
+        var func = testItem.GetCompiledValueGetter("Number");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual(7, result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessSimpleNullableProperty()
+    public void GetCompiledValueGetter_ShouldAccessSimpleNullableProperty()
     {
         var today = DateTimeOffset.Now;
         var testItem = new TestItem { CompletedDate = today };
-        var func = testItem.GetFuncCompiledPropertyPath("CompletedDate");
+        var func = testItem.GetCompiledValueGetter("CompletedDate");
         Assert.IsNotNull(func);
 
         var result = func(testItem);
@@ -37,103 +37,103 @@ public class ObjectExtensionsTests
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessNestedProperty()
+    public void GetCompiledValueGetter_ShouldAccessNestedProperty()
     {
         var testItem = new TestItem { SubItems = [new() { SubSubItems = [new() { Name = "NestedValue" }] }] };
-        var func = testItem.GetFuncCompiledPropertyPath("SubItems[0].SubSubItems[0].Name");
+        var func = testItem.GetCompiledValueGetter("SubItems[0].SubSubItems[0].Name");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual("NestedValue", result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessArrayElement()
+    public void GetCompiledValueGetter_ShouldAccessArrayElement()
     {
         var testItem = new TestItem { IntArray = [10, 20, 30] };
-        var func = testItem.GetFuncCompiledPropertyPath("IntArray[1]");
+        var func = testItem.GetCompiledValueGetter("IntArray[1]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual(20, result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccess2DArrayElement()
+    public void GetCompiledValueGetter_ShouldAccess2DArrayElement()
     {
         var testItem = new TestItem { Int2DArray = new int[,] {{1, 2, 3}, {10, 20, 30}} };
-        var func = testItem.GetFuncCompiledPropertyPath("Int2DArray[1,1]");
+        var func = testItem.GetCompiledValueGetter("Int2DArray[1,1]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual(20, result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessMultiDimensionalIndexer()
+    public void GetCompiledValueGetter_ShouldAccessMultiDimensionalIndexer()
     {
         var testItem = new TestItem();
         testItem[2, "foo"] = "bar";
-        var func = testItem.GetFuncCompiledPropertyPath("[2,foo]");
+        var func = testItem.GetCompiledValueGetter("[2,foo]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual("bar", result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessDictionaryByStringKey()
+    public void GetCompiledValueGetter_ShouldAccessDictionaryByStringKey()
     {
         var testItem = new TestItem { Dictionary1 = new() { { "key1", "value1" } } };
-        var func = testItem.GetFuncCompiledPropertyPath("Dictionary1[key1]");
+        var func = testItem.GetCompiledValueGetter("Dictionary1[key1]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual("value1", result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessDictionaryByIntKey()
+    public void GetCompiledValueGetter_ShouldAccessDictionaryByIntKey()
     {
         var testItem = new TestItem { Dictionary2 = new() { { 1, "value1" } } };
-        var func = testItem.GetFuncCompiledPropertyPath("Dictionary2[1]");
+        var func = testItem.GetCompiledValueGetter("Dictionary2[1]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual("value1", result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForInvalidProperty()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForInvalidProperty()
     {
         var testItem = new TestItem();
-        var func = testItem.GetFuncCompiledPropertyPath("NonExistent.Property.Path");
+        var func = testItem.GetCompiledValueGetter("NonExistent.Property.Path");
         Assert.IsNull(func);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForInvalidProperty2()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForInvalidProperty2()
     {
         var testItem = new TestItem();
-        var func = testItem.GetFuncCompiledPropertyPath("SubItems[0].SubSubItems[0].Invalid");
+        var func = testItem.GetCompiledValueGetter("SubItems[0].SubSubItems[0].Invalid");
         Assert.IsNull(func);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForInvalidProperty3()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForInvalidProperty3()
     {
         var testItem = new TestItem { SubItems = [new() { SubSubItems = [new() { Name = "NestedValue" }] }] };
-        var func = testItem.GetFuncCompiledPropertyPath("SubItems[0].SubSubItems[0].Invalid");
+        var func = testItem.GetCompiledValueGetter("SubItems[0].SubSubItems[0].Invalid");
         Assert.IsNull(func);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForInvalidProperty4()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForInvalidProperty4()
     {
         var testItem = new TestItem();
-        var func = testItem.GetFuncCompiledPropertyPath("Dictionary[123]");
+        var func = testItem.GetCompiledValueGetter("Dictionary[123]");
         Assert.IsNull(func);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForInvalidDictionaryIndexer()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForInvalidDictionaryIndexer()
     {
         var testItem = new TestItem { Dictionary2 = new() { { 1, "value1" } } };
-        var func = testItem.GetFuncCompiledPropertyPath("Dictionary2[1]");
+        var func = testItem.GetCompiledValueGetter("Dictionary2[1]");
         Assert.IsNotNull(func);
 
         var result = func(testItem);
@@ -145,10 +145,10 @@ public class ObjectExtensionsTests
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForInvalidArrayIndex()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForInvalidArrayIndex()
     {
         var testItem = new TestItem { SubItems = [new() { SubSubItems = [new() { Name = "NestedValue" }] }] };
-        var func = testItem.GetFuncCompiledPropertyPath("SubItems[0].SubSubItems[0].Name");
+        var func = testItem.GetCompiledValueGetter("SubItems[0].SubSubItems[0].Name");
         Assert.IsNotNull(func);
 
         var result = func(testItem);
@@ -160,10 +160,10 @@ public class ObjectExtensionsTests
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForOutOfBoundsArrayIndex()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForOutOfBoundsArrayIndex()
     {
         var testItem = new TestItem { IntArray = [10, 20, 30] };
-        var func = testItem.GetFuncCompiledPropertyPath("IntArray[2]");
+        var func = testItem.GetCompiledValueGetter("IntArray[2]");
         Assert.IsNotNull(func);
         var testItem2 = new TestItem { IntArray = [1] };
         var result = func(testItem2);
@@ -171,10 +171,10 @@ public class ObjectExtensionsTests
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForOutOfBoundsMultiDimArrayIndex()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForOutOfBoundsMultiDimArrayIndex()
     {
         var testItem3x3 = new TestItem { Int2DArray = new int[,] { { 1, 2, 3 }, { 10, 20, 30 } } };
-        var func = testItem3x3.GetFuncCompiledPropertyPath("Int2DArray[2,2]");
+        var func = testItem3x3.GetCompiledValueGetter("Int2DArray[2,2]");
         Assert.IsNotNull(func);
         var result = func(testItem3x3);
 
@@ -184,30 +184,30 @@ public class ObjectExtensionsTests
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessListByIndex()
+    public void GetCompiledValueGetter_ShouldAccessListByIndex()
     {
         var testItem = new TestItem { StringList = ["item0", "item1", "item2"] };
-        var func = testItem.GetFuncCompiledPropertyPath("StringList[1]");
+        var func = testItem.GetCompiledValueGetter("StringList[1]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual("item1", result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessPropertyOnString()
+    public void GetCompiledValueGetter_ShouldAccessPropertyOnString()
     {
         var testItem = new TestItem { StringList = ["item0", "item1 long text", "item2"] };
-        var func = testItem.GetFuncCompiledPropertyPath("StringList[1].Length");
+        var func = testItem.GetCompiledValueGetter("StringList[1].Length");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual(15, result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForOutOfBoundsListIndex()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForOutOfBoundsListIndex()
     {
         var testItem = new TestItem { StringList = ["item0", "item1", "item2"] };
-        var func = testItem.GetFuncCompiledPropertyPath("StringList[2]");
+        var func = testItem.GetCompiledValueGetter("StringList[2]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual("item2", result);
@@ -219,86 +219,86 @@ public class ObjectExtensionsTests
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForDictionaryKeyTypeMismatch()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForDictionaryKeyTypeMismatch()
     {
         // Dictionary<string, string> accessed with int key
         var testItem = new TestItem { Dictionary1 = new() { { "key1", "value1" } } };
-        var func = testItem.GetFuncCompiledPropertyPath("Dictionary1[123]"); // int key for string-keyed dictionary
+        var func = testItem.GetCompiledValueGetter("Dictionary1[123]"); // int key for string-keyed dictionary
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.IsNull(result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessValueTypeProperty()
+    public void GetCompiledValueGetter_ShouldAccessValueTypeProperty()
     {
         var testItem = new TestItem { ValueTypeStruct = new TestStruct { Value = 42 } };
-        var func = testItem.GetFuncCompiledPropertyPath("ValueTypeStruct.Value");
+        var func = testItem.GetCompiledValueGetter("ValueTypeStruct.Value");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual(42, result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForNegativeArrayIndex()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForNegativeArrayIndex()
     {
         var testItem = new TestItem { IntArray = [10, 20, 30] };
-        var func = testItem.GetFuncCompiledPropertyPath("IntArray[-1]");
+        var func = testItem.GetCompiledValueGetter("IntArray[-1]");
         Assert.IsNull(func); // Should fail during expression building
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForNegativeListIndex()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForNegativeListIndex()
     {
         var testItem = new TestItem { StringList = ["item0", "item1"] };
-        var func = testItem.GetFuncCompiledPropertyPath("StringList[-1]");
+        var func = testItem.GetCompiledValueGetter("StringList[-1]");
         Assert.IsNull(func); // Should fail during expression building
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForWrongArrayDimensions()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForWrongArrayDimensions()
     {
         var testItem = new TestItem { Int2DArray = new int[,] { { 1, 2 }, { 3, 4 } } };
-        var func = testItem.GetFuncCompiledPropertyPath("Int2DArray[1]"); // 2D array with 1D index
+        var func = testItem.GetCompiledValueGetter("Int2DArray[1]"); // 2D array with 1D index
         Assert.IsNull(func); // Should fail during expression building
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForThrowingIndexer()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForThrowingIndexer()
     {
         var testItem = new TestItem();
         // This should trigger the generic indexer path with try-catch
-        var func = testItem.GetFuncCompiledPropertyPath("[999,nonexistent]");
+        var func = testItem.GetCompiledValueGetter("[999,nonexistent]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.IsNull(result); // Custom indexer returns empty string, but expression should handle gracefully
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldAccessNonGenericList()
+    public void GetCompiledValueGetter_ShouldAccessNonGenericList()
     {
         var testItem = new TestItem { NonGenericList = new System.Collections.ArrayList { "item0", "item1", "item2" } };
-        var func = testItem.GetFuncCompiledPropertyPath("NonGenericList[1]");
+        var func = testItem.GetCompiledValueGetter("NonGenericList[1]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.AreEqual("item1", result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForOutOfBoundsNonGenericList()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForOutOfBoundsNonGenericList()
     {
         var testItem = new TestItem { NonGenericList = new System.Collections.ArrayList { "item0" } };
-        var func = testItem.GetFuncCompiledPropertyPath("NonGenericList[5]");
+        var func = testItem.GetCompiledValueGetter("NonGenericList[5]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.IsNull(result);
     }
 
     [TestMethod]
-    public void GetFuncCompiledPropertyPath_ShouldReturnNull_ForEmptyList()
+    public void GetCompiledValueGetter_ShouldReturnNull_ForEmptyList()
     {
         var testItem = new TestItem { StringList = [] };
-        var func = testItem.GetFuncCompiledPropertyPath("StringList[0]");
+        var func = testItem.GetCompiledValueGetter("StringList[0]");
         Assert.IsNotNull(func);
         var result = func(testItem);
         Assert.IsNull(result);

--- a/tests/ObjectExtensionsTests.cs
+++ b/tests/ObjectExtensionsTests.cs
@@ -1,7 +1,8 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
 using WinUI.TableView.Extensions;
 
 namespace WinUI.TableView.Tests;
@@ -304,6 +305,545 @@ public class ObjectExtensionsTests
     }
 
     [TestMethod]
+    public void GetCompiledValueSetter_ShouldSetSimpleProperty()
+    {
+        var testItem = new TestItem { Number = 7 };
+
+        var setter = testItem.GetCompiledValueSetter("Number");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, 42);
+
+        Assert.AreEqual(42, testItem.Number);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldSetSimpleNullableProperty()
+    {
+        var today = DateTimeOffset.Now;
+        var testItem = new TestItem();
+
+        var setter = testItem.GetCompiledValueSetter("CompletedDate");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, today);
+
+        Assert.AreEqual(today, testItem.CompletedDate);
+
+        setter(testItem, null);
+
+        Assert.IsNull(testItem.CompletedDate);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldSetNestedProperty()
+    {
+        var testItem = new TestItem
+        {
+            SubItems = [new() { SubSubItems = [new() { Name = "OldValue" }] }]
+        };
+
+        var setter = testItem.GetCompiledValueSetter("SubItems[0].SubSubItems[0].Name");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "NewValue");
+
+        Assert.AreEqual("NewValue", testItem.SubItems[0].SubSubItems[0].Name);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldSetArrayElement()
+    {
+        var testItem = new TestItem { IntArray = [10, 20, 30] };
+
+        var setter = testItem.GetCompiledValueSetter("IntArray[1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, 99);
+
+        Assert.AreEqual(99, testItem.IntArray[1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldSet2DArrayElement()
+    {
+        var testItem = new TestItem
+        {
+            Int2DArray = new int[,] { { 1, 2, 3 }, { 10, 20, 30 } }
+        };
+
+        var setter = testItem.GetCompiledValueSetter("Int2DArray[1,1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, 99);
+
+        Assert.AreEqual(99, testItem.Int2DArray[1, 1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldSetMultiDimensionalIndexer()
+    {
+        var testItem = new TestItem();
+
+        var setter = testItem.GetCompiledValueSetter("[2,foo]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "bar");
+
+        Assert.AreEqual("bar", testItem[2, "foo"]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldSetDictionaryByStringKey()
+    {
+        var testItem = new TestItem
+        {
+            Dictionary1 = new() { { "key1", "value1" } }
+        };
+
+        var setter = testItem.GetCompiledValueSetter("Dictionary1[key1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "updated");
+
+        Assert.AreEqual("updated", testItem.Dictionary1["key1"]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldAddDictionaryValue_WhenStringKeyDoesNotExist()
+    {
+        var testItem = new TestItem
+        {
+            Dictionary1 = []
+        };
+
+        var setter = testItem.GetCompiledValueSetter("Dictionary1[key1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "value1");
+
+        Assert.AreEqual("value1", testItem.Dictionary1["key1"]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldSetDictionaryByIntKey()
+    {
+        var testItem = new TestItem
+        {
+            Dictionary2 = new() { { 1, "value1" } }
+        };
+
+        var setter = testItem.GetCompiledValueSetter("Dictionary2[1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "updated");
+
+        Assert.AreEqual("updated", testItem.Dictionary2[1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldAddDictionaryValue_WhenIntKeyDoesNotExist()
+    {
+        var testItem = new TestItem
+        {
+            Dictionary2 = []
+        };
+
+        var setter = testItem.GetCompiledValueSetter("Dictionary2[1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "value1");
+
+        Assert.AreEqual("value1", testItem.Dictionary2[1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldReturnNull_ForInvalidProperty()
+    {
+        var testItem = new TestItem();
+
+        var setter = testItem.GetCompiledValueSetter("NonExistent.Property.Path");
+
+        Assert.IsNull(setter);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldReturnNull_ForInvalidNestedProperty()
+    {
+        var testItem = new TestItem
+        {
+            SubItems = [new() { SubSubItems = [new() { Name = "NestedValue" }] }]
+        };
+
+        var setter = testItem.GetCompiledValueSetter("SubItems[0].SubSubItems[0].Invalid");
+
+        Assert.IsNull(setter);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldReturnNull_ForNullIntermediateProperty()
+    {
+        var testItem = new TestItem
+        {
+            SubItems = [new() { SubSubItems = null! }]
+        };
+
+        var setter = testItem.GetCompiledValueSetter("SubItems[0].SubSubItems[0].Name");
+
+        Assert.IsNull(setter);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldReturnNull_ForInvalidDictionaryProperty()
+    {
+        var testItem = new TestItem();
+
+        var setter = testItem.GetCompiledValueSetter("Dictionary[123]");
+
+        Assert.IsNull(setter);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldNotThrow_ForDictionaryKeyTypeMismatch()
+    {
+        var testItem = new TestItem
+        {
+            Dictionary1 = new() { { "key1", "value1" } }
+        };
+
+        var setter = testItem.GetCompiledValueSetter("Dictionary1[123]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "updated");
+
+        Assert.AreEqual("value1", testItem.Dictionary1["key1"]);
+        Assert.IsFalse(testItem.Dictionary1.ContainsKey("123"));
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldNotSet_ForOutOfBoundsArrayIndex()
+    {
+        var testItem = new TestItem { IntArray = [10, 20, 30] };
+
+        var setter = testItem.GetCompiledValueSetter("IntArray[5]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, 99);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, testItem.IntArray);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldNotSet_ForOutOfBoundsMultiDimArrayIndex()
+    {
+        var testItem = new TestItem
+        {
+            Int2DArray = new int[,] { { 1, 2 }, { 10, 30 } }
+        };
+
+        var setter = testItem.GetCompiledValueSetter("Int2DArray[2,2]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, 99);
+
+        Assert.AreEqual(1, testItem.Int2DArray[0, 0]);
+        Assert.AreEqual(2, testItem.Int2DArray[0, 1]);
+        Assert.AreEqual(10, testItem.Int2DArray[1, 0]);
+        Assert.AreEqual(30, testItem.Int2DArray[1, 1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldSetListByIndex()
+    {
+        var testItem = new TestItem
+        {
+            StringList = ["item0", "item1", "item2"]
+        };
+
+        var setter = testItem.GetCompiledValueSetter("StringList[1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "updated");
+
+        Assert.AreEqual("updated", testItem.StringList[1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldSetNonGenericListByIndex()
+    {
+        var testItem = new TestItem
+        {
+            NonGenericList = new System.Collections.ArrayList { "item0", "item1", "item2" }
+        };
+
+        var setter = testItem.GetCompiledValueSetter("NonGenericList[1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "updated");
+
+        Assert.AreEqual("updated", testItem.NonGenericList[1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldNotSet_ForNegativeListIndex()
+    {
+        var testItem = new TestItem { StringList = ["item0", "item1"] };
+
+        var setter = testItem.GetCompiledValueSetter("StringList[-1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "updated");
+
+        CollectionAssert.AreEqual(new[] { "item0", "item1" }, testItem.StringList);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldNotSet_ForOutOfBoundsListIndex()
+    {
+        var testItem = new TestItem { StringList = ["item0"] };
+
+        var setter = testItem.GetCompiledValueSetter("StringList[5]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "updated");
+
+        CollectionAssert.AreEqual(new[] { "item0" }, testItem.StringList);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldNotSet_ForOutOfBoundsNonGenericListIndex()
+    {
+        var testItem = new TestItem
+        {
+            NonGenericList = new System.Collections.ArrayList { "item0" }
+        };
+
+        var setter = testItem.GetCompiledValueSetter("NonGenericList[5]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "updated");
+
+        Assert.AreEqual("item0", testItem.NonGenericList[0]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldNotSet_ForEmptyList()
+    {
+        var testItem = new TestItem { StringList = [] };
+
+        var setter = testItem.GetCompiledValueSetter("StringList[0]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "updated");
+
+        Assert.AreEqual(0, testItem.StringList.Count);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldReturnNull_ForNegativeArrayIndex()
+    {
+        var testItem = new TestItem { IntArray = [10, 20, 30] };
+
+        var setter = testItem.GetCompiledValueSetter("IntArray[-1]");
+
+        Assert.IsNull(setter);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldReturnNull_ForWrongArrayDimensions()
+    {
+        var testItem = new TestItem
+        {
+            Int2DArray = new int[,] { { 1, 2 }, { 3, 4 } }
+        };
+
+        var setter = testItem.GetCompiledValueSetter("Int2DArray[1]");
+
+        Assert.IsNull(setter);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldReturnNull_ForReadOnlyProperty()
+    {
+        var testItem = new TestItem
+        {
+            StringList = ["item0", "item1 long text", "item2"]
+        };
+
+        var setter = testItem.GetCompiledValueSetter("StringList[1].Length");
+
+        Assert.IsNull(setter);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldConvertStringToInt()
+    {
+        var testItem = new TestItem { Number = 7 };
+
+        var setter = testItem.GetCompiledValueSetter("Number");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "42");
+
+        Assert.AreEqual(42, testItem.Number);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldNotSet_WhenStringCannotConvertToInt()
+    {
+        var testItem = new TestItem { Number = 7 };
+
+        var setter = testItem.GetCompiledValueSetter("Number");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "invalid");
+
+        Assert.AreEqual(7, testItem.Number);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldConvertStringToNullableDateTimeOffset()
+    {
+        var testItem = new TestItem();
+
+        var setter = testItem.GetCompiledValueSetter("CompletedDate");
+
+        Assert.IsNotNull(setter);
+
+        var value = DateTimeOffset.Now;
+
+        setter(testItem, value.ToString(CultureInfo.CurrentCulture));
+
+        Assert.IsNotNull(testItem.CompletedDate);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldSetNullablePropertyToNull_WhenValueIsEmptyString()
+    {
+        var testItem = new TestItem
+        {
+            CompletedDate = DateTimeOffset.Now
+        };
+
+        var setter = testItem.GetCompiledValueSetter("CompletedDate");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "");
+
+        Assert.IsNull(testItem.CompletedDate);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldConvertStringToArrayIntElement()
+    {
+        var testItem = new TestItem
+        {
+            IntArray = [1, 2, 3]
+        };
+
+        var setter = testItem.GetCompiledValueSetter("IntArray[1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "42");
+
+        Assert.AreEqual(42, testItem.IntArray[1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldNotSetArrayIntElement_WhenConversionFails()
+    {
+        var testItem = new TestItem
+        {
+            IntArray = [1, 2, 3]
+        };
+
+        var setter = testItem.GetCompiledValueSetter("IntArray[1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "not-a-number");
+
+        Assert.AreEqual(2, testItem.IntArray[1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldConvertStringToListIntElement()
+    {
+        var testItem = new TestItem
+        {
+            IntList = [1, 2, 3]
+        };
+
+        var setter = testItem.GetCompiledValueSetter("IntList[1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "99");
+
+        Assert.AreEqual(99, testItem.IntList[1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldConvertIntToStringListElement()
+    {
+        var testItem = new TestItem
+        {
+            StringList = ["A", "B", "C"]
+        };
+
+        var setter = testItem.GetCompiledValueSetter("StringList[1]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, 123);
+
+        Assert.AreEqual("123", testItem.StringList[1]);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueSetter_ShouldConvertStringToDictionaryIntValue()
+    {
+        var testItem = new TestItem
+        {
+            IntDictionary = new()
+            {
+                ["A"] = 1
+            }
+        };
+
+        var setter = testItem.GetCompiledValueSetter("IntDictionary[A]");
+
+        Assert.IsNotNull(setter);
+
+        setter(testItem, "500");
+
+        Assert.AreEqual(500, testItem.IntDictionary["A"]);
+    }
+
+    [TestMethod]
     public void GetItemType_ShouldReturnCorrectType_ForGenericEnumerable()
     {
         var list = new List<int> { 1, 2, 3 };
@@ -370,9 +910,11 @@ public class ObjectExtensionsTests
         public List<SubItem> SubItems { get; set; } = [];
         public Dictionary<string, string> Dictionary1 { get; set; } = [];
         public Dictionary<int, string> Dictionary2 { get; set; } = [];
+        public Dictionary<string, int> IntDictionary { get; set; } = [];
         public int[] IntArray { get; set; } = [];
         public int[,] Int2DArray { get; set; } = new int[0, 0];
         public List<string> StringList { get; set; } = [];
+        public List<int> IntList { get; set; } = [];
 
         // Multi-dimensional indexer
         private readonly Dictionary<(int, string), string> _multiIndex = new();

--- a/tests/TableViewBoundColumnTests.cs
+++ b/tests/TableViewBoundColumnTests.cs
@@ -2,11 +2,12 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System;
 
 namespace WinUI.TableView.Tests;
 
 [TestClass]
-public class TableViewBoundColumnTests
+public partial class TableViewBoundColumnTests
 {
     [UITestMethod]
     public void TableViewBoundColumn_BindingAndOperationBinding_UseExpectedDefaults()
@@ -38,5 +39,52 @@ public class TableViewBoundColumnTests
 
         Assert.AreSame(column.Binding, column.ClipboardContentBinding);
         Assert.AreEqual(nameof(ColumnTestItem.Name), column.ClipboardContentBinding!.Path!.Path);
+    }
+
+    [UITestMethod]
+    public void TableViewBoundColumn_SetClipboardContent_WritesBackThroughBindingPath()
+    {
+        var column = new TableViewTextColumn
+        {
+            Binding = new Binding { Path = new PropertyPath(nameof(ColumnTestItem.Name)) }
+        };
+        var item = new ColumnTestItem { Name = "before" };
+
+        var success = column.SetClipboardContent(item, "after");
+
+        Assert.IsTrue(success);
+        Assert.AreEqual("after", item.Name);
+    }
+
+    [UITestMethod]
+    public void TableViewBoundColumn_SetClipboardContent_UsesBindingConverterConvertBack()
+    {
+        var column = new TableViewTextColumn
+        {
+            Binding = new Binding
+            {
+                Path = new PropertyPath(nameof(ColumnTestItem.Name)),
+                Converter = new ConvertBackSuffixConverter()
+            }
+        };
+        var item = new ColumnTestItem();
+
+        var success = column.SetClipboardContent(item, "value");
+
+        Assert.IsTrue(success);
+        Assert.AreEqual("value-converted", item.Name);
+    }
+
+    private sealed partial class ConvertBackSuffixConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            return $"{value}-converted";
+        }
     }
 }


### PR DESCRIPTION
### Summary
This pull request introduces clipboard paste functionality to the TableView, with corresponding UI, event, and localization updates. The main changes include implementing infrastructure for pasting clipboard data into cells and updating localization resources to support the new paste feature in multiple languages, adding a new sample page demonstrating clipboard actions.

**Clipboard Paste Feature Implementation: **

* Added a new event `PasteFromClipboard` and its invocation logic to `TableView`, enabling handling of clipboard paste operations. Also introduced the `TableViewPasteFromClipboardEventArgs` class for event data.
* Enhanced `TableViewColumn` to support setting clipboard content on data items, including new compiled value getter/setter logic and a `SetClipboardContent` method.
Added new `CanCopy` and `CanPaste` properties to TableView for managing clipboard actions.

**Sample Application Updates:**

* Added a new `ClipboardActionsPage` to the sample app, demonstrating how to use copy and paste with TableView.