### PR TITLE
Feature: Allow to Persist table state (column order/width/visibility, sorting, filtering)

### DIFF
--- a/src/EventArgs/TableViewStateChangedEventArgs.cs
+++ b/src/EventArgs/TableViewStateChangedEventArgs.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Provides data for the <see cref="TableView.StateChanged"/> event.
+/// </summary>
+public class TableViewStateChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableViewStateChangedEventArgs"/> class.
+    /// </summary>
+    /// <param name="kind">The kind of change that triggered the event.</param>
+    public TableViewStateChangedEventArgs(TableViewStateChangedKind kind)
+    {
+        Kind = kind;
+    }
+
+    /// <summary>
+    /// Gets the kind of change that triggered the event.
+    /// </summary>
+    public TableViewStateChangedKind Kind { get; }
+}

--- a/src/EventArgs/TableViewStateChangedKind.cs
+++ b/src/EventArgs/TableViewStateChangedKind.cs
@@ -1,0 +1,22 @@
+namespace WinUI.TableView;
+
+/// <summary>
+/// Identifies the kind of change that raised a <see cref="TableView.StateChanged"/> event.
+/// </summary>
+public enum TableViewStateChangedKind
+{
+    /// <summary>
+    /// One or more sort descriptions were added, removed, or cleared.
+    /// </summary>
+    Sort,
+
+    /// <summary>
+    /// One or more filter descriptions were added, removed, or cleared.
+    /// </summary>
+    Filter,
+
+    /// <summary>
+    /// A column was reordered, or its width or visibility changed.
+    /// </summary>
+    Column,
+}

