### PR TITLE
Compiled binding path for subclasses - support for mixed collection

### DIFF
--- a/src/Extensions/ObjectExtensions.cs
+++ b/src/Extensions/ObjectExtensions.cs
@@ -15,23 +15,23 @@ namespace WinUI.TableView.Extensions;
 /// </summary>
 internal static partial class ObjectExtensions
 {
-    // Regex to split property paths into property names and indexers (for cases like e.g. "[2].Foo[0].Bar", where Foo might be a Property that returns an array)
+    // Regex to split binding paths into segments; property names and indexers (for cases like e.g. "[2].Foo[0].Bar", where Foo might be a Property that returns an array)
     [GeneratedRegex(@"([^.[]+)|(\[[^\]]+\])", RegexOptions.Compiled)]
-    private static partial Regex PropertyPathRegex();
+    private static partial Regex BindingPathRegex();
 
     /// <summary>
-    /// Creates and returns a compiled lambda expression for accessing the property path on instances, with runtime type checking and casting support.
+    /// Creates and returns a compiled lambda expression for accessing the binding path on instances, with runtime type checking and casting support.
     /// </summary>
     /// <param name="dataItem">The data item instance to use for runtime type evaluation.</param>
     /// <param name="bindingPath">The binding path to access, e.g. "[0].SubPropertyArray[0].SubSubProperty".</param>
-    /// <returns>A compiled function that takes an instance and returns the property value, or null if the property path is invalid.</returns>
+    /// <returns>A compiled function that takes an instance and returns the property value, or null if the binding path is invalid.</returns>
     internal static Func<object, object?>? GetCompiledValueGetter(this object dataItem, string bindingPath)
     {
         try
         {
             // Build the property access expression chain with runtime type checking
             var parameterObj = Expression.Parameter(typeof(object), "obj");
-            var expressionTree = BuildPropertyPathExpressionTree(parameterObj, bindingPath, dataItem);
+            var expressionTree = BuildGetterExpressionTree(parameterObj, bindingPath, dataItem);
 
             // Compile the lambda expression
             var lambda = Expression.Lambda<Func<object, object?>>(expressionTree, parameterObj);
@@ -50,7 +50,7 @@ internal static partial class ObjectExtensions
             var parameterObj = Expression.Parameter(typeof(object), "obj");
             var parameterValue = Expression.Parameter(typeof(object), "value");
 
-            var expressionTree = BuildPropertyPathSetterExpressionTree(
+            var expressionTree = BuildSetterExpressionTree(
                 parameterObj,
                 parameterValue,
                 bindingPath,
@@ -69,9 +69,9 @@ internal static partial class ObjectExtensions
         }
     }
 
-    private static Expression BuildPropertyPathSetterExpressionTree(ParameterExpression parameterObj, ParameterExpression parameterValue, string bindingPath, object dataItem)
+    private static Expression BuildSetterExpressionTree(ParameterExpression parameterObj, ParameterExpression parameterValue, string bindingPath, object dataItem)
     {
-        var matches = PropertyPathRegex().Matches(bindingPath);
+        var matches = BindingPathRegex().Matches(bindingPath);
 
         if (matches.Count == 0)
             throw new ArgumentException("Binding path is empty.", nameof(bindingPath));
@@ -519,17 +519,17 @@ internal static partial class ObjectExtensions
     }
 
     /// <summary>
-    /// Builds an expression tree for accessing a property path on the given instance expression, with runtime type checking and casting support.
+    /// Builds an expression tree for accessing a binding path on the given instance expression, with runtime type checking and casting support.
     /// </summary>
     /// <param name="parameterObj">The expression representing the instance parameter for which the binding path will be evaluated.</param>
     /// <param name="bindingPath">The binding path to access.</param>
     /// <param name="dataItem">The actual data item to use for runtime type evaluation, to help with any needed subclass type conversions.</param>
     /// <returns>An expression that accesses the property value specified by the binding path for the provided dataItem instance.</returns>
-    private static Expression BuildPropertyPathExpressionTree(ParameterExpression parameterObj, string bindingPath, object dataItem)
+    private static Expression BuildGetterExpressionTree(ParameterExpression parameterObj, string bindingPath, object dataItem)
     {
         Expression current = parameterObj;
 
-        var matches = PropertyPathRegex().Matches(bindingPath);
+        var matches = BindingPathRegex().Matches(bindingPath);
 
         // The function uses a generic object input parameter to allow for any type of data item,
         // but we cast only to the root type that actually declares the first path segment.

--- a/src/Extensions/ObjectExtensions.cs
+++ b/src/Extensions/ObjectExtensions.cs
@@ -76,46 +76,9 @@ internal static partial class ObjectExtensions
         if (matches.Count == 0)
             throw new ArgumentException("Binding path is empty.", nameof(bindingPath));
 
-        Expression current = parameterObj;
-
-        // The function uses a generic object input parameter to allow for any type of data item,
-        // but we cast only to the root type that actually declares the first path segment.
-        // This keeps the accessor compatible with sibling subclasses in mixed collections.
-        {
-            var t = dataItem.GetType();
-            // Resolve the declaring type for the first segment (property or indexer).
-            // If we cannot resolve it, keep the original runtime type as fallback.
-            var typeRoot = matches.Count > 0 ? GetDeclaringTypeForPathSegment(t, matches[0].Value) ?? t : t;
-            if (current.Type != typeRoot && !typeRoot.IsValueType)
-                current = Expression.Convert(current, typeRoot);
-        }
-
-        // Navigate to the parent object of the final path segment.
-        for (int i = 0; i < matches.Count - 1; i++)
-        {
-            var part = matches[i].Value;
-
-            current = part.StartsWith('[') && part.EndsWith(']')
-                ? BuildIndexerGetterExpression(current, part)
-                : BuildPropertyGetterExpression(current, part);
-
-            var lambdaTemp = Expression.Lambda<Func<object, object?>>(
-                EnsureObjectCompatibleResult(current),
-                parameterObj);
-
-            var currentValue = lambdaTemp.Compile()(dataItem);
-
-            if (currentValue is null)
-                throw new ArgumentException($"Cannot build setter. Path segment '{part}' evaluates to null.");
-
-            // Use the declaring type of the NEXT segment instead of the sample instance's runtime type.
-            // This prevents lock-in to a specific sibling subtype and maintains mixed-collection compatibility.
-            var nextSegment = matches[i + 1].Value;
-            var typeCompatible = GetDeclaringTypeForPathSegment(currentValue.GetType(), nextSegment) ?? currentValue.GetType();
-
-            if (current.Type != typeCompatible)
-                current = Expression.Convert(current, typeCompatible);
-        }
+        // Reuse the getter's navigation logic to reach the parent of the final segment.
+        // Only the final segment is setter-specific (a write target instead of a read).
+        var current = BuildPathNavigationExpression(parameterObj, matches, dataItem, matches.Count - 1);
 
         var finalPart = matches[^1].Value;
 
@@ -271,7 +234,14 @@ internal static partial class ObjectExtensions
                 typeof(IList).IsAssignableFrom(current.Type) ||
                 typeof(ICollection).IsAssignableFrom(current.Type))
             {
-                var countProperty = current.Type.GetProperty("Count");
+                // Count may be declared on a base interface (e.g. IList inherits Count from ICollection),
+                // and reflection does not surface inherited interface members, so search interfaces too.
+                // The container type is no longer specialized to the concrete runtime type during navigation,
+                // so current.Type can legitimately be an interface like IList here.
+                var countProperty = current.Type.GetProperty("Count")
+                    ?? current.Type.GetInterfaces()
+                        .Select(i => i.GetProperty("Count"))
+                        .FirstOrDefault(p => p is not null);
 
                 if (countProperty != null)
                 {
@@ -497,27 +467,6 @@ internal static partial class ObjectExtensions
         }
     }
 
-    private static Expression ConvertValueExpression(Expression value, Type targetType)
-    {
-        if (targetType == typeof(object))
-            return value;
-
-        var nullableType = Nullable.GetUnderlyingType(targetType);
-
-        if (nullableType is not null)
-        {
-            return Expression.Condition(
-                Expression.Equal(value, Expression.Constant(null)),
-                Expression.Constant(null, targetType),
-                Expression.Convert(value, targetType));
-        }
-
-        if (!targetType.IsValueType)
-            return Expression.Convert(value, targetType);
-
-        return Expression.Convert(value, targetType);
-    }
-
     /// <summary>
     /// Builds an expression tree for accessing a binding path on the given instance expression, with runtime type checking and casting support.
     /// </summary>
@@ -527,9 +476,28 @@ internal static partial class ObjectExtensions
     /// <returns>An expression that accesses the property value specified by the binding path for the provided dataItem instance.</returns>
     private static Expression BuildGetterExpressionTree(ParameterExpression parameterObj, string bindingPath, object dataItem)
     {
-        Expression current = parameterObj;
-
         var matches = BindingPathRegex().Matches(bindingPath);
+
+        // Navigate through every segment to reach the final value.
+        var current = BuildPathNavigationExpression(parameterObj, matches, dataItem, matches.Count);
+
+        return EnsureObjectCompatibleResult(current);
+    }
+
+    /// <summary>
+    /// Builds the expression that navigates the first <paramref name="navigateCount"/> segments of a binding path on
+    /// the given instance expression, with runtime null-checks and mixed-collection-friendly type specialization.
+    /// Shared by both the getter (which navigates every segment) and the setter (which navigates to the parent of the
+    /// final segment), so the navigation logic only lives in one place.
+    /// </summary>
+    /// <param name="parameterObj">The expression representing the instance parameter for which the binding path will be evaluated.</param>
+    /// <param name="matches">The parsed binding path segments.</param>
+    /// <param name="dataItem">The actual data item to use for runtime type evaluation, to help with any needed subclass type conversions.</param>
+    /// <param name="navigateCount">The number of leading segments to navigate into.</param>
+    /// <returns>An expression that accesses the value at the requested depth for the provided dataItem instance.</returns>
+    private static Expression BuildPathNavigationExpression(ParameterExpression parameterObj, MatchCollection matches, object dataItem, int navigateCount)
+    {
+        Expression current = parameterObj;
 
         // The function uses a generic object input parameter to allow for any type of data item,
         // but we cast only to the root type that actually declares the first path segment.
@@ -543,37 +511,13 @@ internal static partial class ObjectExtensions
                 current = Expression.Convert(current, typeRoot);
         }
 
-        for (var matchIndex = 0; matchIndex < matches.Count; matchIndex++)
+        for (var matchIndex = 0; matchIndex < navigateCount; matchIndex++)
         {
             var part = matches[matchIndex].Value;
-            Expression nextPropertyAccess;
 
-            // Indexer
-            if (part.StartsWith('[') && part.EndsWith(']'))
-            {
-                object[] indices = GetIndices(part[1..^1]);
-
-                if (current.Type.IsArray)
-                {
-                    // Arrays only support integer indexing
-                    if (!indices.All(idx => idx is int))
-                        throw new ArgumentException($"Arrays only support integer indexing, not the provided indexer [{part[1..^1]}]");
-
-                    nextPropertyAccess = AddArrayAccessWithBoundsCheck(current, [.. indices.Select(index => (int)index)]);
-                }
-                else
-                {
-                    nextPropertyAccess = AddIndexerAccessWithSafetyChecks(current, indices);
-                }
-            }
-            // Simple property access
-            else
-            {
-                var propertyInfo = current.Type.GetProperty(part, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-                    ?? throw new ArgumentException($"Property '{part}' not found on type '{current.Type.Name}'");
-
-                nextPropertyAccess = Expression.Property(current, propertyInfo);
-            }
+            var nextPropertyAccess = part.StartsWith('[') && part.EndsWith(']')
+                ? BuildIndexerGetterExpression(current, part)
+                : BuildPropertyGetterExpression(current, part);
 
             if (nextPropertyAccess.Type.IsValueType && !nextPropertyAccess.Type.IsNullableType())
             {
@@ -591,10 +535,10 @@ internal static partial class ObjectExtensions
                 );
             }
 
-            // Only check for type compatibility (i.e.: the need for conversion) if this is not the last match.
+            // Only check for type compatibility (i.e.: the need for conversion) if there is a following segment.
             // We only specialize when the expression type is still object, to avoid over-specializing
             // to a sample instance subtype and breaking mixed type rows.
-            if (matchIndex < matches.Count - 1 && current.Type == typeof(object))
+            if (matchIndex + 1 < matches.Count && current.Type == typeof(object))
             {
                 var lambdaTemp = Expression.Lambda<Func<object, object?>>(EnsureObjectCompatibleResult(current), parameterObj);
                 var funcCurrent = lambdaTemp.Compile();
@@ -617,7 +561,7 @@ internal static partial class ObjectExtensions
             }
         }
 
-        return EnsureObjectCompatibleResult(current);
+        return current;
     }
 
     private static Expression EnsureObjectCompatibleResult(Expression expression)

--- a/src/Extensions/ObjectExtensions.cs
+++ b/src/Extensions/ObjectExtensions.cs
@@ -29,7 +29,7 @@ internal static partial class ObjectExtensions
     {
         try
         {
-            // Build the property access expression chain with runtime type checking
+            // Build the value access expression chain with runtime type checking
             var parameterObj = Expression.Parameter(typeof(object), "obj");
             var expressionTree = BuildGetterExpressionTree(parameterObj, bindingPath, dataItem);
 
@@ -87,7 +87,7 @@ internal static partial class ObjectExtensions
             : BuildPropertySetterExpression(current, finalPart, parameterValue);
     }
 
-    private static Expression BuildPropertyGetterExpression(Expression current, string propertyName)
+    private static MemberExpression BuildPropertyGetterExpression(Expression current, string propertyName)
     {
         var propertyInfo = current.Type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
             ?? throw new ArgumentException($"Property '{propertyName}' not found on type '{current.Type.Name}'.");
@@ -101,10 +101,9 @@ internal static partial class ObjectExtensions
 
         if (current.Type.IsArray)
         {
-            if (!indices.All(index => index is int))
-                throw new ArgumentException($"Arrays only support integer indexing: {indexerPart}");
-
-            return AddArrayAccessWithBoundsCheck(current, [.. indices.Select(index => (int)index)]);
+            return !indices.All(index => index is int)
+                ? throw new ArgumentException($"Arrays only support integer indexing: {indexerPart}")
+                : (Expression)AddArrayAccessWithBoundsCheck(current, [.. indices.Select(index => (int)index)]);
         }
 
         return AddIndexerAccessWithSafetyChecks(current, indices);
@@ -127,13 +126,12 @@ internal static partial class ObjectExtensions
     {
         var indices = GetIndices(indexerPart[1..^1]);
 
-        if (current.Type.IsArray)
-            return BuildArraySetterExpression(current, indices, value);
-
-        return BuildObjectIndexerSetterExpression(current, indices, value);
+        return current.Type.IsArray
+            ? BuildArraySetterExpression(current, indices, value)
+            : BuildObjectIndexerSetterExpression(current, indices, value);
     }
 
-    private static Expression BuildArraySetterExpression(Expression current, object[] indices, Expression value)
+    private static BlockExpression BuildArraySetterExpression(Expression current, object[] indices, Expression value)
     {
         if (!indices.All(index => index is int))
             throw new ArgumentException("Arrays only support integer indexers.");
@@ -275,7 +273,7 @@ internal static partial class ObjectExtensions
             indexerProperty.PropertyType);
     }
 
-    private static Expression BuildConvertedAssignExpression(Expression target, Expression value, Type targetType)
+    private static BlockExpression BuildConvertedAssignExpression(Expression target, Expression value, Type targetType)
     {
         var convertedValue = Expression.Variable(typeof(object), "convertedValue");
         var error = Expression.Variable(typeof(string), "error");
@@ -473,7 +471,7 @@ internal static partial class ObjectExtensions
     /// <param name="parameterObj">The expression representing the instance parameter for which the binding path will be evaluated.</param>
     /// <param name="bindingPath">The binding path to access.</param>
     /// <param name="dataItem">The actual data item to use for runtime type evaluation, to help with any needed subclass type conversions.</param>
-    /// <returns>An expression that accesses the property value specified by the binding path for the provided dataItem instance.</returns>
+    /// <returns>An expression that gets the value specified by the binding path for the provided dataItem instance.</returns>
     private static Expression BuildGetterExpressionTree(ParameterExpression parameterObj, string bindingPath, object dataItem)
     {
         var matches = BindingPathRegex().Matches(bindingPath);
@@ -515,14 +513,14 @@ internal static partial class ObjectExtensions
         {
             var part = matches[matchIndex].Value;
 
-            var nextPropertyAccess = part.StartsWith('[') && part.EndsWith(']')
+            var nextSegmentAccess = part.StartsWith('[') && part.EndsWith(']')
                 ? BuildIndexerGetterExpression(current, part)
                 : BuildPropertyGetterExpression(current, part);
 
-            if (nextPropertyAccess.Type.IsValueType && !nextPropertyAccess.Type.IsNullableType())
+            if (nextSegmentAccess.Type.IsValueType && !nextSegmentAccess.Type.IsNullableType())
             {
-                // Value types cannot be null, so don't need to check for null, and we can directly assign the property access
-                current = nextPropertyAccess;
+                // Value types cannot be null, so don't need to check for null, and we can directly assign the access to the next segment
+                current = nextSegmentAccess;
             }
             else
             {
@@ -530,8 +528,8 @@ internal static partial class ObjectExtensions
                 var notNullCheck = Expression.NotEqual(current, Expression.Constant(null));
                 current = Expression.Condition(
                     notNullCheck,
-                    nextPropertyAccess,
-                    Expression.Constant(null, nextPropertyAccess.Type)
+                    nextSegmentAccess,
+                    Expression.Constant(null, nextSegmentAccess.Type)
                 );
             }
 

--- a/src/Extensions/ObjectExtensions.cs
+++ b/src/Extensions/ObjectExtensions.cs
@@ -519,19 +519,23 @@ internal static partial class ObjectExtensions
     {
         Expression current = parameterObj;
 
-        // The function uses a generic object input parameter to allow for any type of data item,
-        // but we need to ensure that the runtime type matches the data item type that is inputted as example to be able to find members
-        {
-            var typeActual = dataItem.GetType();
-            if (current.Type != typeActual && !typeActual.IsValueType)
-                current = Expression.Convert(current, dataItem.GetType());
-        }
-
         var matches = PropertyPathRegex().Matches(bindingPath);
 
-        foreach (Match match in matches)
+        // The function uses a generic object input parameter to allow for any type of data item,
+        // but we cast only to the root type that actually declares the first path segment.
+        // This keeps the accessor compatible with sibling subclasses in mixed collections.
         {
-            string part = match.Value;
+            var t = dataItem.GetType();
+            // Resolve the declaring type for the first segment (property or indexer).
+            // If we cannot resolve it, keep the original runtime type as fallback.
+            var typeRoot = matches.Count > 0 ? GetDeclaringTypeForPathSegment(t, matches[0].Value) ?? t : t;
+            if (current.Type != typeRoot && !typeRoot.IsValueType)
+                current = Expression.Convert(current, typeRoot);
+        }
+
+        for (var matchIndex = 0; matchIndex < matches.Count; matchIndex++)
+        {
+            var part = matches[matchIndex].Value;
             Expression nextPropertyAccess;
 
             // Indexer
@@ -577,21 +581,28 @@ internal static partial class ObjectExtensions
                 );
             }
 
-            // Only check for type compatibility (i.e.: the need for conversion) if this is not the last match
-            if (match != matches[^1])
+            // Only check for type compatibility (i.e.: the need for conversion) if this is not the last match.
+            // We only specialize when the expression type is still object, to avoid over-specializing
+            // to a sample instance subtype and breaking mixed type rows.
+            if (matchIndex < matches.Count - 1 && current.Type == typeof(object))
             {
-                // Compile a lambda of the partial expression thus far (cast to object), to see if we need to add a cast
                 var lambdaTemp = Expression.Lambda<Func<object, object?>>(EnsureObjectCompatibleResult(current), parameterObj);
                 var funcCurrent = lambdaTemp.Compile();
-                // Evaluate this compiled function, to see if the result type is more specific than the current expression type. If so, cast to it
                 var result = funcCurrent(dataItem);
-                var typeResult = result?.GetType() ?? current.Type;
 
-                if (current.Type != typeResult)
+                // The partial result gives us the runtime container for the NEXT segment.
+                // Convert to the most general declaring type for that next segment (property/indexer)
+                // instead of converting directly to the concrete runtime subtype.
+                var typeResult = result?.GetType();
+                if (typeResult != null)
                 {
-                    // Note that we do not need to check for null before we convert, as the null check is already done in the previous condition
-                    // So, we can safely convert the expression to the result type, even for value types (without the null check, a conversion of null to e.g. an int would result in a NullException being thrown)
-                    current = Expression.Convert(current, typeResult);
+                    var nextPart = matches[matchIndex + 1].Value;
+                    var typeCompatible = GetDeclaringTypeForPathSegment(typeResult, nextPart) ?? typeResult;
+
+                    if (current.Type != typeCompatible)
+                    {
+                        current = Expression.Convert(current, typeCompatible);
+                    }
                 }
             }
         }
@@ -605,6 +616,48 @@ internal static partial class ObjectExtensions
         if (expression.Type.IsValueType)
             return Expression.Convert(expression, typeof(object));
         return expression;
+    }
+
+    /// <summary>
+    /// Resolves the declaring type for one binding-path segment on the provided candidate type.
+    /// </summary>
+    /// <param name="candidateType">The type on which the segment should be resolved.</param>
+    /// <param name="segment">One binding path segment, either a property name or an indexer token like "[0]".</param>
+    /// <returns>The segment declaring type when resolved; otherwise <see langword="null"/>.</returns>
+    private static Type? GetDeclaringTypeForPathSegment(Type candidateType, string segment)
+    {
+        if (string.IsNullOrWhiteSpace(segment))
+            return null;
+
+        // Indexer segment
+        if (segment.StartsWith('[') && segment.EndsWith(']'))
+        {
+            // Infer CLR argument types from parsed index values.
+            var indices = GetIndices(segment[1..^1]);
+            var indexTypes = indices.Select(i => i.GetType()).ToArray();
+
+            // Find an indexer whose parameter list is assignment-compatible with parsed index types.
+            // GetProperties includes inherited members, so we can resolve indexers declared on a base class as well.
+            var indexerInfo = candidateType
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(p => p.GetIndexParameters().Length == indexTypes.Length)
+                .FirstOrDefault(p =>
+                {
+                    var indexParameters = p.GetIndexParameters();
+                    for (var i = 0; i < indexParameters.Length; i++)
+                    {
+                        if (!indexParameters[i].ParameterType.IsAssignableFrom(indexTypes[i]))
+                            return false;
+                    }
+                    return true;
+                });
+
+            return indexerInfo?.DeclaringType;
+        }
+
+        // Property segment
+        var propertyInfo = candidateType.GetProperty(segment, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        return propertyInfo?.DeclaringType;
     }
 
     /// <summary>

--- a/src/Extensions/ObjectExtensions.cs
+++ b/src/Extensions/ObjectExtensions.cs
@@ -78,10 +78,17 @@ internal static partial class ObjectExtensions
 
         Expression current = parameterObj;
 
-        var actualType = dataItem.GetType();
-
-        if (current.Type != actualType && !actualType.IsValueType)
-            current = Expression.Convert(current, actualType);
+        // The function uses a generic object input parameter to allow for any type of data item,
+        // but we cast only to the root type that actually declares the first path segment.
+        // This keeps the accessor compatible with sibling subclasses in mixed collections.
+        {
+            var t = dataItem.GetType();
+            // Resolve the declaring type for the first segment (property or indexer).
+            // If we cannot resolve it, keep the original runtime type as fallback.
+            var typeRoot = matches.Count > 0 ? GetDeclaringTypeForPathSegment(t, matches[0].Value) ?? t : t;
+            if (current.Type != typeRoot && !typeRoot.IsValueType)
+                current = Expression.Convert(current, typeRoot);
+        }
 
         // Navigate to the parent object of the final path segment.
         for (int i = 0; i < matches.Count - 1; i++)
@@ -101,10 +108,13 @@ internal static partial class ObjectExtensions
             if (currentValue is null)
                 throw new ArgumentException($"Cannot build setter. Path segment '{part}' evaluates to null.");
 
-            var runtimeType = currentValue.GetType();
+            // Use the declaring type of the NEXT segment instead of the sample instance's runtime type.
+            // This prevents lock-in to a specific sibling subtype and maintains mixed-collection compatibility.
+            var nextSegment = matches[i + 1].Value;
+            var typeCompatible = GetDeclaringTypeForPathSegment(currentValue.GetType(), nextSegment) ?? currentValue.GetType();
 
-            if (current.Type != runtimeType)
-                current = Expression.Convert(current, runtimeType);
+            if (current.Type != typeCompatible)
+                current = Expression.Convert(current, typeCompatible);
         }
 
         var finalPart = matches[^1].Value;

--- a/tests/ObjectExtensionsTests.cs
+++ b/tests/ObjectExtensionsTests.cs
@@ -305,6 +305,61 @@ public class ObjectExtensionsTests
     }
 
     [TestMethod]
+    public void GetCompiledValueGetter_ShouldSupportMixedSiblingRows_WhenFirstPropertyDeclaredOnBaseType()
+    {
+        SharedRow first = new VariantRowA { Group = "AAA" };
+        var func = first.GetCompiledValueGetter("Group");
+        Assert.IsNotNull(func);
+
+        SharedRow second = new VariantRowB { Group = "BBB" };
+        var result = func(second);
+
+        Assert.AreEqual("BBB", result);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueGetter_ShouldSupportTwoStepPath_WithNestedSubclassValueFromDifferentSibling()
+    {
+        var first = new RootRowA
+        {
+            Shared = new SharedContainer
+            {
+                Nested = new NestedA { Name = "AAA" }
+            }
+        };
+
+        var func = first.GetCompiledValueGetter("Shared.Nested.Name");
+        Assert.IsNotNull(func);
+
+        var second = new RootRowB
+        {
+            Shared = new SharedContainer
+            {
+                Nested = new NestedB { Name = "BBB" }
+            }
+        };
+
+        var result = func(second);
+        Assert.AreEqual("BBB", result);
+    }
+
+    [TestMethod]
+    public void GetCompiledValueGetter_ShouldSupportIndexerFirstPath_WhenIndexerDeclaredOnBaseType()
+    {
+        SharedRow first = new VariantRowA();
+        first[1] = "AAA";
+
+        var func = first.GetCompiledValueGetter("[1]");
+        Assert.IsNotNull(func);
+
+        SharedRow second = new VariantRowB();
+        second[1] = "BBB";
+
+        var result = func(second);
+        Assert.AreEqual("BBB", result);
+    }
+
+    [TestMethod]
     public void GetCompiledValueSetter_ShouldSetSimpleProperty()
     {
         var testItem = new TestItem { Number = 7 };
@@ -928,6 +983,59 @@ public class ObjectExtensionsTests
     public struct TestStruct
     {
         public int Value { get; set; }
+    }
+    private abstract class SharedRow
+    {
+        public string Group { get; set; } = string.Empty;
+
+        private readonly Dictionary<int, string> _values = new();
+
+        public string this[int key]
+        {
+            get => _values[key];
+            set => _values[key] = value;
+        }
+    }
+
+    private class VariantRowA : SharedRow
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    private class VariantRowB : SharedRow
+    {
+        public bool Flag { get; set; }
+    }
+
+    private class RootBase
+    {
+        public SharedContainer Shared { get; set; } = new();
+    }
+
+    private class RootRowA : RootBase
+    {
+    }
+
+    private class RootRowB : RootBase
+    {
+    }
+
+    private class SharedContainer
+    {
+        public NestedBase Nested { get; set; } = new NestedA();
+    }
+
+    private class NestedBase
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private class NestedA : NestedBase
+    {
+    }
+
+    private class NestedB : NestedBase
+    {
     }
 }
 


### PR DESCRIPTION
@w-ahmad , back again with an fix/improvement on the Func/BindingPath code.

Ref this PR, https://github.com/w-ahmad/WinUI.TableView/pull/178, in which we worked on generating a Func at runtime once, instead of repeated reflection to get a cell's value.
In the comments on that PR (https://github.com/w-ahmad/WinUI.TableView/pull/178#issuecomment-3170721582), I already mentioned that the current Func is built just using the first instance for which we happen do a GetPropertyValue(), which might cause trouble.

**The specific problem**: If the instances used for the rows in the table is a mixture of subclasses, and the (first) binding (step) is to an element on the shared parent class, the current code will throw an InvalidCastException when sorting.

The reason is that the first instance that is used to built the Func, dictates the explicit type cast that is done;
An example: suppose the type of the instance is MySubClass and for a column our BindingPath is "MyProperty", the current code in main generates this:

```
.Lambda #Lambda1<System.Func`2[System.Object,System.Object]>(System.Object $obj) {
    .If ((MySubClass)$obj != null) {
        ((MySubClass)$obj).MyProperty
    } .Else {
        null
    }
}
```

However, if MyProperty is actually defined on MySuperClass, that code should use a cast to that type instead:

```
.Lambda #Lambda1<System.Func`2[System.Object,System.Object]>(System.Object $obj) {
    .If ((MySuperClass)$obj != null) {
        ((MySuperClass)$obj).MyProperty
    } .Else {
        null
    }
}
```

This way, if the CollectionView contains a mixture of instance of different subclasses for MySuperClass, we won't get an InvalidCastException.

**Furthermore**:
- The above example is only about the first segment in the Binding Path, but the subclassing can affect any segment of the binding path (different subclass instances, causing a potential InvalidCastException),  but this PR handles this as well, and I added Tests for the case this subclassing happens further on in the BindingPath
- While merging the latest `main`, I noticed you added a func for the Setter variant, so I also hardened your code so it will handle subclassing
- Did some small renaming "PropertyPath" -> "BindingPath" (leftover from my initial code, which was not representative)
- Then, your new Setter flow seemed to partially duplicate the Getter flow, and I figured that both flows are basically the same, except for the last segment of the BindingPath:  For the Setter func, you do the set action. Hence, I refactored this, which resulted in a bit less code, and should make the difference between the two flows clearer.
     - This refactor gave rise to a subtle bug in the code (thanks to your test case!) which surfaced due to the above, different casting (before, the cast to the more specific subclass would `cover' this). See the last commit for the fix, and the commit description for more details.

The above points are in order and in separate commits. 