### PR TITLE
chore: Update Uno.SDK and Uno.WinUI to latest versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.4.53"
+    "Uno.Sdk": "6.5.36"
   },
   "sdk": {
     "version": "10.0.100",

--- a/src/WinUI.TableView.csproj
+++ b/src/WinUI.TableView.csproj
@@ -22,6 +22,11 @@
     <WindowsSdkPackageVersion>10.0.19041.56</WindowsSdkPackageVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' != 'windows'">
+    <UnoWinUIVersion Condition="$([MSBuild]::VersionLessThan($([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')), 'v9.0'))">6.2.87</UnoWinUIVersion>
+    <UnoWinUIVersion Condition="!$([MSBuild]::VersionLessThan($([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')), 'v9.0'))">6.5.237</UnoWinUIVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>WinUI.TableView.Tests</_Parameter1>
@@ -29,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">
-    <PackageReference Include="Uno.WinUI" Version="6.2.87" />
+    <PackageReference Include="Uno.WinUI" Version="$(UnoWinUIVersion)" />
   </ItemGroup>
   
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">


### PR DESCRIPTION
### Summary

This pull request updates the Uno platform dependencies to newer versions and improves how the `Uno.WinUI` package version is selected in the project file. The changes ensure that the correct version of `Uno.WinUI` is used based on the target framework version, which will help maintain compatibility and take advantage of the latest features and fixes.

Dependency updates:

* [`global.json`](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL3-R3): Upgraded the `Uno.Sdk` version from `6.4.53` to `6.5.36` to use the latest SDK improvements.

Project configuration improvements:

* [`src/WinUI.TableView.csproj`](diffhunk://#diff-d1ab9463819260225ea090720cd291f9054cc09dd2d996f9048e7969bf034671R25-R37): Added logic to select the `Uno.WinUI` package version based on the target framework version—using `6.2.87` for frameworks below `v9.0`, and `6.5.237` for `v9.0` or newer. The package reference now uses the dynamically selected version.