--- a/src/Helpers/TableViewStateHelper.cs
+++ b/src/Helpers/TableViewStateHelper.cs
@@ -1,0 +1,317 @@
+using Microsoft.UI.Xaml;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace WinUI.TableView.Helpers;
+
+/// <summary>
+/// Provides methods to capture and apply <see cref="TableViewState"/> snapshots,
+/// enabling persistence of a <see cref="TableView"/>'s sort, filter, and column layout state.
+/// </summary>
+/// <remarks>
+/// This helper operates exclusively on state that can be round-tripped through serialization.
+/// Runtime-only constructs (such as <see cref="FilterDescription.Predicate"/>) are intentionally
+/// excluded — see the filter-related methods for details. Serialization itself (e.g. JSON) is
+/// the responsibility of the consuming application.
+/// </remarks>
+internal static class TableViewStateHelper
+{
+    /// <summary>
+    /// Captures the current sort, filter, and column layout state of <paramref name="tableView"/>
+    /// into a new <see cref="TableViewState"/> instance.
+    /// </summary>
+    /// <param name="tableView">The table view whose state should be captured.</param>
+    /// <returns>A <see cref="TableViewState"/> representing the current state.</returns>
+    internal static TableViewState Capture(TableView tableView)
+    {
+        ArgumentNullException.ThrowIfNull(tableView);
+
+        var state = new TableViewState();
+        CaptureSort(tableView, state);
+        CaptureFilter(tableView, state);
+        CaptureColumns(tableView, state);
+        return state;
+    }
+
+    /// <summary>
+    /// Applies a previously captured <paramref name="state"/> to <paramref name="tableView"/>,
+    /// restoring its sort, filter, and column layout state.
+    /// Columns are restored first so that ordering is correct before sort and filter are applied.
+    /// Unrecognised column keys are silently skipped; a <see langword="null"/>
+    /// <paramref name="state"/> is a no-op.
+    /// </summary>
+    /// <param name="tableView">The target table view.</param>
+    /// <param name="state">The state to apply, or <see langword="null"/> to skip.</param>
+    internal static void Apply(TableView tableView, TableViewState? state)
+    {
+        ArgumentNullException.ThrowIfNull(tableView);
+
+        if (state is null)
+        {
+            return;
+        }
+
+        ApplyColumns(tableView, state.Columns);
+        ApplySort(tableView, state.SortDescriptions);
+        ApplyFilter(tableView, state.FilterDescriptions);
+    }
+
+    // ── Sort ──────────────────────────────────────────────────────────────────
+
+    private static void CaptureSort(TableView tableView, TableViewState state)
+    {
+        foreach (var sd in tableView.SortDescriptions)
+        {
+            state.SortDescriptions.Add(new TableViewSortDescriptionState
+            {
+                PropertyName = sd.PropertyName,
+                Direction = sd.Direction,
+            });
+        }
+    }
+
+    private static void ApplySort(TableView tableView, IEnumerable<TableViewSortDescriptionState> sortDescriptions)
+    {
+        tableView.SortDescriptions.Clear();
+
+        foreach (var sd in sortDescriptions)
+        {
+            if (string.IsNullOrWhiteSpace(sd.PropertyName))
+            {
+                continue;
+            }
+
+            tableView.SortDescriptions.Add(new SortDescription(sd.PropertyName, sd.Direction));
+        }
+    }
+
+    // ── Filter ────────────────────────────────────────────────────────────────
+    //
+    // FilterDescription.Predicate is a runtime-only lambda and cannot be serialized.
+    // Only the user-selected values from FilterHandler.SelectedValues are captured (as strings).
+    // On restore, the predicate is reconstructed by calling FilterHandler.ApplyFilter,
+    // which rebuilds it from the restored SelectedValues.
+
+    private static void CaptureFilter(TableView tableView, TableViewState state)
+    {
+        foreach (var fd in tableView.FilterDescriptions)
+        {
+            // ColumnFilterDescription (internal) carries a direct column reference; use it
+            // when available to avoid the slower property-name lookup.
+            var column = fd is ColumnFilterDescription cfd
+                ? cfd.Column
+                : FindColumnByPropertyName(tableView, fd.PropertyName);
+
+            if (column is null)
+            {
+                continue;
+            }
+
+            var filterState = new TableViewFilterDescriptionState
+            {
+                ColumnKey = GetColumnKey(column),
+            };
+
+            if (tableView.FilterHandler.SelectedValues.TryGetValue(column, out var selectedValues))
+            {
+                foreach (var value in selectedValues)
+                {
+                    filterState.SelectedValues.Add(value?.ToString());
+                }
+            }
+
+            state.FilterDescriptions.Add(filterState);
+        }
+    }
+
+    private static void ApplyFilter(TableView tableView, IEnumerable<TableViewFilterDescriptionState> filterDescriptions)
+    {
+        // Clear all existing column filters before restoring.
+        tableView.FilterHandler?.ClearFilter(null);
+
+        foreach (var filterState in filterDescriptions)
+        {
+            if (string.IsNullOrWhiteSpace(filterState.ColumnKey) || filterState.SelectedValues.Count == 0)
+            {
+                continue;
+            }
+
+            var column = FindColumnByKey(tableView, filterState.ColumnKey);
+            if (column is null)
+            {
+                continue;
+            }
+
+            var targetType = FindColumnValueType(tableView, column);
+            var selectedValues = filterState.SelectedValues
+                .Select(v => ConvertFromString(v, targetType))
+                .ToList<object?>();
+
+            tableView.FilterHandler.SelectedValues[column] = selectedValues;
+            tableView.FilterHandler.ApplyFilter(column);
+        }
+    }
+
+    // ── Columns ───────────────────────────────────────────────────────────────
+
+    private static void CaptureColumns(TableView tableView, TableViewState state)
+    {
+        for (var index = 0; index < tableView.Columns.Count; index++)
+        {
+            var column = tableView.Columns[index];
+            state.Columns.Add(new TableViewColumnState
+            {
+                Key = GetColumnKey(column),
+                Header = column.Header?.ToString(),
+                Visibility = column.Visibility,
+                DisplayIndex = index,
+                WidthValue = column.Width.Value,
+                WidthUnitType = column.Width.GridUnitType,
+            });
+        }
+    }
+
+    private static void ApplyColumns(TableView tableView, IEnumerable<TableViewColumnState> columns)
+    {
+        foreach (var columnState in columns.OrderBy(c => c.DisplayIndex))
+        {
+            var column = FindColumnByKey(tableView, columnState.Key);
+            if (column is null)
+            {
+                continue;
+            }
+
+            // Only restore the header if a non-empty string was saved, to avoid overwriting
+            // complex header objects (e.g. DataTemplates set by code) with a plain string.
+            if (!string.IsNullOrWhiteSpace(columnState.Header))
+            {
+                column.Header = columnState.Header;
+            }
+
+            column.Visibility = columnState.Visibility;
+            column.Width = new GridLength(columnState.WidthValue, columnState.WidthUnitType);
+
+            var currentIndex = tableView.Columns.IndexOf(column);
+            var targetIndex = Math.Clamp(columnState.DisplayIndex, 0, tableView.Columns.Count - 1);
+            if (currentIndex >= 0 && currentIndex != targetIndex)
+            {
+                tableView.Columns.Move(currentIndex, targetIndex);
+            }
+        }
+    }
+
+    // ── Key resolution ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the stable key used to identify a column across sessions.
+    /// </summary>
+    private static string GetColumnKey(TableViewColumn column)
+    {
+        // For bound columns the binding property path is the primary key because it is
+        // semantically tied to the data model: if the binding changes, the column represents
+        // different data and a state miss is the correct outcome.
+        // Edge case: if two bound columns share the same property path, set Tag on both
+        // to disambiguate; Tag takes precedence in that case (see the fallback below).
+        if (column is TableViewBoundColumn boundColumn
+            && !string.IsNullOrWhiteSpace(boundColumn.PropertyPath))
+        {
+            return boundColumn.PropertyPath!;
+        }
+
+        // For template columns (which have no binding), Tag is the primary key — it is
+        // developer-assigned and intentional. Changing the Tag signals a deliberate identity
+        // change, so a state miss is the correct outcome.
+        // Header is a last resort and is fragile (may be localised or display-renamed
+        // without any change to the column's purpose).
+        return column.Tag?.ToString()
+            ?? column.Header?.ToString()
+            ?? string.Empty;
+    }
+
+    private static TableViewColumn? FindColumnByKey(TableView tableView, string? key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return null;
+        }
+
+        return tableView.Columns
+            .FirstOrDefault(c => string.Equals(GetColumnKey(c), key, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static TableViewColumn? FindColumnByPropertyName(TableView tableView, string? propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(propertyName))
+        {
+            return null;
+        }
+
+        foreach (var column in tableView.Columns)
+        {
+            if (column is TableViewBoundColumn boundColumn
+                && string.Equals(boundColumn.PropertyPath, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return column;
+            }
+
+            if (string.Equals(column.SortMemberPath, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return column;
+            }
+        }
+
+        return null;
+    }
+
+    // ── Filter value type resolution ───────────────────────────────────────────
+
+    private static Type? FindColumnValueType(TableView tableView, TableViewColumn column)
+    {
+        if (tableView.ItemsSource is not IEnumerable items)
+        {
+            return null;
+        }
+
+        foreach (var item in items)
+        {
+            var value = column.GetCellContent(item);
+            if (value is not null)
+            {
+                return value.GetType();
+            }
+        }
+
+        return null;
+    }
+
+    private static object? ConvertFromString(string? value, Type? targetType)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (targetType is null || targetType == typeof(string))
+        {
+            return value;
+        }
+
+        var underlying = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+        if (underlying == typeof(bool) && bool.TryParse(value, out var boolVal)) return boolVal;
+        if (underlying == typeof(int) && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intVal)) return intVal;
+        if (underlying == typeof(long) && long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longVal)) return longVal;
+        if (underlying == typeof(short) && short.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var shortVal)) return shortVal;
+        if (underlying == typeof(float) && float.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var floatVal)) return floatVal;
+        if (underlying == typeof(double) && double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleVal)) return doubleVal;
+        if (underlying == typeof(decimal) && decimal.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var decimalVal)) return decimalVal;
+        if (underlying == typeof(Guid) && Guid.TryParse(value, out var guidVal)) return guidVal;
+        if (underlying == typeof(DateTime) && DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dateTimeVal)) return dateTimeVal;
+        if (underlying.IsEnum && Enum.TryParse(underlying, value, ignoreCase: true, out var enumVal)) return enumVal;
+
+        return value;
+    }
+}

