### PR TITLE
Bugfix: Column width regression (since C#14 refactor & cleanup)

### DIFF
--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -375,6 +375,11 @@ public partial class TableView : ListView
     /// </summary>
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
+        if (_isItemsSourceSuspended) // indicates that the control was unloaded and loaded back
+        {
+            HeaderRow?.CalculateHeaderWidths();  // Needed when switching back to an existing TableView (without provided column Widths)
+        }
+
         ResumeItemsSource();
         EnsureAutoColumns();
     }

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -394,7 +394,7 @@ public partial class TableView : ListView
     {
         if (_isItemsSourceSuspended) // indicates that the control was unloaded and loaded back
         {
-            HeaderRow?.CalculateHeaderWidths();  // Needed when switching back to an existing TableView (without provided column Widths)
+            _headerRow?.CalculateHeaderWidths();  // Needed when switching back to an existing TableView (without provided column Widths)
         }
 
         ResumeItemsSource();

--- a/src/TableViewHeaderRow.cs
+++ b/src/TableViewHeaderRow.cs
@@ -204,6 +204,7 @@ public partial class TableViewHeaderRow : Control
         }
         else if (e.PropertyName is nameof(TableViewColumn.DesiredWidth))
         {
+            // Coalesce multiple updates (see in-loop Measure() call in CalculateHeaderWidths) to avoid excessive header width calculations.
             _desiredWidthTimer ??= new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
             _desiredWidthTimer.Tick -= OnDesiredWidthTimerTick;
             _desiredWidthTimer.Tick += OnDesiredWidthTimerTick;

--- a/src/TableViewHeaderRow.cs
+++ b/src/TableViewHeaderRow.cs
@@ -41,6 +41,7 @@ public partial class TableViewHeaderRow : Control
     private Border? _columnDropIndicator;
     private TranslateTransform? _columnDropIndicatorTransform;
     private Image? _dragHeaderImage;
+    private DispatcherTimer? _desiredWidthTimer;
     private bool _calculatingHeaderWidths;
     private int _dropColumnIndex;
     private bool _isValidDropTarget;
@@ -200,6 +201,27 @@ public partial class TableViewHeaderRow : Control
             {
                 CalculateHeaderWidths();
             }
+        }
+        else if (e.PropertyName is nameof(TableViewColumn.DesiredWidth))
+        {
+            _desiredWidthTimer ??= new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
+            _desiredWidthTimer.Tick -= OnDesiredWidthTimerTick;
+            _desiredWidthTimer.Tick += OnDesiredWidthTimerTick;
+            _desiredWidthTimer.Stop();
+            _desiredWidthTimer.Start();
+        }
+    }
+
+    /// <summary>
+    /// Recalculates header widths after deferred desired-width updates.
+    /// </summary>
+    private void OnDesiredWidthTimerTick(object? sender, object e)
+    {
+        _desiredWidthTimer?.Stop();
+
+        if (!_calculatingHeaderWidths)
+        {
+            CalculateHeaderWidths();
         }
     }
 


### PR DESCRIPTION
### Description:
Using the latest version, I noticed that vertical grid lines (header <> rows) are mis-aligned when (tab-based) navigating away and later returning back to a TableView, which has columns for which I did not specify Widths.

https://github.com/user-attachments/assets/a4461395-426a-4cb4-82c0-5985604960eb

### Steps to Reproduce:
1. In the `SampleApp` project:
     1.  in method `ExampleModelColumnsHelper.OnAutoGeneratingColumns()` **comment out** all lines that set the column widths, e.g.: 
           ```
                //e.Column.Width = new GridLength(60);
           ```

      2. In `GridLinesPage.xaml` replace lines 19-21 (the tableview component) with this code:
            ```
                <TabView>
                    <TabViewItem Header="TableView">
                        <tv:TableView x:Name="tableView"
                                      ItemsSource="{Binding Items}"
                                      AutoGeneratingColumn="{x:Bind local:ExampleModelColumnsHelper.OnAutoGeneratingColumns}" />
                    </TabViewItem>
                    <TabViewItem Header="Tabpage for reproduction test">Some text; navigate to here, and back to see if grid lines are still okay</TabViewItem>
                </TabView>
            ```

3. Switch the TableView lib project to commit **bf6208028fabf11413a87969d3acb3c8431b904f** or newer
4. Run the application, and go to the Gridlines example; switch to the "reproduction" tab, and back to the tab with the TableView, and you should see mis-aligned columns

### Expected behavior:
Grid lines should always align, ideally with auto-resizing for columns for which no Width was provided.

### Contribution:
- Narrowed it down to the changes in commit **bf6208028fabf11413a87969d3acb3c8431b904f** (refactor for C# 14);
- The timer logic was removed, and with it the auto calc of the column widths after DesiredWidth updates; restored that code
- In addition CalculateHeaderWidths() is now also triggered from the OnLoaded, which solves my specific problem (switching away and back to the tab with the TableView)
        
https://github.com/user-attachments/assets/ef01af58-41ef-48be-be53-bddf6d954f3b
