### PR TITLE
Fix for #393 - Cancel reordering

### DIFF
--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -7,10 +7,6 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Shapes;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Core;
@@ -47,7 +43,7 @@ public partial class TableViewColumnHeader : ContentControl
     private bool _resizePreviousStarted;
     private double _reorderStartingPosition;
     private bool _reorderStarted;
-    private RenderTargetBitmap? _dragVisuals;    
+    private RenderTargetBitmap? _dragVisuals;
 
     /// <summary>
     /// Initializes a new instance of the TableViewColumnHeader class.
@@ -458,15 +454,10 @@ public partial class TableViewColumnHeader : ContentControl
     protected override void OnManipulationCompleted(ManipulationCompletedRoutedEventArgs e)
     {
         base.OnManipulationCompleted(e);
-
-        if (_reorderStarted && Column is not null)
-        {
-            _headerRow?.ColumnDropCompleted(Column);
-        }
+        CompleteColumnDrop(true);
 
         _resizeStarted = false;
         _resizePreviousStarted = false;
-        _reorderStarted = false;
     }
 
     /// <inheritdoc/>
@@ -477,6 +468,23 @@ public partial class TableViewColumnHeader : ContentControl
 
         _resizeStarted = false;
         _resizePreviousStarted = false;
+        _reorderStarted = false;
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+    {
+        base.OnPointerCaptureLost(e);
+        CompleteColumnDrop(false);
+    }
+
+    private void CompleteColumnDrop(bool applyDrop)
+    {
+        if (_reorderStarted && Column is not null)
+        {
+            _headerRow?.ColumnDropCompleted(Column, applyDrop);
+        }
+
         _reorderStarted = false;
     }
 

--- a/src/TableViewHeaderRow.cs
+++ b/src/TableViewHeaderRow.cs
@@ -12,7 +12,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
-using WinUI.TableView.Converters;
 using WinUI.TableView.Extensions;
 
 namespace WinUI.TableView;
@@ -592,7 +591,7 @@ public partial class TableViewHeaderRow : Control
         }
     }
 
-    internal void ColumnDropCompleted(TableViewColumn column)
+    internal void ColumnDropCompleted(TableViewColumn column, bool applyDrop)
     {
         if (TableView is not null && _columnDropIndicator is not null)
         {
@@ -600,7 +599,7 @@ public partial class TableViewHeaderRow : Control
             var isValidDropTarget = _isValidDropTarget;
             _isValidDropTarget = false;
 
-            if (!isValidDropTarget)
+            if (!isValidDropTarget || !applyDrop)
             {
                 return;
             }


### PR DESCRIPTION
Added an override to PointerCaptureLost and try to cancel the column reordering operation if there's one that's not completed.

Will hopefully fix #393. I could reproduce it with the "Full Name" column in CustomizeFilterPage by clicking a lot on the header.