### PR TITLE
fix: Implement platform-specific ClockIdentifier logic and fix shorttime formatting

### DIFF
--- a/src/Columns/TableViewTimeColumn.cs
+++ b/src/Columns/TableViewTimeColumn.cs
@@ -2,7 +2,6 @@
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using System;
-using Windows.System.UserProfile;
 using WinUI.TableView.Controls;
 using WinUI.TableView.Extensions;
 using WinUI.TableView.Helpers;
@@ -24,8 +23,12 @@ public partial class TableViewTimeColumn : TableViewBoundColumn
     /// </summary>
     public TableViewTimeColumn()
     {
-        var clocks = GlobalizationPreferences.Clocks;
+#if WINDOWS
+        var clocks = Windows.System.UserProfile.GlobalizationPreferences.Clocks;
         ClockIdentifier = clocks.Count > 0 ? clocks[0] : "24HourClock";
+#else
+        ClockIdentifier = Windows.Globalization.DateTimeFormatting.DateTimeFormatter.ShortTime.Clock;
+#endif
     }
 
     /// <summary>

--- a/src/Helpers/DateTimeFormatHelper.cs
+++ b/src/Helpers/DateTimeFormatHelper.cs
@@ -88,6 +88,21 @@ internal static class DateTimeFormatHelper
              formatter.Calendar,
              strClock ?? formatter.Clock);
 
+#if !WINDOWS
+        if (strFormat is "shorttime")
+        {
+            var longDateFormat = new DateTimeFormatter("longdate").Patterns[0];
+            var timeFormat = result.Patterns[0].Replace(longDateFormat, "").Trim();
+
+            result = new DateTimeFormatter(
+             timeFormat,
+             formatter.Languages,
+             formatter.GeographicRegion,
+             formatter.Calendar,
+             strClock ?? formatter.Clock);
+        }
+#endif
+
         _formatters[(strFormat, strClock)] = result;
 
         return result;


### PR DESCRIPTION
### Summary
This pull request updates the handling of time formatting in the `TableViewTimeColumn` and related date/time formatting helpers to improve cross-platform compatibility. The main focus is to ensure the correct clock identifier and time format are used, whether running on Windows or other platforms.