--- a/src/TableView.Events.cs
+++ b/src/TableView.Events.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.UI.Xaml;
 using System;
+using System.Collections.Specialized;
 using System.ComponentModel;
+using WinUI.TableView.Helpers;
 
 namespace WinUI.TableView;
 
@@ -77,6 +79,39 @@ partial class TableView
     protected virtual void OnPasteFromClipboard(TableViewPasteFromClipboardEventArgs args)
     {
         PasteFromClipboard?.Invoke(this, args);
+    }
+
+    /// <summary>
+    /// Occurs when the sort order, active filters, or column layout (width, visibility, or order)
+    /// of the table view changes due to a user action.
+    /// Consumers can handle this event to persist and (later) restore the state via <see cref="TableView.State"/> 
+    /// </summary>
+    public event EventHandler<TableViewStateChangedEventArgs>? StateChanged;
+    
+    private void RaiseStateChanged(TableViewStateChangedKind kind)
+    {
+        StateChanged?.Invoke(this, new TableViewStateChangedEventArgs(kind));
+    }
+
+    private void OnColumnsPropertyChangedForState(object? sender, TableViewColumnPropertyChangedEventArgs e)
+    {
+        // Width and Visibility are user-driven layout choices that should be persisted.
+        // Other property changes (ActualWidth, CellStyle, IsFrozen, etc.) are rendering or
+        // code-controlled concerns and do not represent a user state change.
+        if (e.PropertyName is nameof(TableViewColumn.Width) or nameof(TableViewColumn.Visibility))
+        {
+            RaiseStateChanged(TableViewStateChangedKind.Column);
+        }
+    }
+
+    private void OnColumnsCollectionChangedForState(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        // Only column reorder (Move) is treated as a state change; Add and Remove are
+        // structural setup actions driven by code, not user-driven layout adjustments.
+        if (e.Action == NotifyCollectionChangedAction.Move)
+        {
+            RaiseStateChanged(TableViewStateChangedKind.Column);
+        }
     }
 
     /// <summary>

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -339,6 +339,16 @@ public partial class TableView
     }
 
     /// <summary>
