### PR TITLE
#381 End current edit when IsReadOnly is set to false

### DIFF
--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -520,7 +520,7 @@ public abstract partial class TableViewColumn : DependencyObject
                 tableView.GetCellFromSlot(tableView.CurrentCellSlot.Value) is { } currentCell &&
                 tableView.EndCellEditing(TableViewEditAction.Cancel, currentCell))
             {
-                column.TableView.SetIsEditing(false);
+                tableView.SetIsEditing(false);
             }
 
             column.OwningCollection?.HandleColumnPropertyChanged(column, nameof(IsReadOnly));

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -514,7 +514,6 @@ public abstract partial class TableViewColumn : DependencyObject
         if (d is TableViewColumn column)
         {
             if (column.TableView is TableView tableView &&
-                tableView is not null &&
                 tableView.IsEditing &&
                 tableView.CurrentCellSlot is not null &&
                 tableView.GetCellFromSlot(tableView.CurrentCellSlot.Value) is { } currentCell &&

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -499,12 +499,31 @@ public abstract partial class TableViewColumn : DependencyObject
                 column.OwningCollection.HandleColumnPropertyChanged(column, nameof(MaxWidth));
             else if (e.Property == ActualWidthProperty)
                 column.OwningCollection.HandleColumnPropertyChanged(column, nameof(ActualWidth));
-            else if (e.Property == IsReadOnlyProperty)
-                column.OwningCollection.HandleColumnPropertyChanged(column, nameof(IsReadOnly));
             else if (e.Property == VisibilityProperty)
                 column.OwningCollection.HandleColumnPropertyChanged(column, nameof(Visibility));
             else if (e.Property == OrderProperty)
                 column.OwningCollection.HandleColumnPropertyChanged(column, nameof(Order));
+        }
+    }
+
+    /// <summary>
+    /// Handles changes to the IsReadOnly property.
+    /// </summary>
+    private static void OnIsReadOnlyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableViewColumn column)
+        {
+            if (column.TableView is TableView tableView &&
+                tableView is not null &&
+                tableView.IsEditing &&
+                tableView.CurrentCellSlot is not null &&
+                tableView.GetCellFromSlot(tableView.CurrentCellSlot.Value) is { } currentCell &&
+                tableView.EndCellEditing(TableViewEditAction.Cancel, currentCell))
+            {
+                column.TableView.SetIsEditing(false);
+            }
+
+            column.OwningCollection?.HandleColumnPropertyChanged(column, nameof(IsReadOnly));
         }
     }
 
@@ -587,7 +606,7 @@ public abstract partial class TableViewColumn : DependencyObject
     /// <summary>
     /// Identifies the IsReadOnly dependency property.
     /// </summary>
-    public static readonly DependencyProperty IsReadOnlyProperty = DependencyProperty.Register(nameof(IsReadOnly), typeof(bool), typeof(TableViewColumn), new PropertyMetadata(false, OnPropertyChanged));
+    public static readonly DependencyProperty IsReadOnlyProperty = DependencyProperty.Register(nameof(IsReadOnly), typeof(bool), typeof(TableViewColumn), new PropertyMetadata(false, OnIsReadOnlyChanged));
 
     /// <summary>
     /// Identifies the Visibility dependency property.

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -514,6 +514,7 @@ public abstract partial class TableViewColumn : DependencyObject
         if (d is TableViewColumn column)
         {
             if (column.TableView is TableView tableView &&
+                tableView.IsReadOnly &&
                 tableView.IsEditing &&
                 tableView.CurrentCellSlot is not null &&
                 tableView.GetCellFromSlot(tableView.CurrentCellSlot.Value) is { } currentCell &&

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -943,6 +943,14 @@ public partial class TableView
         {
             tableView.OnIsReadOnlyChanged(e);
 
+            if (tableView.IsEditing &&
+                tableView.CurrentCellSlot is not null &&
+                tableView.GetCellFromSlot(tableView.CurrentCellSlot.Value) is { } currentCell &&
+                tableView.EndCellEditing(TableViewEditAction.Cancel, currentCell))
+            {
+                tableView.SetIsEditing(false);
+            }
+
             if ((tableView.SelectionMode is ListViewSelectionMode.None
                 || tableView.SelectionUnit is TableViewSelectionUnit.Row)
                 && tableView.IsReadOnly)

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -943,6 +943,8 @@ public partial class TableView
         {
             tableView.OnIsReadOnlyChanged(e);
 
+            if (!tableView.IsReadOnly) return;
+
             if (tableView.IsEditing &&
                 tableView.CurrentCellSlot is not null &&
                 tableView.GetCellFromSlot(tableView.CurrentCellSlot.Value) is { } currentCell &&
@@ -951,9 +953,8 @@ public partial class TableView
                 tableView.SetIsEditing(false);
             }
 
-            if ((tableView.SelectionMode is ListViewSelectionMode.None
+            if (tableView.SelectionMode is ListViewSelectionMode.None
                 || tableView.SelectionUnit is TableViewSelectionUnit.Row)
-                && tableView.IsReadOnly)
             {
                 tableView.CurrentCellSlot = null;
             }


### PR DESCRIPTION
Added code for solving issue #381

When IsReadOnly is changed and there´s an ongoing edit operation it is cancelled.
This is solved for both IsReadOnly changes on TableView and TableViewColumn.