### PR TITLE
feat: Add `CellWithRow` selection support

### DIFF
--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -1012,7 +1012,7 @@ public partial class TableView
     {
         if (d is TableView tableView)
         {
-            if (tableView.SelectionUnit is TableViewSelectionUnit.Row)
+            if (tableView.SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellWithRow)
             {
                 tableView.SelectedCellRanges.Clear();
                 tableView.OnCellSelectionChanged();

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -43,6 +43,7 @@ public partial class TableView : ListView
     private Border? _dragRectangle;
     private Point? _dragStartPoint;
     private bool _cellSelectionDirty;
+    private bool _suppressSelectionChangedCellClear;
     private Point? _lastDragCanvasPoint;
     private DispatcherTimer? _autoScrollTimer;
     private double _autoScrollVerticalDelta;
@@ -78,21 +79,28 @@ public partial class TableView : ListView
     /// </summary>
     private void TableView_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (!KeyboardHelper.IsCtrlKeyDown())
+        if (_suppressSelectionChangedCellClear)
         {
-            SelectedCellRanges.Clear();
+            _suppressSelectionChangedCellClear = false;
         }
         else
         {
-            SelectedCellRanges.RemoveWhere(slots =>
+            if (!KeyboardHelper.IsCtrlKeyDown())
             {
-                slots.RemoveWhere(slot => SelectedRanges.Any(range => range.IsInRange(slot.Row)));
-                return slots.Count == 0;
-            });
-        }
+                SelectedCellRanges.Clear();
+            }
+            else
+            {
+                SelectedCellRanges.RemoveWhere(slots =>
+                {
+                    slots.RemoveWhere(slot => SelectedRanges.Any(range => range.IsInRange(slot.Row)));
+                    return slots.Count == 0;
+                });
+            }
 
-        CurrentCellSlot = null;
-        OnCellSelectionChanged();
+            CurrentCellSlot = null;
+            OnCellSelectionChanged();
+        }
 
         if (SelectedItems?.Count == 1)
         {
@@ -1114,9 +1122,12 @@ public partial class TableView : ListView
         {
             ctrlKey = ctrlKey || SelectionMode is ListViewSelectionMode.Multiple;
 
-            if (SelectionUnit is TableViewSelectionUnit.Row
-               || (LastSelectionUnit is TableViewSelectionUnit.Row && slot.IsValidRow(this) && !slot.IsValidColumn(this))
-               || (SelectionUnit is TableViewSelectionUnit.CellOrRow && slot.IsValidRow(this) && !slot.IsValidColumn(this)))
+            var shouldSelectRows = SelectionUnit is TableViewSelectionUnit.Row
+                || (SelectionUnit is TableViewSelectionUnit.CellWithRow && !slot.IsValidColumn(this))
+                || (LastSelectionUnit is TableViewSelectionUnit.Row && slot.IsValidRow(this) && !slot.IsValidColumn(this))
+                || (SelectionUnit is TableViewSelectionUnit.CellOrRow && slot.IsValidRow(this) && !slot.IsValidColumn(this));
+
+            if (shouldSelectRows)
             {
                 if (!ctrlKey)
                     DeselectAllCells();
@@ -1125,8 +1136,16 @@ public partial class TableView : ListView
             }
             else
             {
-                if (!ctrlKey)
+                if (SelectionUnit is TableViewSelectionUnit.CellWithRow)
+                {
+                    _suppressSelectionChangedCellClear = true;
+                    SelectRows(slot, shiftKey, ctrlKey);
+                }
+                else if (!ctrlKey)
+                {
                     DeselectAllItems();
+                }
+
                 SelectCells(slot, shiftKey, ctrlKey);
                 LastSelectionUnit = TableViewSelectionUnit.Cell;
             }
@@ -1210,12 +1229,29 @@ public partial class TableView : ListView
 
         if (!ctrlKey || !(SelectionMode is ListViewSelectionMode.Multiple or ListViewSelectionMode.Extended))
         {
-            DeselectAll();
+            if (SelectionUnit is TableViewSelectionUnit.CellWithRow)
+            {
+                DeselectAllCells();
+            }
+            else
+            {
+                DeselectAll();
+            }
         }
 
         var selectionRange = (SelectionStartCellSlot is null ? null : SelectedCellRanges.LastOrDefault(x => SelectionStartCellSlot.HasValue && x.Contains(SelectionStartCellSlot.Value))) ?? [];
-        SelectedCellRanges.Remove(selectionRange);
-        selectionRange.Clear();
+
+        if (ctrlKey && SelectionMode is ListViewSelectionMode.Multiple or ListViewSelectionMode.Extended)
+        {
+            selectionRange = SelectedCellRanges.SelectMany(x => x).ToHashSet();
+            SelectedCellRanges.Clear();
+        }
+        else
+        {
+            SelectedCellRanges.Remove(selectionRange);
+            selectionRange.Clear();
+        }
+
         SelectionStartCellSlot ??= CurrentCellSlot;
         SelectionStartCellSlot ??= slot;
 

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -1122,6 +1122,7 @@ public partial class TableView : ListView
         {
             ctrlKey = ctrlKey || SelectionMode is ListViewSelectionMode.Multiple;
 
+            _suppressSelectionChangedCellClear = SelectionUnit is TableViewSelectionUnit.CellWithRow;
             var shouldSelectRows = SelectionUnit is TableViewSelectionUnit.Row
                 || (SelectionUnit is TableViewSelectionUnit.CellWithRow && !slot.IsValidColumn(this))
                 || (LastSelectionUnit is TableViewSelectionUnit.Row && slot.IsValidRow(this) && !slot.IsValidColumn(this))
@@ -1137,8 +1138,7 @@ public partial class TableView : ListView
             else
             {
                 if (SelectionUnit is TableViewSelectionUnit.CellWithRow)
-                {
-                    _suppressSelectionChangedCellClear = true;
+                {                    
                     SelectRows(slot, shiftKey, ctrlKey);
                 }
                 else if (!ctrlKey)
@@ -1860,7 +1860,6 @@ public partial class TableView : ListView
     private void UpdateBaseSelectionMode()
     {
         _shouldThrowSelectionModeChangedException = true;
-
         base.SelectionMode = SelectionUnit is TableViewSelectionUnit.Cell ? ListViewSelectionMode.None : SelectionMode;
 
         UpdateHorizontalScrollBarMargin();

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -186,7 +186,7 @@ public partial class TableViewRow : ListViewItem
     {
         base.OnTapped(e);
 
-        if (TableView?.SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow)
+        if (TableView?.SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow or TableViewSelectionUnit.CellWithRow)
         {
             TableView.CurrentRowIndex = Index;
             TableView.LastSelectionUnit = TableViewSelectionUnit.Row;

--- a/src/TableViewSelectionUnit.cs
+++ b/src/TableViewSelectionUnit.cs
@@ -6,9 +6,14 @@
 public enum TableViewSelectionUnit
 {
     /// <summary>
-    /// Selection can be either a cell or a row.
+    /// Selection can be either a cell or a row, but selecting a cell does not select the owning row.
     /// </summary>
     CellOrRow,
+
+    /// <summary>
+    /// Selection can be either a cell or a row, but selecting a cell also selects the owning row.
+    /// </summary>
+    CellWithRow,
 
     /// <summary>
     /// Selection is limited to cells.

--- a/tests/TableViewSelectionUnitTests.cs
+++ b/tests/TableViewSelectionUnitTests.cs
@@ -1,0 +1,124 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System.Threading.Tasks;
+
+namespace WinUI.TableView.Tests;
+
+[TestClass]
+public class TableViewSelectionUnitTests
+{
+    [UITestMethod]
+    public async Task CellWithRow_CellClickSelectsCellAndOwningRow()
+    {
+        var tableView = await CreateTableViewAsync(TableViewSelectionUnit.CellWithRow);
+
+        tableView.MakeSelection(new TableViewCellSlot(1, 0), false, false);
+
+        await Task.Yield(); // Allow selection to propagate
+    
+        Assert.IsTrue(tableView.SelectedCells.Contains(new TableViewCellSlot(1, 0)));
+        Assert.AreEqual(1, tableView.SelectedItems.Count);
+        Assert.AreSame(tableView.Items[1], tableView.SelectedItem);
+    }
+
+    [UITestMethod]
+    public async Task CellAndRow_RowHeaderClickSelectsOnlyRow()
+    {
+        var tableView = await CreateTableViewAsync(TableViewSelectionUnit.CellWithRow);
+
+        tableView.MakeSelection(new TableViewCellSlot(1, -1), false, false);
+
+        Assert.AreEqual(0, tableView.SelectedCells.Count);
+        Assert.AreEqual(1, tableView.SelectedItems.Count);
+        Assert.AreSame(tableView.Items[1], tableView.SelectedItem);
+    }
+
+    [UITestMethod]
+    public async Task CellSelectionUnitStillSelectsOnlyCells()
+    {
+        var tableView = await CreateTableViewAsync(TableViewSelectionUnit.Cell);
+
+        tableView.MakeSelection(new TableViewCellSlot(0, 0), false, false);
+
+        await Task.Yield(); // Allow selection to propagate
+
+        tableView.MakeSelection(new TableViewCellSlot(1, 1), false, true);
+
+        await Task.Yield(); // Allow selection to propagate
+
+        Assert.AreEqual(0, tableView.SelectedItems.Count);
+        Assert.AreEqual(2, tableView.SelectedCells.Count);
+        Assert.IsTrue(tableView.SelectedCells.Contains(new TableViewCellSlot(0, 0)));
+        Assert.IsTrue(tableView.SelectedCells.Contains(new TableViewCellSlot(1, 1)));
+    }
+
+    [UITestMethod]
+    public async Task CellOrRowSelectionUnitStillUsesCellAndRowSemantics()
+    {
+        var tableView = await CreateTableViewAsync(TableViewSelectionUnit.CellOrRow);
+
+        tableView.MakeSelection(new TableViewCellSlot(1, 0), false, false);
+        Assert.AreEqual(0, tableView.SelectedItems.Count);
+
+        tableView.MakeSelection(new TableViewCellSlot(0, -1), false, false);
+        Assert.AreEqual(1, tableView.SelectedItems.Count);
+        Assert.AreEqual(0, tableView.SelectedCells.Count);
+    }
+
+    [UITestMethod]
+    public async Task CellWithRow_MultiSelectionAddsCellAndRowSelections()
+    {
+        var tableView = await CreateTableViewAsync(TableViewSelectionUnit.CellWithRow, ListViewSelectionMode.Multiple);
+
+        tableView.MakeSelection(new TableViewCellSlot(0, 0), false, false);
+
+        await Task.Yield(); // Allow selection to propagate
+
+        tableView.MakeSelection(new TableViewCellSlot(1, 1), false, true);
+
+        await Task.Delay(200); // Allow selection to propagate
+
+        Assert.AreEqual(2, tableView.SelectedItems.Count);
+        Assert.AreEqual(2, tableView.SelectedCells.Count);
+        Assert.IsTrue(tableView.SelectedCells.Contains(new TableViewCellSlot(0, 0)));
+        Assert.IsTrue(tableView.SelectedCells.Contains(new TableViewCellSlot(1, 1)));
+    }
+
+    private static async Task<TableView> CreateTableViewAsync(TableViewSelectionUnit selectionUnit, ListViewSelectionMode selectionMode = ListViewSelectionMode.Extended)
+    {
+        var tableView = new TableView
+        {
+            SelectionMode = selectionMode,
+            SelectionUnit = selectionUnit
+        };
+
+        tableView.Columns.Add(new TableViewTextColumn
+        {
+            Header = "Name",
+            Binding = new Binding { Path = new PropertyPath(nameof(SelectionItem.Name)) }
+        });
+        tableView.Columns.Add(new TableViewTextColumn
+        {
+            Header = "Value",
+            Binding = new Binding { Path = new PropertyPath(nameof(SelectionItem.Value)) }
+        });
+        tableView.ItemsSource = new[]
+        {
+            new SelectionItem { Name = "A", Value = 1 },
+            new SelectionItem { Name = "B", Value = 2 }
+        };
+
+        await UnitTestApp.Current.MainWindow.LoadTestContentAsync(tableView);
+
+        return tableView;
+    }
+
+    private sealed class SelectionItem
+    {
+        public string Name { get; set; } = string.Empty;
+        public int Value { get; set; }
+    }
+}


### PR DESCRIPTION
Closes #336 

### PR Summary

This PR adds a new `CellWithRow` value to `TableViewSelectionUnit`.

The new selection unit allows a cell and its owning row to be selected together when a cell is clicked. This supports scenarios where users need cell-level focus/selection while still keeping the full row visually selected for context.


https://github.com/user-attachments/assets/8308d8ab-e141-47e9-8f42-e08af83ddc5d