+    /// Gets or sets the current (run-time) state of the TableView, which includes sort, filter, and column layout
+    /// into a single serializable object of type <see cref="TableViewState"/>. This can be used for persisting and restoring the state of the TableView.
+    /// </summary>
+    public TableViewState State
+    {
+        get => TableViewStateHelper.Capture(this);
+        set => TableViewStateHelper.Apply(this, value);
+    }
+
+    /// <summary>
     /// Gets or sets the last selection unit used.
     /// </summary>
     internal TableViewSelectionUnit LastSelectionUnit { get; set; }

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Media;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
@@ -71,6 +72,12 @@ public partial class TableView : ListView
         Unloaded += OnUnloaded;
         SelectionChanged += TableView_SelectionChanged;
         _collectionView.ItemPropertyChanged += OnItemPropertyChanged;
+
+        // Wire StateChanged to sort, filter and to column property / reorder changes
+        ((INotifyCollectionChanged)SortDescriptions).CollectionChanged += (_, _) => RaiseStateChanged(TableViewStateChangedKind.Sort);
+        ((INotifyCollectionChanged)FilterDescriptions).CollectionChanged += (_, _) => RaiseStateChanged(TableViewStateChangedKind.Filter);
+        Columns.ColumnPropertyChanged += OnColumnsPropertyChangedForState;
+        Columns.CollectionChanged += OnColumnsCollectionChangedForState;
     }
 
     /// <summary>

