### PR TITLE
Add incremental loading sample page and documentation

### DIFF
--- a/docs/docs/incremental-loading.md
+++ b/docs/docs/incremental-loading.md
@@ -1,0 +1,107 @@
+﻿# Incremental loading
+
+`TableView` supports incremental loading (also known as infinite scrolling or lazy loading). When the [`ItemsSource`](xref:WinUI.TableView.TableView.ItemsSource) implements [`ISupportIncrementalLoading`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.data.isupportincrementalloading), the control automatically requests more items as the user scrolls toward the end of the list. The internal collection view forwards `HasMoreItems` and `LoadMoreItemsAsync` to your source collection.
+
+This is a good fit for data coming from a remote service or database where loading everything upfront would be slow or wasteful.
+
+## Implementing an incremental source
+
+Implement `ISupportIncrementalLoading` on a collection type — typically by deriving from `ObservableCollection<T>` so the view also updates when items are added:
+
+```csharp
+using Microsoft.UI.Xaml.Data;
+using System.Collections.ObjectModel;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+
+public class IncrementalProductSource : ObservableCollection<Product>, ISupportIncrementalLoading
+{
+    private const uint PageSize = 50;
+    private const uint MaxItemsCount = 10_000;
+    private const int SimulatedDelayMs = 750;
+    private int _nextId = 1;
+
+    public event EventHandler<bool>? LoadingStateChanged;
+
+    public bool HasMoreItems => Count < MaxItemsCount;
+
+    public IAsyncOperation<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
+    {
+        return AsyncInfo.Run(async cancellationToken =>
+        {
+            LoadingStateChanged?.Invoke(this, true);
+
+            try
+            {
+                // Simulate fetching a page of data from a remote service.
+                await Task.Delay(SimulatedDelayMs, cancellationToken);
+
+                for (var i = 0; i < PageSize; i++)
+                {
+                    Add(CreateItem());
+                }
+
+                return new LoadMoreItemsResult { Count = PageSize };
+            }
+            finally
+            {
+                LoadingStateChanged?.Invoke(this, false);
+            }
+        });
+    }
+}
+```
+
+Then assign it as the items source:
+
+```csharp
+tableView.ItemsSource = new IncrementalProductSource();
+```
+
+The first page is loaded automatically when the control is displayed; subsequent pages are requested as the user scrolls.
+
+## Controlling when items are loaded
+
+`TableView` derives from `ListView`, so the standard incremental loading properties apply:
+
+```xml
+<tv:TableView ItemsSource="{x:Bind Products}"
+              IncrementalLoadingTrigger="Edge"
+              IncrementalLoadingThreshold="2"
+              DataFetchSize="3" />
+```
+
+| Property | Description |
+|---|---|
+| `IncrementalLoadingTrigger` | `Edge` (default) triggers loading when scrolling near the end; `None` disables automatic loading |
+| `IncrementalLoadingThreshold` | How close to the end (in pages of visible items) the user must scroll before loading begins |
+| `DataFetchSize` | The amount of data to request, in pages of visible items; determines the `count` passed to `LoadMoreItemsAsync` |
+
+## Loading items manually
+
+You can also trigger a load from code, for example behind a "Load more" button:
+
+```csharp
+if (tableView.ItemsSource is ISupportIncrementalLoading source && source.HasMoreItems)
+{
+    await source.LoadMoreItemsAsync(50);
+}
+```
+
+## Notes
+
+- Sorting and filtering operate on the items loaded so far, not on the full remote dataset. If the user sorts or filters while more pages remain, the result reflects only the loaded items. For server-side data, consider applying sort/filter criteria in your service query instead. See [Sorting](sorting.md) and [Filtering](filtering.md).
+- Clipboard copy, select all, and CSV export also include only the loaded items.
+- `LoadMoreItemsAsync` is invoked on the UI thread. Perform the actual data fetch asynchronously (as in the example above) to keep the UI responsive.
+- Items added by `LoadMoreItemsAsync` must be added on the UI thread since the collection is bound to the view.
+
+## Example
+
+The [sample app](https://github.com/w-ahmad/WinUI.TableView/tree/main/samples/WinUI.TableView.SampleApp) includes an interactive **Incremental Loading** page (`Pages/IncrementalLoadingPage.xaml`) that simulates fetching pages of data from a remote service.
+
+## Related articles
+
+- [Binding data](binding-data.md)
+- [Performance guidance](performance.md)
+- [Sorting](sorting.md)
+- [Filtering](filtering.md)

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -100,7 +100,7 @@ On Uno Platform targets, data binding and layout passes may have slightly differ
 
 ## Notes
 
-- `TableView` does not support incremental loading (i.e., `ISupportIncrementalLoading`) directly. Load pages of data manually and add them to your `ObservableCollection`.
+- `TableView` supports incremental loading when the items source implements `ISupportIncrementalLoading`. See [Incremental loading](incremental-loading.md).
 - The `CellsHorizontalOffset` property (default `16`) adds padding to the left of the cells area. This is separate from column widths.
 
 ## Related articles

--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -12,6 +12,8 @@
   items:
   - name: Binding Data
     href: binding-data.md
+  - name: Incremental Loading
+    href: incremental-loading.md
   - name: Defining Columns
     href: defining-columns.md
   - name: Column Types

--- a/samples/WinUI.TableView.SampleApp/IncrementalLoadingSource.cs
+++ b/samples/WinUI.TableView.SampleApp/IncrementalLoadingSource.cs
@@ -1,0 +1,69 @@
+using Microsoft.UI.Xaml.Data;
+using System.Collections.ObjectModel;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+
+namespace WinUI.TableView.SampleApp;
+
+/// <summary>
+/// An items source that loads items incrementally as the user scrolls,
+/// simulating paged data coming from a remote service.
+/// </summary>
+public partial class IncrementalLoadingSource : ObservableCollection<ExampleModel>, ISupportIncrementalLoading
+{
+    private const uint PageSize = 50;
+    private const uint MaxItemsCount = 10_000;
+    private const int SimulatedDelayMs = 750;
+    private int _nextId = 1;
+
+    public event EventHandler<bool>? LoadingStateChanged;
+
+    public bool HasMoreItems => Count < MaxItemsCount;
+
+    public IAsyncOperation<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
+    {
+        return AsyncInfo.Run(async cancellationToken =>
+        {
+            LoadingStateChanged?.Invoke(this, true);
+
+            try
+            {
+                // Simulate fetching a page of data from a remote service.
+                await Task.Delay(SimulatedDelayMs, cancellationToken);
+
+                for (var i = 0; i < PageSize; i++)
+                {
+                    Add(CreateItem());
+                }
+
+                return new LoadMoreItemsResult { Count = PageSize };
+            }
+            finally
+            {
+                LoadingStateChanged?.Invoke(this, false);
+            }
+        });
+    }
+
+    private ExampleModel CreateItem()
+    {
+        var firstName = DataFaker.FirstName();
+        var lastName = DataFaker.LastName();
+
+        return new ExampleModel
+        {
+            Id = _nextId++,
+            FirstName = firstName,
+            LastName = lastName,
+            Email = DataFaker.Email(firstName, lastName),
+            Gender = DataFaker.Gender(),
+            Dob = DataFaker.PastDate(50, new DateOnly(1970, 1, 1)),
+            IsActive = DataFaker.Boolean(),
+            ActiveAt = DataFaker.TimeOfDay(),
+            Department = DataFaker.Department(),
+            Designation = DataFaker.JobTitle(),
+            Address = DataFaker.Address(),
+            Avatar = DataFaker.Avatar()
+        };
+    }
+}

--- a/samples/WinUI.TableView.SampleApp/MainWindow.xaml
+++ b/samples/WinUI.TableView.SampleApp/MainWindow.xaml
@@ -84,6 +84,11 @@
                         <FontIcon Glyph="&#xE89A;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem Content="Incremental Loading">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE896;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
                 <NavigationViewItem Content="Editing">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE70F;" />

--- a/samples/WinUI.TableView.SampleApp/MainWindow.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/MainWindow.xaml.cs
@@ -61,6 +61,7 @@ public sealed partial class MainWindow : Window
                 "Context Flyouts" => typeof(ContextFlyoutsPage),
                 "Row Reorder" => typeof(ReorderRowsPage),
                 "Pagination" => typeof(PaginationPage),
+                "Incremental Loading" => typeof(IncrementalLoadingPage),
                 "Filtering" => typeof(FilteringPage),
                 "Customize Filter Flyout" => typeof(CustomizeFilterPage),
                 "External Filtering" => typeof(ExternalFilteringPage),

--- a/samples/WinUI.TableView.SampleApp/Pages/IncrementalLoadingPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/IncrementalLoadingPage.xaml
@@ -1,0 +1,99 @@
+<Page x:Class="WinUI.TableView.SampleApp.Pages.IncrementalLoadingPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:WinUI.TableView.SampleApp"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:tv="using:WinUI.TableView"
+      xmlns:controls="using:WinUI.TableView.SampleApp.Controls"
+      mc:Ignorable="d">
+
+    <Grid>
+        <controls:SamplePresenter Header="Incremental Loading"
+                                  Description="TableView supports incremental loading when the items source implements ISupportIncrementalLoading. More items are fetched automatically as the user scrolls toward the end of the list.">
+            <controls:SamplePresenter.Example>
+                <tv:TableView x:Name="tableView"
+                              IsReadOnly="True"
+                              IncrementalLoadingTrigger="Edge"
+                              IncrementalLoadingThreshold="2"
+                              DataFetchSize="3" />
+            </controls:SamplePresenter.Example>
+
+            <controls:SamplePresenter.Options>
+                <StackPanel Spacing="16">
+                    <ProgressBar x:Name="loadingBar"
+                                 IsIndeterminate="True"
+                                 Visibility="Collapsed" />
+                    <TextBlock>
+                        <Run Text="Loaded items:" />
+                        <Run x:Name="loadedCountRun"
+                             Text="0" />
+                    </TextBlock>
+                    <TextBlock>
+                        <Run Text="Has more items:" />
+                        <Run x:Name="hasMoreItemsRun"
+                             Text="True" />
+                    </TextBlock>
+                </StackPanel>
+            </controls:SamplePresenter.Options>
+
+            <controls:SamplePresenter.Xaml>
+                <x:String xml:space="preserve">
+&lt;tv:TableView x:Name="tableView"
+    IsReadOnly="True"
+    IncrementalLoadingTrigger="Edge"
+    IncrementalLoadingThreshold="2"
+    DataFetchSize="3">
+    &lt;tv:TableView.Columns>
+    ............
+    &lt;/tv:TableView.Columns>
+&lt;/tv:TableView>
+                </x:String>
+            </controls:SamplePresenter.Xaml>
+
+            <controls:SamplePresenter.CSharp>
+                <x:String xml:space="preserve">
+public partial class IncrementalLoadingSource : ObservableCollection&lt;ExampleModel>, ISupportIncrementalLoading
+{
+    private const uint PageSize = 50;
+    private const uint MaxItemsCount = 10_000;
+    private const int SimulatedDelayMs = 750;
+    private int _nextId = 1;
+    
+    public event EventHandler&lt;bool>? LoadingStateChanged;
+    
+    public bool HasMoreItems => Count &lt; MaxItemsCount;
+    
+    public IAsyncOperation&lt;LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
+    {
+        return AsyncInfo.Run(async cancellationToken =>
+        {
+            LoadingStateChanged?.Invoke(this, true);
+    
+            try
+            {
+                // Simulate fetching a page of data from a remote service.
+                await Task.Delay(SimulatedDelayMs, cancellationToken);
+    
+                for (var i = 0; i &lt; PageSize; i++)
+                {
+                    Add(CreateItem());
+                }
+    
+                return new LoadMoreItemsResult { Count = PageSize };
+            }
+            finally
+            {
+                LoadingStateChanged?.Invoke(this, false);
+            }
+        });
+    }
+}
+
+// Set the items source
+tableView.ItemsSource = new IncrementalLoadingSource();
+                </x:String>
+            </controls:SamplePresenter.CSharp>
+        </controls:SamplePresenter>
+    </Grid>
+</Page>

--- a/samples/WinUI.TableView.SampleApp/Pages/IncrementalLoadingPage.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/Pages/IncrementalLoadingPage.xaml.cs
@@ -1,0 +1,24 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace WinUI.TableView.SampleApp.Pages;
+
+public sealed partial class IncrementalLoadingPage : Page
+{
+    private readonly IncrementalLoadingSource _source = [];
+
+    public IncrementalLoadingPage()
+    {
+        InitializeComponent();
+
+        _source.LoadingStateChanged += OnLoadingStateChanged;
+        tableView.ItemsSource = _source;
+    }
+
+    private void OnLoadingStateChanged(object? sender, bool isLoading)
+    {
+        loadingBar.Visibility = isLoading ? Visibility.Visible : Visibility.Collapsed;
+        loadedCountRun.Text = _source.Count.ToString();
+        hasMoreItemsRun.Text = _source.HasMoreItems.ToString();
+    }
+}


### PR DESCRIPTION
## Why

`TableView` already supports incremental loading - its internal collection view forwards `HasMoreItems` and `LoadMoreItemsAsync` to any `ItemsSource` implementing `ISupportIncrementalLoading` - but this was undocumented, and the performance guide incorrectly stated the feature was unsupported. There was also no sample demonstrating it.

## What's changed

**Sample app**
- New `IncrementalLoadingSource` - an `ObservableCollection<ExampleModel>` implementing `ISupportIncrementalLoading` that simulates fetching pages from a remote service (750 ms delay, capped at 1,000 items).
- New `IncrementalLoadingPage` using `SamplePresenter`, with `IncrementalLoadingTrigger`/`IncrementalLoadingThreshold`/`DataFetchSize` set on the TableView, an options panel showing loaded item count, `HasMoreItems` state, and an indeterminate progress bar while a page loads. XAML and C# source snippets included.
- Wired a new "Incremental Loading" navigation item into `MainWindow`.

**Docs**
- New `docs/docs/incremental-loading.md` covering how to implement an incremental source, the inherited `ListView` loading properties, manual loading from code, and caveats (sorting/filtering/clipboard/export operate only on loaded items).
- Added the article to the toc under Data.
- Fixed the outdated note in `performance.md` that claimed `ISupportIncrementalLoading` was not supported.