### PR TITLE
docs: add v1.5.0-preview1 release notes

### DIFF
--- a/docs/docs/release-notes/index.md
+++ b/docs/docs/release-notes/index.md
@@ -24,6 +24,7 @@ This section contains release notes for all versions of WinUI.TableView.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| [v1.5.0-preview1](v1.5.0-preview1.md) | | CellWithRow selection, drag selection, paste support, AOT, accessibility |
 | [v1.4.0-preview2](v1.4.0-preview2.md) | January 23, 2026 | Performance boost, SortMemberPath, double-tap events |
 | [v1.4.0-preview1](v1.4.0-preview1.md) | November 28, 2025 | Frozen columns, row details, column reordering, conditional styling |
 | [v1.3.0-preview2](v1.3.0-preview2.md) | April 3, 2025 | Uno Platform support (WASM, macOS, Linux) |

--- a/docs/docs/release-notes/index.md
+++ b/docs/docs/release-notes/index.md
@@ -24,7 +24,7 @@ This section contains release notes for all versions of WinUI.TableView.
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| [v1.5.0-preview1](v1.5.0-preview1.md) | | CellWithRow selection, drag selection, paste support, AOT, accessibility |
+| [v1.5.0-preview1](v1.5.0-preview1.md) | July 7, 2026 | CellWithRow selection, drag selection, paste support, AOT, accessibility |
 | [v1.4.0-preview2](v1.4.0-preview2.md) | January 23, 2026 | Performance boost, SortMemberPath, double-tap events |
 | [v1.4.0-preview1](v1.4.0-preview1.md) | November 28, 2025 | Frozen columns, row details, column reordering, conditional styling |
 | [v1.3.0-preview2](v1.3.0-preview2.md) | April 3, 2025 | Uno Platform support (WASM, macOS, Linux) |

--- a/docs/docs/release-notes/toc.yml
+++ b/docs/docs/release-notes/toc.yml
@@ -30,6 +30,8 @@
     href: v1.0.0.md
 - name: Preview Releases
   items:
+  - name: v1.5.0-preview1
+    href: v1.5.0-preview1.md
   - name: v1.4.0-preview2
     href: v1.4.0-preview2.md
   - name: v1.4.0-preview1