--- a/src/TableViewState.cs
+++ b/src/TableViewState.cs
@@ -1,0 +1,100 @@
+using Microsoft.UI.Xaml;
+using System.Collections.Generic;
+using WinUI.TableView.Helpers;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Represents a captured snapshot of a <see cref="TableView"/>'s sort, filter, and column
+/// layout state that can be persisted and restored via <see cref="TableViewStateHelper"/>.
+/// </summary>
+public sealed class TableViewState
+{
+    /// <summary>
+    /// Gets or sets the sort descriptions captured from the table view.
+    /// </summary>
+    public List<TableViewSortDescriptionState> SortDescriptions { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the filter descriptions captured from the table view.
+    /// </summary>
+    public List<TableViewFilterDescriptionState> FilterDescriptions { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the column layout captured from the table view.
+    /// </summary>
+    public List<TableViewColumnState> Columns { get; set; } = [];
+}
+
+/// <summary>
+/// Represents the persisted state of a sort description.
+/// </summary>
+public sealed class TableViewSortDescriptionState
+{
+    /// <summary>
+    /// Gets or sets the name of the property to sort by.
+    /// </summary>
+    public string? PropertyName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sort direction.
+    /// </summary>
+    public SortDirection Direction { get; set; }
+}
+
+/// <summary>
+/// Represents the persisted state of a column filter.
+/// </summary>
+/// <remarks>
+/// Only the user-selected values are persisted, not the predicate. The predicate is
+/// reconstructed from the selected values when the state is applied.
+/// </remarks>
+public sealed class TableViewFilterDescriptionState
+{
+    /// <summary>
+    /// Gets or sets the key that identifies the column this filter applies to.
+    /// </summary>
+    public string? ColumnKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user-selected filter values, serialized as strings.
+    /// A <see langword="null"/> entry represents a blank (null or empty) data value.
+    /// </summary>
+    public List<string?> SelectedValues { get; set; } = [];
+}
+
+/// <summary>
+/// Represents the persisted layout state of a single column.
+/// </summary>
+public sealed class TableViewColumnState
+{
+    /// <summary>
+    /// Gets or sets the key that identifies the column.
+    /// </summary>
+    public string? Key { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header text of the column as it was when captured.
+    /// </summary>
+    public string? Header { get; set; }
+
+    /// <summary>
+    /// Gets or sets the visibility of the column.
+    /// </summary>
+    public Visibility Visibility { get; set; } = Visibility.Visible;
+
+    /// <summary>
+    /// Gets or sets the zero-based display index (order) of the column.
+    /// </summary>
+    public int DisplayIndex { get; set; }
+
+    /// <summary>
+    /// Gets or sets the numeric value of the column width.
+    /// </summary>
+    public double WidthValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets the unit type of the column width.
+    /// </summary>
+    public GridUnitType WidthUnitType { get; set; } = GridUnitType.Auto;
+}


### PR DESCRIPTION
@w-ahmad  Usability feature that I needed myself, and wanted to share, as probably more people may like to use this.

This PR adds
- a StateChanged event,
- a State get/set property to the TableView;
    - state includes all things the user can influence at runtime; column order, sorting, 
- which interacts with a Helper to get/set the current column/sorting/filtering state in/from a State object
- that state object can be used to store to e.g. the AppSettings, using the JsonSerializer

## Notes
- Designed to be opt-in, and minimal changes to existing code.
- the state setting code is forgiving; best effort processing (persisted state could (partially) mismatch after column changes by developer)
- matching is done for bound columns based on path (Tag is secondary, when multiple matches); for template columns the Tag/Name is used.

## Column Visibility
Note that this State also includes "Visibility"; I don't think we have functionality yet to hide columns in a built-in fashion, do we?
I would love to add this as well, as with this PR it would allows users to modify a column, and persist their preferred order and visibility etc.

## New Column
Furthermore, I would think these are great additionals to runtime configurability:
- We could allow (totally new!) columns to be added at runtime; based on the associated (abstract) type in the CollectionView, we could create a dialog where users choose a property to add a new column, and then obviously persist those across sessions. (This could be even more advanced, by using reflection to `walk' the model and choose a binding path)
- In addition, it would then also be good to allow columns to be renamed (the default property name might not do the functional context justice)

## Grouping
Also the Grouping feature (this PR: https://github.com/w-ahmad/WinUI.TableView/pull/340) would be excellent to be end-user configurable (out-of-the-box), and persist-able. Of course the developer could set a default, but we could allow to change the grouping column via a context menu on the header of a column.
I hope you will consider to merge your implementation of the grouping 🙏, as it seems functionally very valuable have.