--- a/docs/docs/release-notes/v1.5.0-preview1.md
+++ b/docs/docs/release-notes/v1.5.0-preview1.md
@@ -1,0 +1,46 @@
+# v1.5.0-preview1
+
+> **Preview Release** · [NuGet](https://www.nuget.org/packages/WinUI.TableView/1.5.0-preview1) · [GitHub Release](https://github.com/w-ahmad/WinUI.TableView/releases/tag/v1.5.0-preview1)
+
+## 🌟 Features
+
+- Added `CellWithRow` selection mode to select the clicked cell while keeping the full row highlighted by [@w-ahmad](https://github.com/w-ahmad) in [#388](https://github.com/w-ahmad/WinUI.TableView/pull/388)
+- Added drag selection rectangle for multi-cell selection by [@godlytalias](https://github.com/godlytalias) in [#344](https://github.com/w-ahmad/WinUI.TableView/pull/344)
+- Added clipboard paste support (`CanPaste`, `Pasting` event, paste command) by [@w-ahmad](https://github.com/w-ahmad) in [#379](https://github.com/w-ahmad/WinUI.TableView/pull/379)
+- Added `ColumnAutoWidthMode` to auto-size columns to their content by [@Mangepange](https://github.com/Mangepange) in [#361](https://github.com/w-ahmad/WinUI.TableView/pull/361)
+- Added support for inline cell templates in `TableViewTemplateColumn` by [@w-ahmad](https://github.com/w-ahmad) in [#360](https://github.com/w-ahmad/WinUI.TableView/pull/360)
+- Added Native AOT compatibility by [@w-ahmad](https://github.com/w-ahmad) in [#352](https://github.com/w-ahmad/WinUI.TableView/pull/352)
+- Added UI Automation / accessibility support (`TableViewAutomationPeer`, `TableViewCellAutomationPeer`, `TableViewRowAutomationPeer`, `TableViewColumnHeaderAutomationPeer`, `TableViewRowHeaderAutomationPeer`) by [@w-ahmad](https://github.com/w-ahmad) in [#397](https://github.com/w-ahmad/WinUI.TableView/pull/397)
+
+## Enhancements
+
+- Improved keyboard navigation (Tab, Enter, and arrow key handling across cells) by [@Mangepange](https://github.com/Mangepange) in [#356](https://github.com/w-ahmad/WinUI.TableView/pull/356)
+- Added `OperationContentBinding` to `TableViewTemplateColumn` for sorting, filtering, and export support by [@Mangepange](https://github.com/Mangepange) in [#356](https://github.com/w-ahmad/WinUI.TableView/pull/356)
+- `TableViewTemplateColumn` now uses `ClipboardContentBinding` for copy and export operations by [@Mangepange](https://github.com/Mangepange) in [#355](https://github.com/w-ahmad/WinUI.TableView/pull/355)
+- Extended compiled binding path to support mixed collections and subclass hierarchies by [@DanielTrommel](https://github.com/DanielTrommel) in [#382](https://github.com/w-ahmad/WinUI.TableView/pull/382)
+- Added option to select a cell or row when a context menu is triggered by [@cricketthomas](https://github.com/cricketthomas) in [#374](https://github.com/w-ahmad/WinUI.TableView/pull/374)
+- Migrated library source to C# 14 using the `field` keyword by [@w-ahmad](https://github.com/w-ahmad) in [#375](https://github.com/w-ahmad/WinUI.TableView/pull/375)
+- Improved memory management and lifecycle handling for `TableView` by [@w-ahmad](https://github.com/w-ahmad) in [#369](https://github.com/w-ahmad/WinUI.TableView/pull/369)
+- Allow selector-only `TableViewTemplateColumn` to enter edit mode by [@w-ahmad](https://github.com/w-ahmad) in [#400](https://github.com/w-ahmad/WinUI.TableView/pull/400)
+- Derive default date/time formats from the user profile locale by [@w-ahmad](https://github.com/w-ahmad) in [#401](https://github.com/w-ahmad/WinUI.TableView/pull/401)
+- Added Persian (fa-IR) translations by [@ghost1372](https://github.com/ghost1372) in [#402](https://github.com/w-ahmad/WinUI.TableView/pull/402)
+- Updated Windows App SDK target from 1.6 to 1.8 by [@licon4812](https://github.com/licon4812) in [#285](https://github.com/w-ahmad/WinUI.TableView/pull/285)
+- Updated Uno.SDK and Uno.WinUI to latest versions by [@w-ahmad](https://github.com/w-ahmad) in [#405](https://github.com/w-ahmad/WinUI.TableView/pull/405)
+
+## Fixes
+
+- Fix: null clipboard payload handling by [@mavaddat](https://github.com/mavaddat) in [#305](https://github.com/w-ahmad/WinUI.TableView/pull/305)
+- Fix: End current edit when `IsReadOnly` changes on `TableView` or column by [@Mangepange](https://github.com/Mangepange) in [#389](https://github.com/w-ahmad/WinUI.TableView/pull/389)
+- Fix: End editing on pointer press to prevent stale edit states by [@Mangepange](https://github.com/Mangepange) in [#357](https://github.com/w-ahmad/WinUI.TableView/pull/357)
+- Fix: Column width regression after C# 14 refactor and `ColumnAutoWidthMode` changes by [@DanielTrommel](https://github.com/DanielTrommel) in [#386](https://github.com/w-ahmad/WinUI.TableView/pull/386)
+- Fix: Ensure cell measures when element is set for correct column auto-sizing by [@w-ahmad](https://github.com/w-ahmad) in [#372](https://github.com/w-ahmad/WinUI.TableView/pull/372)
+- Fix: Filter flyout search behavior using custom `MenuFlyout` control by [@w-ahmad](https://github.com/w-ahmad) in [#378](https://github.com/w-ahmad/WinUI.TableView/pull/378)
+- Fix: Guard column reorder on valid drop target and prevent duplicate header option commands by [@w-ahmad](https://github.com/w-ahmad) in [#352](https://github.com/w-ahmad/WinUI.TableView/pull/352)
+- Fix: Implement platform-specific `ClockIdentifier` logic for date/time columns by [@w-ahmad](https://github.com/w-ahmad) in [#404](https://github.com/w-ahmad/WinUI.TableView/pull/404)
+
+## New Contributors
+
+- [@godlytalias](https://github.com/godlytalias) made their first contribution in [#344](https://github.com/w-ahmad/WinUI.TableView/pull/344)
+- [@mavaddat](https://github.com/mavaddat) made their first contribution in [#305](https://github.com/w-ahmad/WinUI.TableView/pull/305)
+- [@Mangepange](https://github.com/Mangepange) made their first contribution in [#355](https://github.com/w-ahmad/WinUI.TableView/pull/355)
+- [@ghost1372](https://github.com/ghost1372) made their first contribution in [#402](https://github.com/w-ahmad/WinUI.TableView/pull/402)


### PR DESCRIPTION
## Summary

Adds release notes for the `v1.5.0-preview1` preview release.

### Changes
- New file: `docs/docs/release-notes/v1.5.0-preview1.md`
- Added entry to `docs/docs/release-notes/toc.yml` (top of Preview Releases)
- Added entry to `docs/docs/release-notes/index.md` (top of Preview Releases table)