### PR TITLE
feat: allow drag selection to start from rows and empty space

### DIFF
--- a/samples/WinUI.TableView.SampleApp/App.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
+using System.Diagnostics;
 
 namespace WinUI.TableView.SampleApp;
 
@@ -25,17 +26,17 @@ public partial class App : Application
 #if DEBUG && WINDOWS
     private void DebugSettings_BindingFailed(object sender, BindingFailedEventArgs e)
     {
-        System.Diagnostics.Debug.WriteLine(e.Message);
+        Debug.WriteLine(e.Message);
     }
 
     private void DebugSettings_XamlResourceReferenceFailed(DebugSettings sender, XamlResourceReferenceFailedEventArgs args)
     {
-        System.Diagnostics.Debug.WriteLine(args.Message);
+        Debug.WriteLine(args.Message);
     }
 
     private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
     {
-        if (System.Diagnostics.Debugger.IsAttached) System.Diagnostics.Debugger.Break();
+        if (Debugger.IsAttached) Debugger.Break();
     }
 #endif
 
@@ -45,21 +46,27 @@ public partial class App : Application
     /// <param name="args">Details about the launch request and process.</param>
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
-#if DEBUG && !WINDOWS
+#if DEBUG
+        if (Debugger.IsAttached)
+        {
+            DebugSettings.EnableFrameRateCounter = true;
+        }
+#if !WINDOWS
         MainWindow.UseStudio();
         MainWindow.SetWindowIcon();
+#endif
 #endif
         MainWindow.Activate();
     }
 
     public static void InitializeLogging()
     {
+
 #if DEBUG
         var factory = LoggerFactory.Create(builder =>
         {
 #if __WASM__
             builder.AddProvider(new global::Uno.Extensions.Logging.WebAssembly.WebAssemblyConsoleLoggerProvider());
-            // Note: DebugSettings.EnableFrameRateCounter requires an Application instance
 #elif !WINDOWS
             builder.AddConsole();
 #else

--- a/src/Extensions/ItemIndexRangeExtensions.cs
+++ b/src/Extensions/ItemIndexRangeExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.UI.Xaml.Data;
-using System.Runtime.CompilerServices;
+using Microsoft.UI.Xaml.Data;
 
 namespace WinUI.TableView.Extensions;
 

--- a/src/Extensions/ItemIndexRangeExtensions.cs
+++ b/src/Extensions/ItemIndexRangeExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.UI.Xaml.Data;
+using System.Runtime.CompilerServices;
 
 namespace WinUI.TableView.Extensions;
 
@@ -21,11 +22,55 @@ public static class ItemIndexRangeExtensions
     /// <summary>
     /// Determines whether the given item index range is valid within the TableView.
     /// </summary>
-    /// <param name="itemIndexRange">The ItemIndexRange to check.</param>
+    /// <param name="range">The ItemIndexRange to check.</param>
     /// <param name="tableView">The TableView to check against.</param>
     /// <returns>True if the item index range of TableView is valid; otherwise, false.</returns>
-    public static bool IsValid(this ItemIndexRange itemIndexRange, TableView tableView)
+    public static bool IsValid(this ItemIndexRange range, TableView tableView)
     {
-        return itemIndexRange.FirstIndex >= 0 && itemIndexRange.LastIndex < tableView?.Items.Count;
+        return range.FirstIndex >= 0 && range.LastIndex < tableView?.Items.Count;
+    }
+
+    /// <summary>
+    /// Determines whether the specified range completely contains another range.
+    /// </summary>
+    /// <param name="range">The range to check.</param>
+    /// <param name="other">The range to check against.</param>
+    /// <returns>True if the range completely contains the other range; otherwise, false.</returns>
+    public static bool Contains(this ItemIndexRange range, ItemIndexRange other)
+    {
+        return other.FirstIndex >= range.FirstIndex && other.LastIndex <= range.LastIndex;
+    }
+
+    /// <summary>
+    /// Subtracts another ItemIndexRange from the current range and returns the resulting range.
+    /// </summary>
+    /// <param name="range">The range to subtract from.</param>
+    /// <param name="other">The range to subtract.</param>
+    /// <returns>The resulting range after subtraction.</returns>
+    public static IEnumerable<ItemIndexRange> Subtract(this ItemIndexRange range, ItemIndexRange other)
+    {
+        var start = range.FirstIndex;
+        var end = start + (int)range.Length - 1;
+
+        var otherStart = other.FirstIndex;
+        var otherEnd = otherStart + (int)other.Length - 1;
+
+        // No overlap.
+        if (otherEnd < start || otherStart > end)
+        {
+            yield break;
+        }
+
+        // Left remainder.
+        if (otherStart > start)
+        {
+            yield return new ItemIndexRange(start, (uint)(otherStart - start));
+        }
+
+        // Right remainder.
+        if (otherEnd < end)
+        {
+            yield return new ItemIndexRange(otherEnd + 1, (uint)(end - otherEnd));
+        }
     }
 }

--- a/src/Extensions/TableViewCellSlotRangeExtensions.cs
+++ b/src/Extensions/TableViewCellSlotRangeExtensions.cs
@@ -1,5 +1,3 @@
-﻿using Microsoft.UI.Xaml.Data;
-
 namespace WinUI.TableView.Extensions;
 
 /// <summary>

--- a/src/Extensions/TableViewCellSlotRangeExtensions.cs
+++ b/src/Extensions/TableViewCellSlotRangeExtensions.cs
@@ -1,0 +1,189 @@
+﻿using Microsoft.UI.Xaml.Data;
+
+namespace WinUI.TableView.Extensions;
+
+/// <summary>
+/// Provides extension methods for the TableViewCellSlotRange type.
+/// </summary>
+internal static class TableViewCellSlotRangeExtensions
+{
+    /// <summary>
+    /// Determines whether a specified cell slot is within the range.
+    /// </summary>
+    /// <param name="range">The TableViewCellSlotRange to check.</param>
+    /// <param name="slot">The cell slot to check.</param>
+    /// <returns>True if the slot is within the range; otherwise, false.</returns>
+    public static bool IsInRange(this TableViewCellSlotRange? range, TableViewCellSlot slot)
+    {
+        if (range is null || range.Length <= 0) return false;
+
+        var minRow = Math.Min(range.FirstRow, range.LastRow);
+        var maxRow = Math.Max(range.FirstRow, range.LastRow);
+        var minColumn = Math.Min(range.FirstColumn, range.LastColumn);
+        var maxColumn = Math.Max(range.FirstColumn, range.LastColumn);
+
+        return slot.Row >= minRow && slot.Row <= maxRow
+            && slot.Column >= minColumn && slot.Column <= maxColumn;
+    }
+
+    /// <summary>
+    /// Determines whether a specified row index is within the range.
+    /// </summary>
+    /// <param name="range">The TableViewCellSlotRange to check.</param>
+    /// <param name="row">The row index to check.</param>
+    /// <returns>True if the row index is within the range; otherwise, false.</returns>
+    public static bool IsRowInRange(this TableViewCellSlotRange? range, int row)
+    {
+        return range?.Length > 0
+            && row >= Math.Min(range.FirstRow, range.LastRow)
+            && row <= Math.Max(range.FirstRow, range.LastRow);
+    }
+
+    /// <summary>
+    /// Determines whether a specified column index is within the range.
+    /// </summary>
+    /// <param name="range">The TableViewCellSlotRange to check.</param>
+    /// <param name="column">The column index to check.</param>
+    /// <returns>True if the column index is within the range; otherwise, false.</returns>
+    public static bool IsColumnInRange(this TableViewCellSlotRange? range, int column)
+    {
+        return range?.Length > 0
+            && column >= Math.Min(range.FirstColumn, range.LastColumn)
+            && column <= Math.Max(range.FirstColumn, range.LastColumn);
+    }
+
+    /// <summary>
+    /// Determines whether the given cell slot range is valid within the TableView.
+    /// </summary>
+    /// <param name="range">The TableViewCellSlotRange to check.</param>
+    /// <param name="tableView">The TableView to check against.</param>
+    /// <returns>True if the cell slot range of TableView is valid; otherwise, false.</returns>
+    public static bool IsValid(this TableViewCellSlotRange range, TableView tableView)
+    {
+        return range.FirstSlot.IsValid(tableView) && range.LastSlot.IsValid(tableView);
+    }
+
+    /// <summary>
+    /// Returns all cell slots contained within this range, enumerated row by row.
+    /// </summary>
+    public static IEnumerable<TableViewCellSlot> GetSlots(this TableViewCellSlotRange range)
+    {
+        for (var row = range.FirstRow; row <= range.LastRow; row++)
+        {
+            for (var col = range.FirstColumn; col <= range.LastColumn; col++)
+            {
+                yield return new TableViewCellSlot(row, col);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether a specific cell slot falls within this range.
+    /// </summary>
+    public static bool Contains(this TableViewCellSlotRange range, int rowIndex, int columnIndex)
+    {
+        return rowIndex >= range.FirstRow && rowIndex <= range.LastRow &&
+               columnIndex >= range.FirstColumn && columnIndex <= range.LastColumn;
+    }
+
+    /// <summary>
+    /// Determines whether another TableViewCellSlotRange is completely contained within this range.
+    /// </summary>
+    public static bool Contains(this TableViewCellSlotRange? range, TableViewCellSlotRange? other)
+    {
+        if (range == null || other == null) return false;
+
+        return range.Contains(other.FirstRow, other.FirstColumn) &&
+            range.Contains(other.LastRow, other.LastColumn);
+    }
+
+    /// <summary>
+    /// Determines whether another range intersects with this range.
+    /// </summary>
+    public static bool IntersectsWith(this TableViewCellSlotRange range, TableViewCellSlotRange other)
+    {
+        if (other == null) return false;
+
+        return range.FirstRow <= other.LastRow && range.LastRow >= other.FirstRow &&
+               range.FirstColumn <= other.LastColumn && range.LastColumn >= other.FirstColumn;
+    }
+
+    /// <summary>
+    /// Subtracts another range from this range and returns the resulting ranges.
+    /// </summary>
+    /// <param name="range">The range to subtract from.</param>
+    /// <param name="other">The range to subtract.</param>
+    /// <returns>An enumerable of resulting ranges after subtraction.</returns>
+    public static IEnumerable<TableViewCellSlotRange> Subtract(this TableViewCellSlotRange range, TableViewCellSlotRange other)
+    {
+        // No overlap.
+        if (!range.IntersectsWith(other))
+        {
+            yield return range;
+            yield break;
+        }
+
+        // Intersection rectangle.
+        var top = Math.Max(range.FirstRow, other.FirstRow);
+        var left = Math.Max(range.FirstColumn, other.FirstColumn);
+        var bottom = Math.Min(range.LastRow, other.LastRow);
+        var right = Math.Min(range.LastColumn, other.LastColumn);
+
+        // Top strip.
+        if (range.FirstRow < top)
+        {
+            yield return new TableViewCellSlotRange(
+                range.FirstRow,
+                range.FirstColumn,
+                top - range.FirstRow,
+                range.Columns);
+        }
+
+        // Bottom strip.
+        if (bottom < range.LastRow)
+        {
+            yield return new TableViewCellSlotRange(
+                bottom + 1,
+                range.FirstColumn,
+                range.LastRow - bottom,
+                range.Columns);
+        }
+
+        // Left strip.
+        if (range.FirstColumn < left)
+        {
+            yield return new TableViewCellSlotRange(
+                top,
+                range.FirstColumn,
+                bottom - top + 1,
+                left - range.FirstColumn);
+        }
+
+        // Right strip.
+        if (right < range.LastColumn)
+        {
+            yield return new TableViewCellSlotRange(
+                top,
+                right + 1,
+                bottom - top + 1,
+                range.LastColumn - right);
+        }
+    }
+
+    /// <summary>
+    /// Merges two TableViewCellSlotRanges into a single range that encompasses both.
+    /// </summary>
+    public static TableViewCellSlotRange Merge(this TableViewCellSlotRange range, TableViewCellSlotRange other)
+    {
+        var firstRow = Math.Min(range.FirstRow, other.FirstRow);
+        var firstColumn = Math.Min(range.FirstColumn, other.FirstColumn);
+        var lastRow = Math.Max(range.LastRow, other.LastRow);
+        var lastColumn = Math.Max(range.LastColumn, other.LastColumn);
+
+        return TableViewCellSlotRange.FromCoordinates(
+            firstRow,
+            firstColumn,
+            lastRow,
+            lastColumn);
+    }
+}

--- a/src/Helpers/IndexRangeHelper.cs
+++ b/src/Helpers/IndexRangeHelper.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.UI.Xaml.Data;
+
+namespace WinUI.TableView.Helpers;
+
+/// <summary>
+/// Provides helper methods for working with index ranges in a TableView.
+/// </summary>
+internal static class IndexRangeHelper
+{
+    /// <summary>
+    /// Gets a list of contiguous index ranges from a collection of indexes.
+    /// </summary>
+    /// <param name="indexes">The collection of indexes to process.</param>
+    /// <returns>A list of contiguous index ranges.</returns>
+    public static List<ItemIndexRange> GetRanges(IEnumerable<int> indexes)
+    {
+        var sorted = indexes.Order().ToArray();
+
+        if (sorted.Length == 0)
+            return [];
+
+        List<ItemIndexRange> ranges = [];
+
+        var first = sorted[0];
+        var previous = sorted[0];
+
+        for (var i = 1; i < sorted.Length; i++)
+        {
+            if (sorted[i] == previous + 1)
+            {
+                previous = sorted[i];
+                continue;
+            }
+
+            ranges.Add(new ItemIndexRange(first, (uint)(previous - first + 1)));
+
+            first = previous = sorted[i];
+        }
+
+        ranges.Add(new ItemIndexRange(first, (uint)(previous - first + 1)));
+
+        return ranges;
+    }
+}

--- a/src/Helpers/TableViewTrace.cs
+++ b/src/Helpers/TableViewTrace.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics;
+
+namespace WinUI.TableView.Helpers;
+
+internal static class TableViewTrace
+{
+    [Conditional("DEBUG")]
+    public static void Write(string message)
+    {
+        Debug.WriteLine($"[TableView] {message}");
+    }
+}

--- a/src/Helpers/TableViewTrace.cs
+++ b/src/Helpers/TableViewTrace.cs
@@ -7,6 +7,9 @@ internal static class TableViewTrace
     [Conditional("DEBUG")]
     public static void Write(string message)
     {
-        Debug.WriteLine($"[TableView] {message}");
+        if (Debugger.IsAttached)
+        {
+            Debug.WriteLine($"[TableView] {message}"); 
+        }
     }
 }

--- a/src/TableView.Events.cs
+++ b/src/TableView.Events.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.UI.Xaml;
-using System;
-using System.ComponentModel;
+using System.Diagnostics;
+using WinUI.TableView.Helpers;
 
 namespace WinUI.TableView;
 
@@ -186,6 +186,7 @@ partial class TableView
     /// </summary>
     protected virtual void OnCellSelectionChanged(TableViewCellSelectionChangedEventArgs args)
     {
+        TableViewTrace.Write($"TableViewCellSelectionChanged: Added={args.AddedCells.Count}, Removed={args.RemovedCells.Count}");
         CellSelectionChanged?.Invoke(this, args);
     }
 

--- a/src/TableView.Events.cs
+++ b/src/TableView.Events.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.UI.Xaml;
-using System.Diagnostics;
+using Microsoft.UI.Xaml;
 using WinUI.TableView.Helpers;
 
 namespace WinUI.TableView;

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -416,7 +416,7 @@ public partial class TableView
     /// <summary>
     /// Gets the selected cell ranges.
     /// </summary>
-    internal HashSet<HashSet<TableViewCellSlot>> SelectedCellRanges { get; } = [];
+    internal HashSet<TableViewCellSlotRange> SelectedCellRanges { get; } = [];
 
     /// <summary>
     /// Gets or sets a value indicating whether the TableView is in editing mode.
@@ -897,7 +897,7 @@ public partial class TableView
 
                 if (tableView.SelectionMode is ListViewSelectionMode.Single && tableView.CurrentCellSlot.HasValue)
                 {
-                    tableView.SelectedCellRanges.Add([tableView.CurrentCellSlot.Value]);
+                    tableView.SelectedCellRanges.Add(TableViewCellSlotRange.FromSlots(tableView.CurrentCellSlot.Value));
                 }
 
                 tableView.OnCellSelectionChanged();

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -3,18 +3,11 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
 using Windows.Storage;
@@ -22,6 +15,7 @@ using Windows.Storage.Pickers;
 using Windows.System;
 using WinUI.TableView.Extensions;
 using WinUI.TableView.Helpers;
+using Pointer = Microsoft.UI.Xaml.Input.Pointer;
 
 namespace WinUI.TableView;
 
@@ -42,7 +36,6 @@ public partial class TableView : ListView
     private readonly CollectionView _collectionView = [];
     private Border? _dragRectangle;
     private Point? _dragStartPoint;
-    private bool _cellSelectionDirty;
     private bool _suppressSelectionChangedCellClear;
     private Point? _lastDragCanvasPoint;
     private DispatcherTimer? _autoScrollTimer;
@@ -50,6 +43,12 @@ public partial class TableView : ListView
     private double _autoScrollHorizontalDelta;
     private double _dragStartVerticalOffset;
     private double _dragStartHorizontalOffset;
+    private Pointer? _tableViewDragPointer;
+    private UIElement? _pointerCaptureElement;
+    private TableViewCellSlotRange? _lastDragSelectionCellRange;
+    private ItemIndexRange? _lastDragSelectionRowRange;
+    private bool _cellStateDispatchPending;
+    private readonly HashSet<int> _pendingCellStateRows = [];
 
     /// <summary>
     /// Initializes a new instance of the TableView class.
@@ -72,6 +71,8 @@ public partial class TableView : ListView
         Unloaded += OnUnloaded;
         SelectionChanged += TableView_SelectionChanged;
         _collectionView.ItemPropertyChanged += OnItemPropertyChanged;
+        AddHandler(PointerPressedEvent, new PointerEventHandler(OnAnyPointerPressed), handledEventsToo: true);
+        AddHandler(PointerReleasedEvent, new PointerEventHandler(OnAnyPointerReleased), handledEventsToo: true);
     }
 
     /// <summary>
@@ -79,6 +80,8 @@ public partial class TableView : ListView
     /// </summary>
     private void TableView_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
+        TableViewTrace.Write($"TableViewSelectionChanged: AddedItems={e.AddedItems.Count}, RemovedItems={e.RemovedItems.Count}");
+
         if (_suppressSelectionChangedCellClear)
         {
             _suppressSelectionChangedCellClear = false;
@@ -91,11 +94,13 @@ public partial class TableView : ListView
             }
             else
             {
-                SelectedCellRanges.RemoveWhere(slots =>
+                var addedIndexes = e.AddedItems.Select(item => Items.IndexOf(item));
+
+                foreach (var range in IndexRangeHelper.GetRanges(addedIndexes))
                 {
-                    slots.RemoveWhere(slot => SelectedRanges.Any(range => range.IsInRange(slot.Row)));
-                    return slots.Count == 0;
-                });
+                    var slotRange = TableViewCellSlotRange.FromCoordinates(range.FirstIndex, 0, range.LastIndex, Columns.VisibleColumns.Count - 1);
+                    SubtractCellRangeFromSelection(slotRange);
+                }
             }
 
             CurrentCellSlot = null;
@@ -105,6 +110,23 @@ public partial class TableView : ListView
         if (SelectedItems?.Count == 1)
         {
             DispatcherQueue.TryEnqueue(async () => await ScrollRowIntoView(SelectedIndex));
+        }
+    }
+
+    /// <summary>
+    /// Subtracts a specified cell range from the current selection.
+    /// </summary>
+    /// <param name="slotRange">The cell range to subtract from the current selection.</param>
+    private void SubtractCellRangeFromSelection(TableViewCellSlotRange slotRange)
+    {
+        while (SelectedCellRanges.FirstOrDefault(r => r.IntersectsWith(slotRange)) is { } intersectingRange)
+        {
+            foreach (var slicedRange in intersectingRange.Subtract(slotRange))
+            {
+                SelectedCellRanges.Add(slicedRange);
+            }
+
+            SelectedCellRanges.Remove(intersectingRange);
         }
     }
 
@@ -183,6 +205,214 @@ public partial class TableView : ListView
         }
 
         HandleNavigations(e, shiftKey, ctrlKey);
+    }
+
+    /// <summary>
+    /// Handles pointer-pressed for all cases, including when elements sets <c>e.Handled = true</c>.
+    /// </summary>
+    private void OnAnyPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        var pointerPoint = e.GetCurrentPoint(this);
+        var position = pointerPoint.Position;
+        var canvasPoint = GetCanvasPoint(position);
+        var ctrlKey = KeyboardHelper.IsCtrlKeyDown();
+        var isShiftkey = KeyboardHelper.IsShiftKeyDown();
+        var orignalSoruce = e.OriginalSource as FrameworkElement;
+
+        if (SelectionMode is ListViewSelectionMode.None         // Skip selection when SelectionMode is None
+            || IsDragSelecting                                  // Skip selection when a drag is already in progress
+            || orignalSoruce is ScrollBar                       // Skip selection when the pointer is over the ScrollBar
+            || orignalSoruce?.FindAscendant<ScrollBar>() is { } // Skip selection when the pointer is within a ScrollBar
+            || !pointerPoint.Properties.IsLeftButtonPressed     // Skip selection when the left mouse button is not pressed
+            || canvasPoint is null                              // Skip selection when canvasPoint is null (e.g., pointer is outside the scroll canvas)
+            || canvasPoint.Value.Y < 0                          // Skip selection when the pointer is in the column header area (above the scroll canvas)  
+            || canvasPoint.Value.X < CellsHorizontalOffset      // Skip selection when the pointer is in the row header area (to the left of the scroll canvas)
+            || isShiftkey)                                      // Skip selection when the Shift key is held
+        {
+            return;
+        }
+
+        _lastDragCanvasPoint = null;
+        CurrentCellSlot = null;
+        SelectionStartCellSlot = null;
+        SelectionStartRowIndex = null;
+        _lastDragSelectionRowRange = null;
+        _lastDragSelectionCellRange = null;
+        LastSelectionUnit = TableViewSelectionUnit.Row;
+
+        if (!ctrlKey && SelectionMode is not ListViewSelectionMode.Multiple)
+            DeselectAll();
+
+        if (e.OriginalSource is UIElement element)
+        {
+            UIElement? clickedElement = element.FindAscendant<TableViewCell>(); // Check if the pointer is over a TableViewCell
+            clickedElement ??= element.FindAscendant<TableViewRow>(); // If not, check if the pointer is over a TableViewRow
+            clickedElement ??= this; // If not, default to the TableView itself
+
+            SelectionStartCellSlot = (clickedElement as TableViewCell)?.Slot;
+            SelectionStartRowIndex = (clickedElement as TableViewRow)?.Index;
+
+            LastSelectionUnit = SelectionUnit switch
+            {
+                TableViewSelectionUnit.Cell => TableViewSelectionUnit.Cell,
+                TableViewSelectionUnit.Row => TableViewSelectionUnit.Row,
+                _ => clickedElement is TableViewCell
+                    ? TableViewSelectionUnit.Cell
+                    : TableViewSelectionUnit.Row
+            };
+
+#if WINDOWS
+            _pointerCaptureElement = clickedElement;
+#else
+            _pointerCaptureElement = this;
+#endif
+
+            _pointerCaptureElement.CapturePointer(e.Pointer);
+            _tableViewDragPointer = e.Pointer;
+            StartDragSelection(canvasPoint.Value);
+            MakeSelectionInDragRect();
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPointerMoved(PointerRoutedEventArgs e)
+    {
+        base.OnPointerMoved(e);
+
+        if (!IsDragSelecting)
+        {
+            return;
+        }
+
+        var canvasPoint = GetCanvasPoint(e.GetCurrentPoint(this).Position);
+        if (canvasPoint is null)
+        {
+            return;
+        }
+
+        // Drive the rect visual for all drag sources (cell-initiated drags bubble pointer events here).
+        UpdateDragRectangleVisual(canvasPoint.Value);
+
+        // Selection-by-hit-test is only needed for TableView-initiated drags; cell-initiated
+        // drags perform selection in the cell's OnManipulationDelta via FindCell.
+        if (_tableViewDragPointer is not null)
+        {
+            MakeSelectionInDragRect();
+        }
+    }
+
+    /// <summary>
+    /// Makes selection based on the current drag rectangle, selecting either rows or cells depending on the last selection unit.
+    /// </summary>
+    private void MakeSelectionInDragRect()
+    {
+        if (_lastDragCanvasPoint is null) return;
+
+        if (LastSelectionUnit is not TableViewSelectionUnit.Cell && GetRowIndexAtCanvasPoint(_lastDragCanvasPoint.Value) is int row)
+        {
+            SelectionStartRowIndex ??= row;
+            var minRow = Math.Min(SelectionStartRowIndex.Value, row);
+            var maxRow = Math.Max(SelectionStartRowIndex.Value, row);
+            var rows = new ItemIndexRange(minRow, (uint)(maxRow - minRow + 1));
+
+            SelectRowsInDragRect(rows);
+        }
+        else if (LastSelectionUnit is not TableViewSelectionUnit.Row && GetSlotAtCanvasPoint(_lastDragCanvasPoint.Value) is { } slot)
+        {
+            if (SelectionStartCellSlot is null)
+            {
+                var startColumn = slot.Column;
+
+                if (_dragStartPoint is not null)
+                {
+                    var horizontalScrollDelta = HorizontalOffset - _dragStartHorizontalOffset;
+                    var startX = _dragStartPoint.Value.X - horizontalScrollDelta;
+                    startColumn = GetColumnIndexAtCanvasX(startX)
+                        ?? (startX < CellsHorizontalOffset - HorizontalOffset ? 0 : Columns.VisibleColumns.Count - 1);
+                }
+
+                SelectionStartCellSlot = new(SelectionStartRowIndex ?? slot.Row, startColumn);
+            }
+
+            var startRow = Math.Min(SelectionStartCellSlot.Value.Row, slot.Row);
+            var endRow = Math.Max(SelectionStartCellSlot.Value.Row, slot.Row);
+            var startCol = Math.Min(SelectionStartCellSlot.Value.Column, slot.Column);
+            var endCol = Math.Max(SelectionStartCellSlot.Value.Column, slot.Column);
+            var cells = TableViewCellSlotRange.FromCoordinates(startRow, startCol, endRow, endCol);
+
+            SelectCellsInDragRect(cells);
+        }
+        else if (LastSelectionUnit is not TableViewSelectionUnit.Cell && _lastDragSelectionRowRange?.Length > 0)
+        {
+            DeselectRange(_lastDragSelectionRowRange);
+
+            _lastDragSelectionRowRange = null;
+            SelectionStartRowIndex = null;
+        }
+        else if (LastSelectionUnit is not TableViewSelectionUnit.Row && _lastDragSelectionCellRange?.Length > 0)
+        {
+            DeselectCellRange(_lastDragSelectionCellRange);
+
+            _lastDragSelectionCellRange = null;
+            SelectionStartCellSlot = null;
+        }
+    }
+
+    /// <summary>
+    /// Selects rows that intersect with the current drag rectangle, updating the selection state accordingly.
+    /// </summary>
+    private void SelectRowsInDragRect(ItemIndexRange rows)
+    {
+        if (_lastDragSelectionRowRange?.FirstIndex == rows?.FirstIndex && _lastDragSelectionRowRange?.LastIndex == rows?.LastIndex) return;
+
+        if (_lastDragSelectionRowRange is not null && rows is not null && _lastDragSelectionRowRange.Contains(rows))
+        {
+            foreach (var slicedRange in _lastDragSelectionRowRange.Subtract(rows))
+            {
+                DeselectRange(slicedRange);
+            }
+        }
+        else if (rows?.Length > 0)
+        {
+            SelectRange(rows);
+        }
+
+        _lastDragSelectionRowRange = rows;
+    }
+
+    /// <summary>
+    /// Selects cells that intersect with the current drag rectangle, updating the selection state accordingly.
+    /// </summary>
+    private void SelectCellsInDragRect(TableViewCellSlotRange cells)
+    {
+        if (_lastDragSelectionCellRange == cells) return;
+
+        if (_lastDragSelectionCellRange is not null && cells is not null)
+        {
+            foreach (var range in _lastDragSelectionCellRange.Subtract(cells))
+            {
+                SubtractCellRangeFromSelection(range);
+            }
+        }
+
+        if (SelectedCellRanges.Any(r => r == cells))
+        {
+            OnCellSelectionChanged();
+        }
+        else if (cells?.Length > 0)
+        {
+            SelectCellRange(cells);
+        }
+
+        _lastDragSelectionCellRange = cells;
+    }
+
+    /// <summary>
+    /// Handles pointer-released for all cases, including when elements sets <c>e.Handled = true</c>.
+    /// </summary>
+    private void OnAnyPointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        EndDragSelection();
     }
 
     /// <summary>
@@ -313,6 +543,9 @@ public partial class TableView : ListView
         return (int)Math.Floor(availableHeight / rowHeight);
     }
 
+    /// <summary>
+    /// Ends the editing of a cell, committing or canceling the edit based on the specified action.
+    /// </summary>
     internal bool EndCellEditing(TableViewEditAction editAction, TableViewCell cell)
     {
         var editingElement = cell.Content as FrameworkElement;
@@ -573,8 +806,7 @@ public partial class TableView : ListView
         {
             // Clipboard failures are normal on Windows (e.g., CLIPBRD_E_CANT_OPEN).
             // Swallow to avoid crashing the application.
-            Debug.WriteLine(
-                $"TableView: Clipboard.SetContent failed: {ex}");
+            TableViewTrace.Write($"TableView: Clipboard.SetContent failed: {ex}");
         }
     }
 
@@ -1053,7 +1285,7 @@ public partial class TableView : ListView
                 if (Items.Count > 0 && Columns.VisibleColumns.Count > 0)
                 {
                     SelectedCellRanges.Clear();
-                    SelectedCellRanges.Add([new TableViewCellSlot(0, 0)]);
+                    SelectedCellRanges.Add(TableViewCellSlotRange.FromSlots(new(0, 0)));
                 }
                 break;
             case ListViewSelectionMode.Multiple:
@@ -1145,7 +1377,7 @@ public partial class TableView : ListView
             else
             {
                 if (SelectionUnit is TableViewSelectionUnit.CellWithRow)
-                {                    
+                {
                     SelectRows(slot, shiftKey, ctrlKey);
                 }
                 else if (!ctrlKey)
@@ -1246,17 +1478,15 @@ public partial class TableView : ListView
             }
         }
 
-        var selectionRange = (SelectionStartCellSlot is null ? null : SelectedCellRanges.LastOrDefault(x => SelectionStartCellSlot.HasValue && x.Contains(SelectionStartCellSlot.Value))) ?? [];
+        var selectionRange = (SelectionStartCellSlot is null ? null : SelectedCellRanges.LastOrDefault(x => SelectionStartCellSlot.HasValue && x.Contains(SelectionStartCellSlot.Value.Row, SelectionStartCellSlot.Value.Column)));
 
         if (ctrlKey && SelectionMode is ListViewSelectionMode.Multiple or ListViewSelectionMode.Extended)
         {
-            selectionRange = SelectedCellRanges.SelectMany(x => x).ToHashSet();
-            SelectedCellRanges.Clear();
+            // Keep existing ranges; the new slot/range will be added alongside them.
         }
         else
         {
-            SelectedCellRanges.Remove(selectionRange);
-            selectionRange.Clear();
+            SelectedCellRanges.Remove(selectionRange!);
         }
 
         SelectionStartCellSlot ??= CurrentCellSlot;
@@ -1264,36 +1494,14 @@ public partial class TableView : ListView
 
         if (shiftKey && SelectionMode is ListViewSelectionMode.Multiple or ListViewSelectionMode.Extended)
         {
-            var currentSlot = SelectionStartCellSlot.Value;
-            var startRow = Math.Min(slot.Row, currentSlot.Row);
-            var endRow = Math.Max(slot.Row, currentSlot.Row);
-            var startCol = Math.Min(slot.Column, currentSlot.Column);
-            var endCol = Math.Max(slot.Column, currentSlot.Column);
-            for (var row = startRow; row <= endRow; row++)
-            {
-                for (var column = startCol; column <= endCol; column++)
-                {
-                    var nextSlot = new TableViewCellSlot(row, column);
-                    selectionRange.Add(nextSlot);
-                    if (SelectedCellRanges.LastOrDefault(x => x.Contains(nextSlot)) is { } range)
-                    {
-                        range.Remove(nextSlot);
-                    }
-                }
-            }
+            var newRange = TableViewCellSlotRange.FromSlots(SelectionStartCellSlot.Value, slot);
+            SelectedCellRanges.Add(newRange);
         }
         else
         {
             SelectionStartCellSlot = slot;
-            selectionRange.Add(slot);
-
-            if (SelectedCellRanges.LastOrDefault(x => x.Contains(slot)) is { } range)
-            {
-                range.Remove(slot);
-            }
+            SelectedCellRanges.Add(TableViewCellSlotRange.FromSlots(slot));
         }
-
-        SelectedCellRanges.Add(selectionRange);
         OnCellSelectionChanged();
         CurrentCellSlot = slot;
     }
@@ -1303,15 +1511,56 @@ public partial class TableView : ListView
     /// </summary>
     internal void DeselectCell(TableViewCellSlot slot)
     {
-        var selectionRange = SelectedCellRanges.LastOrDefault(x => x.Contains(slot));
-        selectionRange?.Remove(slot);
-
-        if (selectionRange?.Count == 0)
+        var selectionRange = SelectedCellRanges.LastOrDefault(x => x.Contains(slot.Row, slot.Column));
+        if (selectionRange is not null)
         {
             SelectedCellRanges.Remove(selectionRange);
         }
 
         CurrentCellSlot = slot;
+        OnCellSelectionChanged();
+    }
+
+    /// <summary>
+    /// Selects all the cells within the specified range, raising the <see cref="CellSelectionChanged"/> event only once.
+    /// </summary>
+    /// <param name="range">The range of cell slots to select.</param>
+    public void SelectCellRange(TableViewCellSlotRange? range)
+    {
+        if (range is null || range.Length <= 0
+            || !range.IsValid(this)
+            || SelectionMode is ListViewSelectionMode.None
+            || SelectionUnit is TableViewSelectionUnit.Row)
+        {
+            return;
+        }
+
+        if (SelectedCellRanges.Any(x => x == range)) return;
+
+        if (SelectionUnit is TableViewSelectionUnit.CellWithRow)
+        {
+            _suppressSelectionChangedCellClear = true;
+            var rowRange = new ItemIndexRange(range.FirstRow, (uint)range.Rows);
+            SelectRange(rowRange);
+        }
+
+        SubtractCellRangeFromSelection(range);
+        SelectedCellRanges.Add(range);
+        OnCellSelectionChanged();
+    }
+
+    /// <summary>
+    /// Deselects all the cells within the specified range, raising the <see cref="CellSelectionChanged"/> event only once.
+    /// </summary>
+    /// <param name="range">The range of cell slots to deselect.</param>
+    public void DeselectCellRange(TableViewCellSlotRange? range)
+    {
+        if (range is null || range.Length <= 0 || SelectedCellRanges.Count is 0)
+        {
+            return;
+        }
+
+        SubtractCellRangeFromSelection(range);
         OnCellSelectionChanged();
     }
 
@@ -1353,43 +1602,38 @@ public partial class TableView : ListView
     /// </summary>
     private void OnCellSelectionChanged()
     {
-        if (_cellSelectionDirty) return;
-        _cellSelectionDirty = true;
+        var newSelection = SelectedCellRanges.SelectMany(x => x.GetSlots()).ToHashSet();
+        var removedCells = SelectedCells.Where(s => !newSelection.Contains(s)).ToList();
+        var addedCells = newSelection.Where(s => !SelectedCells.Contains(s)).ToList();
 
-        if (!DispatcherQueue.TryEnqueue(() =>
+        if (removedCells.Count is 0 && addedCells.Count is 0) return;
+
+        foreach (var slot in removedCells) SelectedCells.Remove(slot);
+        foreach (var slot in addedCells) SelectedCells.Add(slot);
+
+        OnCellSelectionChanged(new TableViewCellSelectionChangedEventArgs(removedCells, addedCells));
+
+        foreach (var slot in removedCells.Concat(addedCells))
+            _pendingCellStateRows.Add(slot.Row);
+
+        if (!_cellStateDispatchPending)
         {
-            _cellSelectionDirty = false;
-
-            var oldSelection = SelectedCells;
-            SelectedCells = [.. SelectedCellRanges.SelectMany(x => x)];
-
-            var rowIndexes = oldSelection.Select(x => x.Row).Concat(SelectedCells.Select(x => x.Row)).Distinct();
-
-            foreach (var rowIndex in rowIndexes)
-            {
-                var row = _rows.FirstOrDefault(x => x.Index == rowIndex);
-                row?.ApplyCellsSelectionState();
-            }
-
-            InvokeCellSelectionChangedEvent(oldSelection);
-        }))
-        {
-            _cellSelectionDirty = false;
+            _cellStateDispatchPending = true;
+            DispatcherQueue.TryEnqueue(ApplyPendingCellStates);
         }
     }
 
-    /// <summary>
-    /// Invokes the <see cref="CellSelectionChanged"/> event to notify subscribers of changes in the selected cells.
-    /// </summary>
-    private void InvokeCellSelectionChangedEvent(HashSet<TableViewCellSlot> oldSelection)
+    private void ApplyPendingCellStates()
     {
-        var removedCells = oldSelection.Except(SelectedCells).ToList();
-        var addedCells = SelectedCells.Except(oldSelection).ToList();
+        _cellStateDispatchPending = false;
+        if (_pendingCellStateRows.Count is 0) return;
 
-        if (removedCells.Count > 0 || addedCells.Count > 0)
+        foreach (var row in _rows)
         {
-            OnCellSelectionChanged(new TableViewCellSelectionChangedEventArgs(removedCells, addedCells));
+            if (_pendingCellStateRows.Contains(row.Index))
+                row.ApplyCellsSelectionState();
         }
+        _pendingCellStateRows.Clear();
     }
 
     /// <summary>
@@ -1414,10 +1658,7 @@ public partial class TableView : ListView
         _dragStartVerticalOffset = _scrollViewer?.VerticalOffset ?? 0;
         _dragStartHorizontalOffset = HorizontalOffset;
 
-        if (_scrollViewer is not null)
-        {
-            _scrollViewer.ViewChanged += OnScrollViewerViewChangedDuringDrag;
-        }
+        _scrollViewer?.ViewChanged += OnScrollViewerViewChangedDuringDrag;
 
         // Show the drag rectangle visual if enabled and template parts are available
         if (ShowDragRectangle && DragRectangleCanvas is not null && _dragRectangle is not null)
@@ -1453,6 +1694,26 @@ public partial class TableView : ListView
         }
 
         UpdateAutoScroll(currentPoint);
+    }
+
+    /// <summary>
+    /// Transforms a point relative to this <see cref="TableView"/> into coordinates relative to the <see cref="DragRectangleCanvas"/>.
+    /// Returns <c>null</c> when the canvas is unavailable or the transform cannot be computed.
+    /// A negative Y value indicates the point is above the scroll area (column header territory).
+    /// </summary>
+    /// <param name="position">The position relative to this TableView.</param>
+    /// <returns>The canvas-relative point, or <c>null</c> if unavailable.</returns>
+    private Point? GetCanvasPoint(Point position)
+    {
+        if (DragRectangleCanvas is null) return null;
+        try
+        {
+            return TransformToVisual(DragRectangleCanvas).TransformPoint(position);
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
     }
 
     /// <summary>
@@ -1597,8 +1858,6 @@ public partial class TableView : ListView
             {
                 PositionDragRectangle(_lastDragCanvasPoint.Value);
             }
-
-            SelectCellAtDragPoint();
         }
     }
 
@@ -1627,54 +1886,6 @@ public partial class TableView : ListView
         {
             PositionDragRectangle(_lastDragCanvasPoint.Value);
         }
-
-        // Update selection for newly visible rows during auto-scroll
-        SelectCellAtDragPoint();
-    }
-
-    /// <summary>
-    /// Selects the cell at the last known drag pointer position.
-    /// Used during auto-scroll to select newly visible cells when the pointer isn't moving.
-    /// </summary>
-    private void SelectCellAtDragPoint()
-    {
-        if (_scrollViewer is null || _lastDragCanvasPoint is null || DragRectangleCanvas is null)
-        {
-            return;
-        }
-
-        // Clamp to the cell area within the viewport.
-        // CellsHorizontalOffset accounts for row headers so we don't hit-test on header area.
-        var canvasPoint = _lastDragCanvasPoint.Value;
-        var minX = CellsHorizontalOffset + 1;
-        var clampedPoint = new Point(
-            Math.Clamp(canvasPoint.X, minX, Math.Max(minX, _scrollViewer.ViewportWidth - 1)),
-            Math.Clamp(canvasPoint.Y, 1, Math.Max(1, _scrollViewer.ViewportHeight - 1)));
-
-        try
-        {
-            var screenPoint = DragRectangleCanvas.TransformToVisual(null).TransformPoint(clampedPoint);
-#if WINDOWS
-            var cell = VisualTreeHelper.FindElementsInHostCoordinates(screenPoint, _scrollViewer)
-#else
-            var cell = VisualTreeHelper.FindElementsInHostCoordinates(screenPoint, _scrollViewer, true)
-                                       .OfType<ContentPresenter>()
-                                       .Where(x => x.Name is "Content")
-                                       .Select(x => x.FindAscendant<TableViewCell>() is { } c ? c : default)
-#endif
-                                       .OfType<TableViewCell>()
-                                       .FirstOrDefault();
-
-            if (cell is not null && cell.Slot != CurrentCellSlot)
-            {
-                var ctrlKey = KeyboardHelper.IsCtrlKeyDown();
-                MakeSelection(cell.Slot, true, ctrlKey);
-            }
-        }
-        catch (ArgumentException)
-        {
-            // Element not in visual tree during container recycling
-        }
     }
 
     /// <summary>
@@ -1686,32 +1897,45 @@ public partial class TableView : ListView
 
         StopAutoScroll();
 
-        if (_scrollViewer is not null)
+        _pointerCaptureElement?.ReleasePointerCaptures();
+        _tableViewDragPointer = null;
+
+        _scrollViewer?.ViewChanged -= OnScrollViewerViewChangedDuringDrag;
+        _dragRectangle?.Visibility = Visibility.Collapsed;
+
+        // Determine the corner of the selection nearest the pointer before clearing drag state.
+        TableViewCellSlot? endSlot = null;
+        if (_lastDragSelectionCellRange is { Length: > 0 } endRange && _dragStartPoint is not null && _lastDragCanvasPoint is not null)
         {
-            _scrollViewer.ViewChanged -= OnScrollViewerViewChangedDuringDrag;
+            var verticalScrollDelta = (_scrollViewer?.VerticalOffset ?? 0) - _dragStartVerticalOffset;
+            var horizontalScrollDelta = HorizontalOffset - _dragStartHorizontalOffset;
+            var rowsTopToBottom = _dragStartPoint.Value.Y - verticalScrollDelta <= _lastDragCanvasPoint.Value.Y;
+            var colsLeftToRight = _dragStartPoint.Value.X - horizontalScrollDelta <= _lastDragCanvasPoint.Value.X;
+            endSlot = new TableViewCellSlot(
+                rowsTopToBottom ? endRange.LastRow : endRange.FirstRow,
+                colsLeftToRight ? endRange.LastColumn : endRange.FirstColumn);
         }
 
-        if (_dragRectangle is not null)
+        // Clean up any pointer capture the TableView itself held (empty-space drag path).
+        if (_tableViewDragPointer is not null)
         {
-            _dragRectangle.Visibility = Visibility.Collapsed;
+            _tableViewDragPointer = null;
+            ReleasePointerCaptures();
         }
 
         IsDragSelecting = false;
         _dragStartPoint = null;
         _lastDragCanvasPoint = null;
+        SelectionStartCellSlot = null;
 
         // Restore focus and scroll to the current cell now that dragging has ended
-        try
+        if (endSlot?.IsValid(this) == true)
         {
-            if (CurrentCellSlot.HasValue)
-            {
-                var cell = await ScrollCellIntoView(CurrentCellSlot.Value);
-                cell?.ApplyCurrentCellState();
-            }
+            CurrentCellSlot = endSlot.Value;
         }
-        catch (Exception)
+        else if (_lastDragSelectionCellRange?.Length > 0 && _lastDragSelectionCellRange.LastSlot.IsValid(this))
         {
-            // Focus restoration is best-effort after drag ends
+            CurrentCellSlot = _lastDragSelectionCellRange.LastSlot;
         }
     }
 
@@ -1826,6 +2050,112 @@ public partial class TableView : ListView
     internal TableViewCell? GetCellFromSlot(TableViewCellSlot slot)
     {
         return slot.IsValid(this) && ContainerFromIndex(slot.Row) is TableViewRow row ? row.Cells[slot.Column] : default;
+    }
+
+    /// <summary>
+    /// Returns the index of the row that contains <paramref name="canvasPoint"/>, or the nearest row
+    /// within the vertical span between the drag start point and <paramref name="canvasPoint"/> when
+    /// the point falls in empty space. Returns <c>null</c> when no realized row falls in that span.
+    /// </summary>
+    private int? GetRowIndexAtCanvasPoint(Point canvasPoint)
+    {
+        if (DragRectangleCanvas is null) return null;
+
+        // Compute the vertical span of the drag so we can snap to the nearest in-span row when the
+        // pointer is in empty space. If there is no drag start (called outside a drag), minY == maxY
+        // == canvasPoint.Y, which collapses back to the original exact hit-test behaviour.
+        var verticalScrollDelta = (_scrollViewer?.VerticalOffset ?? 0) - _dragStartVerticalOffset;
+        var adjustedStartY = _dragStartPoint is not null
+            ? _dragStartPoint.Value.Y - verticalScrollDelta
+            : canvasPoint.Y;
+
+        var minY = Math.Min(adjustedStartY, canvasPoint.Y);
+        var maxY = Math.Max(adjustedStartY, canvasPoint.Y);
+
+        TableViewRow? nearestRow = null;
+        var nearestDistance = double.MaxValue;
+
+        foreach (var row in _rows)
+        {
+            Point rowOrigin;
+            try { rowOrigin = row.TransformToVisual(DragRectangleCanvas).TransformPoint(default); }
+            catch (ArgumentException) { continue; }
+
+            var rowTop = rowOrigin.Y;
+            var rowBottom = rowTop + row.ActualHeight;
+
+            if (rowBottom <= minY || rowTop >= maxY) continue;
+
+            var distance = Math.Max(0d, Math.Max(rowTop - canvasPoint.Y, canvasPoint.Y - rowBottom));
+            if (distance < nearestDistance)
+            {
+                nearestDistance = distance;
+                nearestRow = row;
+            }
+        }
+
+        return nearestRow?.Index;
+    }
+
+    /// <summary>
+    /// Returns the index of the visible column whose bounds contain the given canvas X coordinate.
+    /// Returns <c>null</c> when x falls outside the column area or there are no visible columns.
+    /// </summary>
+    private int? GetColumnIndexAtCanvasX(double x)
+    {
+        var columnLeft = CellsHorizontalOffset - HorizontalOffset;
+        for (var i = 0; i < Columns.VisibleColumns.Count; i++)
+        {
+            var columnRight = columnLeft + Columns.VisibleColumns[i].ActualWidth;
+            if (x >= columnLeft && x < columnRight)
+                return i;
+            columnLeft = columnRight;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the cell slot at <paramref name="canvasPoint"/>, snapping to the nearest row and
+    /// column within the horizontal and vertical span of the current drag when the point falls in
+    /// empty space. Returns <c>null</c> when no realized row or visible column falls in that span.
+    /// </summary>
+    private TableViewCellSlot? GetSlotAtCanvasPoint(Point canvasPoint)
+    {
+        if (DragRectangleCanvas is null) return null;
+
+        if (GetRowIndexAtCanvasPoint(canvasPoint) is not int rowIndex) return null;
+
+        // Mirror the row snapping: find the nearest column within the horizontal drag span.
+        var horizontalScrollDelta = HorizontalOffset - _dragStartHorizontalOffset;
+        var adjustedStartX = _dragStartPoint is not null
+            ? _dragStartPoint.Value.X - horizontalScrollDelta
+            : canvasPoint.X;
+
+        var minX = Math.Min(adjustedStartX, canvasPoint.X);
+        var maxX = Math.Max(adjustedStartX, canvasPoint.X);
+
+        var nearestColIndex = -1;
+        var nearestDistance = double.MaxValue;
+        var columnLeft = CellsHorizontalOffset - HorizontalOffset;
+
+        for (var i = 0; i < Columns.VisibleColumns.Count; i++)
+        {
+            var columnRight = columnLeft + Columns.VisibleColumns[i].ActualWidth;
+
+            if (columnRight > minX && columnLeft < maxX)
+            {
+                var distance = Math.Max(0d, Math.Max(columnLeft - canvasPoint.X, canvasPoint.X - columnRight));
+                if (distance < nearestDistance)
+                {
+                    nearestDistance = distance;
+                    nearestColIndex = i;
+                }
+            }
+
+            columnLeft = columnRight;
+        }
+
+        return nearestColIndex == -1 ? null : new TableViewCellSlot(rowIndex, nearestColIndex);
     }
 
     /// <summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -247,6 +247,10 @@ public partial class TableView : ListView
         {
             UIElement? clickedElement = element.FindAscendant<TableViewCell>(); // Check if the pointer is over a TableViewCell
             clickedElement ??= element.FindAscendant<TableViewRow>(); // If not, check if the pointer is over a TableViewRow
+
+            // Skip selection when the pointer is not over a Cell or Row, and ShowDragRectangle is false.
+            if (clickedElement == null && !ShowDragRectangle) return;
+
             clickedElement ??= this; // If not, default to the TableView itself
 
             SelectionStartCellSlot = (clickedElement as TableViewCell)?.Slot;
@@ -1661,7 +1665,7 @@ public partial class TableView : ListView
         _scrollViewer?.ViewChanged += OnScrollViewerViewChangedDuringDrag;
 
         // Show the drag rectangle visual if enabled and template parts are available
-        if (ShowDragRectangle && DragRectangleCanvas is not null && _dragRectangle is not null)
+        if (DragRectangleCanvas is not null && _dragRectangle is not null)
         {
             _dragStartPoint = startPoint;
 
@@ -1670,7 +1674,7 @@ public partial class TableView : ListView
             _dragRectangle.Width = 0;
             _dragRectangle.Height = 0;
 
-            _dragRectangle.Visibility = Visibility.Visible;
+            _dragRectangle.Visibility = ShowDragRectangle ? Visibility.Visible : Visibility.Collapsed;
         }
     }
 

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -71,6 +71,7 @@ public partial class TableView : ListView
         Unloaded += OnUnloaded;
         SelectionChanged += TableView_SelectionChanged;
         _collectionView.ItemPropertyChanged += OnItemPropertyChanged;
+
         AddHandler(PointerPressedEvent, new PointerEventHandler(OnAnyPointerPressed), handledEventsToo: true);
         AddHandler(PointerReleasedEvent, new PointerEventHandler(OnAnyPointerReleased), handledEventsToo: true);
     }
@@ -253,22 +254,22 @@ public partial class TableView : ListView
 
         if (e.OriginalSource is UIElement element)
         {
-            UIElement? clickedElement = element.FindAscendant<TableViewCell>(); // Check if the pointer is over a TableViewCell
-            clickedElement ??= element.FindAscendant<TableViewRow>(); // If not, check if the pointer is over a TableViewRow
+            UIElement? pressedElement = element.FindAscendant<TableViewCell>(); // Check if the pointer is over a TableViewCell
+            pressedElement ??= element.FindAscendant<TableViewRow>(); // If not, check if the pointer is over a TableViewRow
 
             // Skip selection when the pointer is not over a Cell or Row, and ShowDragRectangle is false.
-            if (clickedElement == null && !ShowDragRectangle) return;
+            if (pressedElement == null && !ShowDragRectangle) return;
 
-            clickedElement ??= this; // If not, default to the TableView itself
+            pressedElement ??= this; // If not, default to the TableView itself
 
-            SelectionStartCellSlot = (clickedElement as TableViewCell)?.Slot;
-            SelectionStartRowIndex = (clickedElement as TableViewRow)?.Index;
+            SelectionStartCellSlot = (pressedElement as TableViewCell)?.Slot;
+            SelectionStartRowIndex = (pressedElement as TableViewRow)?.Index;
 
             LastSelectionUnit = SelectionUnit switch
             {
                 TableViewSelectionUnit.Cell => TableViewSelectionUnit.Cell,
                 TableViewSelectionUnit.Row => TableViewSelectionUnit.Row,
-                _ => clickedElement is TableViewCell
+                _ => pressedElement is TableViewCell
                     ? TableViewSelectionUnit.Cell
                     : TableViewSelectionUnit.Row
             };
@@ -282,9 +283,9 @@ public partial class TableView : ListView
                 return;
             }
 
-            clickedElement.Focus(FocusState.Programmatic);
+            pressedElement.Focus(FocusState.Programmatic);
 #if WINDOWS
-            _pointerCaptureElement = clickedElement;
+            _pointerCaptureElement = pressedElement;
 #else
             _pointerCaptureElement = this;
 #endif

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -254,62 +254,57 @@ public partial class TableView : ListView
         _lastDragSelectionRowRange = null;
         _lastDragSelectionCellRange = null;
         LastSelectionUnit = TableViewSelectionUnit.Row;
-
-        if (e.OriginalSource is UIElement element)
-        {
-
 #if !WINDOWS
-            _dragStartCell = pressedElement as TableViewCell;
-            _dragStartRow = element.FindAscendant<TableViewRow>();
+        _dragStartCell = pressedElement as TableViewCell;
+        _dragStartRow = (pressedElement as TableViewRow) ?? orignalSoruce?.FindAscendant<TableViewRow>();
 #endif
-            pressedElement ??= this; // If not, default to the TableView itself
+        pressedElement ??= this; // If not, default to the TableView itself
 
-            SelectionStartCellSlot = (pressedElement as TableViewCell)?.Slot;
-            SelectionStartRowIndex = (pressedElement as TableViewRow)?.Index;
+        SelectionStartCellSlot = (pressedElement as TableViewCell)?.Slot;
+        SelectionStartRowIndex = (pressedElement as TableViewRow)?.Index;
 
-            LastSelectionUnit = SelectionUnit switch
-            {
-                TableViewSelectionUnit.Cell => TableViewSelectionUnit.Cell,
-                TableViewSelectionUnit.Row => TableViewSelectionUnit.Row,
-                _ => pressedElement is TableViewCell
-                    ? TableViewSelectionUnit.Cell
-                    : TableViewSelectionUnit.Row
-            };
+        LastSelectionUnit = SelectionUnit switch
+        {
+            TableViewSelectionUnit.Cell => TableViewSelectionUnit.Cell,
+            TableViewSelectionUnit.Row => TableViewSelectionUnit.Row,
+            _ => pressedElement is TableViewCell
+                ? TableViewSelectionUnit.Cell
+                : TableViewSelectionUnit.Row
+        };
 
-            if (SelectionMode is ListViewSelectionMode.Single)
-            {
-                _lastDragCanvasPoint = canvasPoint;
-                MakeSelectionInDragRect();
-                SetCurrentCell(GetSlotAtCanvasPoint(_lastDragCanvasPoint.Value));
-
-                return;
-            }
-
-            pressedElement.Focus(FocusState.Programmatic);
-#if WINDOWS
-            _pointerCaptureElement = pressedElement;
-#else
-            _pointerCaptureElement = this;
-#endif
-
-            _pointerCaptureElement.CapturePointer(e.Pointer);
-            _tableViewDragPointer = e.Pointer;
-
-            if (!ctrlKey && SelectionMode is not ListViewSelectionMode.Multiple && LastSelectionUnit is not TableViewSelectionUnit.Cell)
-                DeselectAll();
-
-            StartDragSelection(canvasPoint.Value);
-
-            if (!IsDragSelecting)
-            {
-                _pointerCaptureElement?.ReleasePointerCaptures();
-                _pointerCaptureElement = null;
-                _tableViewDragPointer = null;
-                return;
-            }
-
+        if (SelectionMode is ListViewSelectionMode.Single)
+        {
+            _lastDragCanvasPoint = canvasPoint;
             MakeSelectionInDragRect();
+            SetCurrentCell(GetSlotAtCanvasPoint(_lastDragCanvasPoint.Value));
+
+            return;
         }
+
+        pressedElement.Focus(FocusState.Programmatic);
+#if WINDOWS
+        _pointerCaptureElement = pressedElement;
+#else
+        _pointerCaptureElement = this;
+#endif
+
+        _pointerCaptureElement.CapturePointer(e.Pointer);
+        _tableViewDragPointer = e.Pointer;
+
+        if (!ctrlKey && SelectionMode is not ListViewSelectionMode.Multiple && LastSelectionUnit is not TableViewSelectionUnit.Cell)
+            DeselectAll();
+
+        StartDragSelection(canvasPoint.Value);
+
+        if (!IsDragSelecting)
+        {
+            _pointerCaptureElement?.ReleasePointerCaptures();
+            _pointerCaptureElement = null;
+            _tableViewDragPointer = null;
+            return;
+        }
+
+        MakeSelectionInDragRect();
     }
 
     /// <inheritdoc/>
@@ -2122,12 +2117,35 @@ public partial class TableView : ListView
         _scrollViewer?.ViewChanged -= OnScrollViewerViewChangedDuringDrag;
         _dragRectangle?.Visibility = Visibility.Collapsed;
 
-        SetCurrentCell(GetSlotAtCanvasPoint(_lastDragCanvasPoint.Value));
+        var slot = GetSlotAtCanvasPoint(_lastDragCanvasPoint.Value);
+        SetCurrentCell(slot);
 
         IsDragSelecting = false;
         _dragStartPoint = null;
         _lastDragCanvasPoint = null;
         SelectionStartCellSlot = null;
+
+#if !WINDOWS
+        if (_dragStartCell is not null && slot != _dragStartCell.Slot)
+        {
+            VisualStates.GoToState(_dragStartCell, false, VisualStates.StateNormal);
+
+            if (_dragStartCell.IsSelected)
+            {
+                VisualStates.GoToState(_dragStartCell, false, VisualStates.StateSelected);
+            }
+        }
+
+        if (_dragStartRow is not null && _dragStartRow.Index != slot?.Row)
+        {
+            VisualStates.GoToState(_dragStartRow, false, VisualStates.StateNormal);
+
+            if (_dragStartRow.IsSelected)
+            {
+                VisualStates.GoToState(_dragStartRow, false, VisualStates.StateSelected);
+            }
+        }
+#endif
     }
 
     private void SetCurrentCell(TableViewCellSlot? slot)
@@ -2139,32 +2157,8 @@ public partial class TableView : ListView
         if (!(SelectionUnit is TableViewSelectionUnit.Row && IsReadOnly))
         {
             CurrentCellSlot = slot;
-#if !WINDOWS
-            if (_dragStartCell is not null
-                && _dragStartPoint is not null
-                && slot != _dragStartCell.Slot)
-            {
-                VisualStates.GoToState(_dragStartCell, false, VisualStates.StateNormal);
 
-                if (_dragStartCell.IsSelected)
-                {
-                    VisualStates.GoToState(_dragStartCell, false, VisualStates.StateSelected);
-                }
-            }
-#endif
         }
-
-#if !WINDOWS
-        if (_dragStartRow is not null && _dragStartRow.Index != slot.Value.Row)
-        {
-            VisualStates.GoToState(_dragStartRow, false, VisualStates.StateNormal);
-
-            if (_dragStartRow.IsSelected)
-            {
-                VisualStates.GoToState(_dragStartRow, false, VisualStates.StateSelected);
-            }
-        }
-#endif
     }
 
     /// <summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -228,7 +228,7 @@ public partial class TableView : ListView
         var position = pointerPoint.Position;
         var canvasPoint = GetCanvasPoint(position);
         var ctrlKey = KeyboardHelper.IsCtrlKeyDown();
-        var isShiftkey = KeyboardHelper.IsShiftKeyDown();
+        var isShiftKey = KeyboardHelper.IsShiftKeyDown();
         var orignalSoruce = e.OriginalSource as FrameworkElement;
         UIElement? pressedElement = orignalSoruce?.FindAscendant<TableViewCell>();      // Check if the pointer is over a cell
         pressedElement ??= orignalSoruce?.FindAscendant<TableViewRow>();                // If not, check if the pointer is over a row
@@ -241,8 +241,8 @@ public partial class TableView : ListView
             || !pointerPoint.Properties.IsLeftButtonPressed                             // Skip selection when the left mouse button is not pressed
             || canvasPoint is null                                                      // Skip selection when canvasPoint is null (e.g., pointer is outside the scroll canvas)
             || canvasPoint.Value.Y < 0                                                  // Skip selection when the pointer is in the column header area (above the scroll canvas)              
-            || (pressedElement != null && canvasPoint.Value.X < CellsHorizontalOffset)  // Skip selection when the pointer is in the row header area (to the left of the scroll canvas)
-            || isShiftkey)                                                              // Skip selection when the Shift key is held
+            || (pressedElement == null && canvasPoint.Value.X < CellsHorizontalOffset)  // Skip selection when the pointer is in the row header area (and not on a row/cell)
+            || isShiftKey)                                                              // Skip selection when the Shift key is held
         {
             return;
         }
@@ -2275,9 +2275,8 @@ public partial class TableView : ListView
     }
 
     /// <summary>
-    /// Returns the index of the row that contains <paramref name="canvasPoint"/>, or the nearest row
-    /// within the vertical span between the drag start point and <paramref name="canvasPoint"/> when
-    /// the point falls in empty space. Returns <c>null</c> when no realized row falls in that span.
+    /// Returns the index of the realized row whose vertical bounds contain <paramref name="canvasPoint"/>.
+    /// Returns <c>null</c> when no realized row contains the point.
     /// </summary>
     private int? GetRowIndexAtCanvasPoint(Point canvasPoint)
     {
@@ -2328,9 +2327,8 @@ public partial class TableView : ListView
     }
 
     /// <summary>
-    /// Resolves the cell slot at <paramref name="canvasPoint"/>, snapping to the nearest row and
-    /// column within the horizontal and vertical span of the current drag when the point falls in
-    /// empty space. Returns <c>null</c> when no realized row or visible column falls in that span.
+    /// Resolves the cell slot at <paramref name="canvasPoint"/>.
+    /// Returns <c>null</c> when no realized row or visible column contains the point.
     /// </summary>
     private TableViewCellSlot? GetSlotAtCanvasPoint(Point canvasPoint)
     {

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -273,6 +273,16 @@ public partial class TableView : ListView
                     : TableViewSelectionUnit.Row
             };
 
+            if (SelectionMode is ListViewSelectionMode.Single)
+            {
+                _lastDragCanvasPoint = canvasPoint;
+                MakeSelectionInDragRect();
+                SetCurrentCellFromCanvasPoint(_lastDragCanvasPoint.Value);
+
+                return;
+            }
+
+            clickedElement.Focus(FocusState.Programmatic);
 #if WINDOWS
             _pointerCaptureElement = clickedElement;
 #else
@@ -390,7 +400,11 @@ public partial class TableView : ListView
     {
         if (_lastDragSelectionRowRange?.FirstIndex == rows.FirstIndex && _lastDragSelectionRowRange?.LastIndex == rows.LastIndex) return;
 
-        if (_lastDragSelectionRowRange is not null && _lastDragSelectionRowRange.Contains(rows))
+        if (SelectionMode is ListViewSelectionMode.Single && rows.Length is 1)
+        {
+            SelectedIndex = rows.FirstIndex;
+        }
+        else if (_lastDragSelectionRowRange is not null && _lastDragSelectionRowRange.Contains(rows))
         {
             foreach (var slicedRange in _lastDragSelectionRowRange.Subtract(rows))
             {
@@ -1635,18 +1649,9 @@ public partial class TableView : ListView
 
         if (newSlot.HasValue)
         {
-            // During drag selection, skip expensive scroll-into-view and focus operations.
-            // The drag rectangle handles visual feedback, and focus is restored when dragging ends.
-            if (IsDragSelecting)
-            {
-                var cell = GetCellFromSlot(newSlot.Value);
-                cell?.ApplyCurrentCellState(skipFocus: true);
-            }
-            else
-            {
-                var cell = await ScrollCellIntoView(newSlot.Value);
-                cell?.ApplyCurrentCellState();
-            }
+            var cell = await ScrollCellIntoView(newSlot.Value);
+            cell?.ApplyCurrentCellState();
+            cell?.Focus(FocusState.Programmatic);
         }
     }
 
@@ -1959,7 +1964,7 @@ public partial class TableView : ListView
     /// </summary>
     internal async void EndDragSelection()
     {
-        if (!IsDragSelecting) return;
+        if (!IsDragSelecting || _lastDragCanvasPoint is null) return;
 
         StopAutoScroll();
 
@@ -1970,32 +1975,24 @@ public partial class TableView : ListView
         _scrollViewer?.ViewChanged -= OnScrollViewerViewChangedDuringDrag;
         _dragRectangle?.Visibility = Visibility.Collapsed;
 
-        // Determine the corner of the selection nearest the pointer before clearing drag state.
-        TableViewCellSlot? endSlot = null;
-        if (_lastDragSelectionCellRange is { Length: > 0 } endRange && _dragStartPoint is not null && _lastDragCanvasPoint is not null)
-        {
-            var verticalScrollDelta = (_scrollViewer?.VerticalOffset ?? 0) - _dragStartVerticalOffset;
-            var horizontalScrollDelta = HorizontalOffset - _dragStartHorizontalOffset;
-            var rowsTopToBottom = _dragStartPoint.Value.Y - verticalScrollDelta <= _lastDragCanvasPoint.Value.Y;
-            var colsLeftToRight = _dragStartPoint.Value.X - horizontalScrollDelta <= _lastDragCanvasPoint.Value.X;
-            endSlot = new TableViewCellSlot(
-                rowsTopToBottom ? endRange.LastRow : endRange.FirstRow,
-                colsLeftToRight ? endRange.LastColumn : endRange.FirstColumn);
-        }
+        SetCurrentCellFromCanvasPoint(_lastDragCanvasPoint.Value);
 
         IsDragSelecting = false;
         _dragStartPoint = null;
         _lastDragCanvasPoint = null;
         SelectionStartCellSlot = null;
+    }
 
-        // Restore focus and scroll to the current cell now that dragging has ended
-        if (endSlot?.IsValid(this) == true)
+    private void SetCurrentCellFromCanvasPoint(Point canvasPoint)
+    {
+        if (GetSlotAtCanvasPoint(canvasPoint, exactMatch: true) is { } endSlot)
         {
-            CurrentCellSlot = endSlot.Value;
-        }
-        else if (_lastDragSelectionCellRange?.Length > 0 && _lastDragSelectionCellRange.LastSlot.IsValid(this))
-        {
-            CurrentCellSlot = _lastDragSelectionCellRange.LastSlot;
+            CurrentRowIndex = endSlot.Row;
+
+            if (!(SelectionUnit is TableViewSelectionUnit.Row && IsReadOnly))
+            {
+                CurrentCellSlot = endSlot;
+            }
         }
     }
 
@@ -2117,9 +2114,25 @@ public partial class TableView : ListView
     /// within the vertical span between the drag start point and <paramref name="canvasPoint"/> when
     /// the point falls in empty space. Returns <c>null</c> when no realized row falls in that span.
     /// </summary>
-    private int? GetRowIndexAtCanvasPoint(Point canvasPoint)
+    private int? GetRowIndexAtCanvasPoint(Point canvasPoint, bool exactMatch = false)
     {
         if (DragRectangleCanvas is null) return null;
+
+        if (exactMatch)
+        {
+            foreach (var row in _rows)
+            {
+                var rowTop = row.Position;
+                var rowBottom = rowTop + row.ActualHeight;
+
+                if (canvasPoint.Y >= rowTop && canvasPoint.Y < rowBottom)
+                {
+                    return row.Index;
+                }
+            }
+
+            return null;
+        }
 
         // Compute the vertical span of the drag so we can snap to the nearest in-span row when the
         // pointer is in empty space. If there is no drag start (called outside a drag), minY == maxY
@@ -2140,14 +2153,14 @@ public partial class TableView : ListView
             var rowTop = row.Position;
             var rowBottom = rowTop + row.ActualHeight;
 
-            if (rowBottom <= minY || rowTop >= maxY) continue;
+            if (rowBottom <= minY || rowTop >= maxY)
+                continue;
 
             var distance = Math.Max(0d, Math.Max(rowTop - canvasPoint.Y, canvasPoint.Y - rowBottom));
             if (distance < nearestDistance)
             {
                 nearestDistance = distance;
                 nearestRow = row;
-                rowTop += row.ActualHeight;
             }
         }
 
@@ -2176,11 +2189,11 @@ public partial class TableView : ListView
     /// column within the horizontal and vertical span of the current drag when the point falls in
     /// empty space. Returns <c>null</c> when no realized row or visible column falls in that span.
     /// </summary>
-    private TableViewCellSlot? GetSlotAtCanvasPoint(Point canvasPoint)
+    private TableViewCellSlot? GetSlotAtCanvasPoint(Point canvasPoint, bool exactMatch = false)
     {
         if (DragRectangleCanvas is null) return null;
 
-        if (GetRowIndexAtCanvasPoint(canvasPoint) is not int rowIndex) return null;
+        if (GetRowIndexAtCanvasPoint(canvasPoint, exactMatch) is not int rowIndex) return null;
 
         // Mirror the row snapping: find the nearest column within the horizontal drag span.
         var horizontalScrollDelta = HorizontalOffset - _dragStartHorizontalOffset;
@@ -2193,14 +2206,20 @@ public partial class TableView : ListView
             var columnRight = columnLeft + Columns.VisibleColumns[i].ActualWidth;
 
             if (adjustedPointerX <= columnRight)
-                return new TableViewCellSlot(rowIndex, i);
+            {
+                // Require the pointer to actually be inside the cell.
+                if (exactMatch && adjustedPointerX < columnLeft)
+                    return null;
+
+                return new(rowIndex, i);
+            }
 
             columnLeft = columnRight;
         }
 
-        return Columns.VisibleColumns.Count > 0
-            ? new TableViewCellSlot(rowIndex, Columns.VisibleColumns.Count - 1)
-            : null;
+        return exactMatch || Columns.VisibleColumns.Count == 0
+            ? null
+            : new(rowIndex, Columns.VisibleColumns.Count - 1);
     }
 
     /// <summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -230,16 +230,19 @@ public partial class TableView : ListView
         var ctrlKey = KeyboardHelper.IsCtrlKeyDown();
         var isShiftkey = KeyboardHelper.IsShiftKeyDown();
         var orignalSoruce = e.OriginalSource as FrameworkElement;
+        UIElement? pressedElement = orignalSoruce?.FindAscendant<TableViewCell>();      // Check if the pointer is over a cell
+        pressedElement ??= orignalSoruce?.FindAscendant<TableViewRow>();                // If not, check if the pointer is over a row
 
-        if (SelectionMode is ListViewSelectionMode.None         // Skip selection when SelectionMode is None
-            || IsDragSelecting                                  // Skip selection when a drag is already in progress
-            || orignalSoruce is ScrollBar                       // Skip selection when the pointer is over the ScrollBar
-            || orignalSoruce?.FindAscendant<ScrollBar>() is { } // Skip selection when the pointer is within a ScrollBar
-            || !pointerPoint.Properties.IsLeftButtonPressed     // Skip selection when the left mouse button is not pressed
-            || canvasPoint is null                              // Skip selection when canvasPoint is null (e.g., pointer is outside the scroll canvas)
-            || canvasPoint.Value.Y < 0                          // Skip selection when the pointer is in the column header area (above the scroll canvas)  
-            || canvasPoint.Value.X < CellsHorizontalOffset      // Skip selection when the pointer is in the row header area (to the left of the scroll canvas)
-            || isShiftkey)                                      // Skip selection when the Shift key is held
+        if (SelectionMode is ListViewSelectionMode.None                                 // Skip selection when SelectionMode is None
+            || IsDragSelecting                                                          // Skip selection when a drag is already in progress
+            || orignalSoruce is ScrollBar                                               // Skip selection when the pointer is over the ScrollBar
+            || orignalSoruce?.FindAscendant<ScrollBar>() is { }                         // Skip selection when the pointer is within a ScrollBar
+            || (pressedElement == null && !ShowDragRectangle)                           // Skip selection when the pointer is not over a Cell or Row, and ShowDragRectangle is false.
+            || !pointerPoint.Properties.IsLeftButtonPressed                             // Skip selection when the left mouse button is not pressed
+            || canvasPoint is null                                                      // Skip selection when canvasPoint is null (e.g., pointer is outside the scroll canvas)
+            || canvasPoint.Value.Y < 0                                                  // Skip selection when the pointer is in the column header area (above the scroll canvas)              
+            || (pressedElement != null && canvasPoint.Value.X < CellsHorizontalOffset)  // Skip selection when the pointer is in the row header area (to the left of the scroll canvas)
+            || isShiftkey)                                                              // Skip selection when the Shift key is held
         {
             return;
         }
@@ -254,17 +257,11 @@ public partial class TableView : ListView
 
         if (e.OriginalSource is UIElement element)
         {
-            UIElement? pressedElement = element.FindAscendant<TableViewCell>(); // Check if the pointer is over a TableViewCell
-            pressedElement ??= element.FindAscendant<TableViewRow>(); // If not, check if the pointer is over a TableViewRow
 
 #if !WINDOWS
             _dragStartCell = pressedElement as TableViewCell;
             _dragStartRow = element.FindAscendant<TableViewRow>();
 #endif
-
-            // Skip selection when the pointer is not over a Cell or Row, and ShowDragRectangle is false.
-            if (pressedElement == null && !ShowDragRectangle) return;
-
             pressedElement ??= this; // If not, default to the TableView itself
 
             SelectionStartCellSlot = (pressedElement as TableViewCell)?.Slot;
@@ -283,7 +280,7 @@ public partial class TableView : ListView
             {
                 _lastDragCanvasPoint = canvasPoint;
                 MakeSelectionInDragRect();
-                SetCurrentCellFromCanvasPoint(_lastDragCanvasPoint.Value);
+                SetCurrentCell(GetSlotAtCanvasPoint(_lastDragCanvasPoint.Value));
 
                 return;
             }
@@ -347,56 +344,201 @@ public partial class TableView : ListView
     /// </summary>
     private void MakeSelectionInDragRect()
     {
-        if (_lastDragCanvasPoint is null) return;
-
-        if (LastSelectionUnit is not TableViewSelectionUnit.Cell && GetRowIndexAtCanvasPoint(_lastDragCanvasPoint.Value) is int row)
+        if (LastSelectionUnit is not TableViewSelectionUnit.Cell)
         {
-            SelectionStartRowIndex ??= row;
-            var minRow = Math.Min(SelectionStartRowIndex.Value, row);
-            var maxRow = Math.Max(SelectionStartRowIndex.Value, row);
-            var rows = new ItemIndexRange(minRow, (uint)(maxRow - minRow + 1));
-
-            SelectRowsInDragRect(rows);
-        }
-        else if (LastSelectionUnit is not TableViewSelectionUnit.Row && GetSlotAtCanvasPoint(_lastDragCanvasPoint.Value) is { } slot)
-        {
-            if (SelectionStartCellSlot is null)
+            if (GetRowsInDragRect() is ItemIndexRange rows)
             {
-                var startColumn = slot.Column;
+                SelectRowsInDragRect(rows);
+            }
+            else if (_lastDragSelectionRowRange?.Length > 0)
+            {
+                DeselectRange(_lastDragSelectionRowRange);
 
-                if (_dragStartPoint is not null)
-                {
-                    var horizontalScrollDelta = HorizontalOffset - _dragStartHorizontalOffset;
-                    var startX = _dragStartPoint.Value.X - horizontalScrollDelta;
-                    startColumn = GetColumnIndexAtCanvasX(startX)
-                        ?? (startX < CellsHorizontalOffset - HorizontalOffset ? 0 : Columns.VisibleColumns.Count - 1);
-                }
+                _lastDragSelectionRowRange = null;
+                SelectionStartRowIndex = null;
+            }
+        }
+        else if (LastSelectionUnit is not TableViewSelectionUnit.Row)
+        {
+            if (GetCellsInDragRect() is TableViewCellSlotRange cells)
+            {
+                SelectCellsInDragRect(cells);
+            }
+            else if (_lastDragSelectionCellRange?.Length > 0)
+            {
+                DeselectCellRange(_lastDragSelectionCellRange);
 
-                SelectionStartCellSlot = new(SelectionStartRowIndex ?? slot.Row, startColumn);
+                _lastDragSelectionCellRange = null;
+                SelectionStartCellSlot = null;
+            }
+            else if (!KeyboardHelper.IsCtrlKeyDown())
+            {
+                DeselectAllCells();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the range of cell slots covered by the current drag rectangle.
+    /// The first slot is the one nearest the drag start point and the last slot
+    /// is the one nearest the drag end point.
+    /// </summary>
+    private ItemIndexRange? GetRowsInDragRect()
+    {
+        if (_dragRectangle is null || _dragStartPoint is null || _lastDragCanvasPoint is null)
+        {
+            return null;
+        }
+
+        // Reconstruct the scroll-adjusted start corner the same way PositionDragRectangle does,
+        // so we know which corner of the rect corresponds to the drag origin.
+        var verticalScrollDelta = (_scrollViewer?.VerticalOffset ?? 0) - _dragStartVerticalOffset;
+        var startY = _dragStartPoint.Value.Y - verticalScrollDelta;
+        var endY = _lastDragCanvasPoint.Value.Y;
+
+        // Orientation of the drag, used to order the returned range from start to end.
+        var rowsTopToBottom = startY <= endY; ;
+
+        // Drag rect bounds in canvas space (already clamped and scroll-adjusted by PositionDragRectangle).
+        var rectTop = Canvas.GetTop(_dragRectangle);
+        var rectBottom = rectTop + _dragRectangle.Height;
+
+        // Find the min/max row indices whose bounds intersect the rect vertically.
+        var minRow = -1;
+        var maxRow = -1;
+
+        for (var rowIndex = 0; rowIndex < Items.Count; rowIndex++)
+        {
+            if (ContainerFromIndex(rowIndex) is not TableViewRow row)
+            {
+                continue;
             }
 
-            var startRow = Math.Min(SelectionStartCellSlot.Value.Row, slot.Row);
-            var endRow = Math.Max(SelectionStartCellSlot.Value.Row, slot.Row);
-            var startCol = Math.Min(SelectionStartCellSlot.Value.Column, slot.Column);
-            var endCol = Math.Max(SelectionStartCellSlot.Value.Column, slot.Column);
-            var cells = TableViewCellSlotRange.FromCoordinates(startRow, startCol, endRow, endCol);
+            var rowTop = row.Position.Y;
+            var rowBottom = rowTop + row.ActualHeight;
 
-            SelectCellsInDragRect(cells);
+            if (rowBottom <= rectTop || rowTop >= rectBottom)
+            {
+                continue;
+            }
+
+            if (minRow == -1) minRow = rowIndex;
+            maxRow = rowIndex;
         }
-        else if (LastSelectionUnit is not TableViewSelectionUnit.Cell && _lastDragSelectionRowRange?.Length > 0)
+
+        if (minRow == -1)
         {
-            DeselectRange(_lastDragSelectionRowRange);
-
-            _lastDragSelectionRowRange = null;
-            SelectionStartRowIndex = null;
+            return null;
         }
-        else if (LastSelectionUnit is not TableViewSelectionUnit.Row && _lastDragSelectionCellRange?.Length > 0)
+
+        // Use the anchor slot captured at drag start as the first slot. The visible scan above
+        // can't see rows/columns that auto-scroll has moved out of view (virtualized), so the
+        // anchor is the only reliable record of where the drag actually began.
+        if (SelectionStartRowIndex is { } anchor)
         {
-            DeselectCellRange(_lastDragSelectionCellRange);
-
-            _lastDragSelectionCellRange = null;
-            SelectionStartCellSlot = null;
+            if (rowsTopToBottom) minRow = anchor;
+            else maxRow = anchor;
         }
+        else
+        {
+            SelectionStartRowIndex = rowsTopToBottom ? minRow : maxRow;
+        }
+
+        return new ItemIndexRange(minRow, (uint)(maxRow - minRow + 1));
+    }
+
+    /// <summary>
+    /// Returns the range of cell slots covered by the current drag rectangle.
+    /// The first slot is the one nearest the drag start point and the last slot
+    /// is the one nearest the drag end point.
+    /// </summary>
+    private TableViewCellSlotRange? GetCellsInDragRect()
+    {
+        if (_dragRectangle is null || DragRectangleCanvas is null || _dragRectangle.Visibility != Visibility.Visible
+            || _dragStartPoint is null || _lastDragCanvasPoint is null)
+        {
+            return null;
+        }
+
+        // Reconstruct the scroll-adjusted start corner the same way PositionDragRectangle does,
+        // so we know which corner of the rect corresponds to the drag origin.
+        var verticalScrollDelta = (_scrollViewer?.VerticalOffset ?? 0) - _dragStartVerticalOffset;
+        var horizontalScrollDelta = HorizontalOffset - _dragStartHorizontalOffset;
+        var startX = _dragStartPoint.Value.X - horizontalScrollDelta;
+        var startY = _dragStartPoint.Value.Y - verticalScrollDelta;
+        var endX = _lastDragCanvasPoint.Value.X;
+        var endY = _lastDragCanvasPoint.Value.Y;
+
+        // Orientation of the drag, used to order the returned range from start to end.
+        var rowsTopToBottom = startY <= endY;
+        var colsLeftToRight = startX <= endX;
+
+        // Drag rect bounds in canvas space (already clamped and scroll-adjusted by PositionDragRectangle).
+        var rectLeft = Canvas.GetLeft(_dragRectangle);
+        var rectRight = rectLeft + _dragRectangle.Width;
+
+        var rows = GetRowsInDragRect();
+
+        if (rows is null || rows.Length == 0) return null;
+
+        // Find the min/max row indices whose bounds intersect the rect vertically.
+        var minRow = rows.FirstIndex;
+        var maxRow = rows.LastIndex;
+
+        // Find the min/max column indices whose bounds intersect the rect horizontally.
+        // Frozen columns are pinned and don't scroll; non-frozen columns shift with HorizontalOffset.
+        // Non-frozen columns that scroll behind the frozen panel are not selectable from that area.
+        var minColumn = -1;
+        var maxColumn = -1;
+        var frozenCount = FrozenColumnCount;
+        var columnLeft = CellsHorizontalOffset;
+        var frozenPanelRight = CellsHorizontalOffset; // updated when we cross into non-frozen territory
+
+        for (var colIndex = 0; colIndex < Columns.VisibleColumns.Count; colIndex++)
+        {
+            if (colIndex == frozenCount)
+            {
+                frozenPanelRight = columnLeft;
+                columnLeft -= HorizontalOffset;
+            }
+
+            var columnRight = columnLeft + Columns.VisibleColumns[colIndex].ActualWidth;
+
+            // Clamp non-frozen columns to the visible area past the frozen panel.
+            var effectiveLeft = colIndex >= frozenCount ? Math.Max(columnLeft, frozenPanelRight) : columnLeft;
+
+            if (columnRight > rectLeft && effectiveLeft < rectRight)
+            {
+                if (minColumn == -1) minColumn = colIndex;
+                maxColumn = colIndex;
+            }
+
+            columnLeft = columnRight;
+        }
+
+        if (minColumn == -1)
+        {
+            return null;
+        }
+
+        // Use the anchor slot captured at drag start as the first slot. The visible scan above
+        // can't see rows/columns that auto-scroll has moved out of view (virtualized), so the
+        // anchor is the only reliable record of where the drag actually began.
+        if (SelectionStartCellSlot is { } anchor)
+        {
+            if (rowsTopToBottom) minRow = anchor.Row;
+            else maxRow = anchor.Row;
+
+            if (colsLeftToRight) minColumn = anchor.Column;
+            else maxColumn = anchor.Column;
+        }
+        else
+        {
+            var startCol = colsLeftToRight ? minColumn : maxColumn;
+            SelectionStartCellSlot = new(SelectionStartRowIndex ?? minRow, startCol);
+        }
+
+        return TableViewCellSlotRange.FromSlots(new(minRow, minColumn), new(maxRow, maxColumn));
     }
 
     /// <summary>
@@ -1427,7 +1569,6 @@ public partial class TableView : ListView
         if (SelectionMode != ListViewSelectionMode.None)
         {
             ctrlKey = ctrlKey || SelectionMode is ListViewSelectionMode.Multiple;
-
             _suppressSelectionChangedCellClear = SelectionUnit is TableViewSelectionUnit.CellWithRow;
             var shouldSelectRows = SelectionUnit is TableViewSelectionUnit.Row
                 || (SelectionUnit is TableViewSelectionUnit.CellWithRow && !slot.IsValidColumn(this))
@@ -1981,7 +2122,7 @@ public partial class TableView : ListView
         _scrollViewer?.ViewChanged -= OnScrollViewerViewChangedDuringDrag;
         _dragRectangle?.Visibility = Visibility.Collapsed;
 
-        SetCurrentCellFromCanvasPoint(_lastDragCanvasPoint.Value);
+        SetCurrentCell(GetSlotAtCanvasPoint(_lastDragCanvasPoint.Value));
 
         IsDragSelecting = false;
         _dragStartPoint = null;
@@ -1989,42 +2130,41 @@ public partial class TableView : ListView
         SelectionStartCellSlot = null;
     }
 
-    private void SetCurrentCellFromCanvasPoint(Point canvasPoint)
+    private void SetCurrentCell(TableViewCellSlot? slot)
     {
-        if (GetSlotAtCanvasPoint(canvasPoint, exactMatch: true) is { } endSlot)
+        if (slot is null) return;
+
+        CurrentRowIndex = slot.Value.Row;
+
+        if (!(SelectionUnit is TableViewSelectionUnit.Row && IsReadOnly))
         {
-            CurrentRowIndex = endSlot.Row;
-
-            if (!(SelectionUnit is TableViewSelectionUnit.Row && IsReadOnly))
-            {
-                CurrentCellSlot = endSlot;
+            CurrentCellSlot = slot;
 #if !WINDOWS
-                if (_dragStartCell is not null
-                    && _dragStartPoint is not null
-                    && endSlot != _dragStartCell.Slot)
-                {
-                    VisualStates.GoToState(_dragStartCell, false, VisualStates.StateNormal);
-
-                    if (_dragStartCell.IsSelected)
-                    {
-                        VisualStates.GoToState(_dragStartCell, false, VisualStates.StateSelected);
-                    }
-                }
-#endif
-            }
-
-#if !WINDOWS
-            if (_dragStartRow is not null && _dragStartRow.Index != endSlot.Row)
+            if (_dragStartCell is not null
+                && _dragStartPoint is not null
+                && slot != _dragStartCell.Slot)
             {
-                VisualStates.GoToState(_dragStartRow, false, VisualStates.StateNormal);
+                VisualStates.GoToState(_dragStartCell, false, VisualStates.StateNormal);
 
-                if (_dragStartRow.IsSelected)
+                if (_dragStartCell.IsSelected)
                 {
-                    VisualStates.GoToState(_dragStartRow, false, VisualStates.StateSelected);
+                    VisualStates.GoToState(_dragStartCell, false, VisualStates.StateSelected);
                 }
             }
 #endif
         }
+
+#if !WINDOWS
+        if (_dragStartRow is not null && _dragStartRow.Index != slot.Value.Row)
+        {
+            VisualStates.GoToState(_dragStartRow, false, VisualStates.StateNormal);
+
+            if (_dragStartRow.IsSelected)
+            {
+                VisualStates.GoToState(_dragStartRow, false, VisualStates.StateSelected);
+            }
+        }
+#endif
     }
 
     /// <summary>
@@ -2145,57 +2285,22 @@ public partial class TableView : ListView
     /// within the vertical span between the drag start point and <paramref name="canvasPoint"/> when
     /// the point falls in empty space. Returns <c>null</c> when no realized row falls in that span.
     /// </summary>
-    private int? GetRowIndexAtCanvasPoint(Point canvasPoint, bool exactMatch = false)
+    private int? GetRowIndexAtCanvasPoint(Point canvasPoint)
     {
         if (DragRectangleCanvas is null) return null;
 
-        if (exactMatch)
-        {
-            foreach (var row in _rows)
-            {
-                var rowTop = row.Position;
-                var rowBottom = rowTop + row.ActualHeight;
-
-                if (canvasPoint.Y >= rowTop && canvasPoint.Y < rowBottom)
-                {
-                    return row.Index;
-                }
-            }
-
-            return null;
-        }
-
-        // Compute the vertical span of the drag so we can snap to the nearest in-span row when the
-        // pointer is in empty space. If there is no drag start (called outside a drag), minY == maxY
-        // == canvasPoint.Y, which collapses back to the original exact hit-test behaviour.
-        var verticalScrollDelta = (_scrollViewer?.VerticalOffset ?? 0) - _dragStartVerticalOffset;
-        var adjustedStartY = _dragStartPoint is not null
-            ? _dragStartPoint.Value.Y - verticalScrollDelta
-            : canvasPoint.Y;
-
-        var minY = Math.Min(adjustedStartY, canvasPoint.Y);
-        var maxY = Math.Max(adjustedStartY, canvasPoint.Y);
-
-        TableViewRow? nearestRow = null;
-        var nearestDistance = double.MaxValue;
-
         foreach (var row in _rows)
         {
-            var rowTop = row.Position;
+            var rowTop = row.Position.Y;
             var rowBottom = rowTop + row.ActualHeight;
 
-            if (rowBottom <= minY || rowTop >= maxY)
-                continue;
-
-            var distance = Math.Max(0d, Math.Max(rowTop - canvasPoint.Y, canvasPoint.Y - rowBottom));
-            if (distance < nearestDistance)
+            if (canvasPoint.Y >= rowTop && canvasPoint.Y < rowBottom)
             {
-                nearestDistance = distance;
-                nearestRow = row;
+                return row.Index;
             }
         }
 
-        return nearestRow?.Index;
+        return null;
     }
 
     /// <summary>
@@ -2204,14 +2309,27 @@ public partial class TableView : ListView
     /// </summary>
     private int? GetColumnIndexAtCanvasX(double x)
     {
-        var columnLeft = CellsHorizontalOffset - HorizontalOffset;
+        var frozenCount = FrozenColumnCount;
+        var columnLeft = CellsHorizontalOffset;
+        var frozenPanelRight = CellsHorizontalOffset;
+
         for (var i = 0; i < Columns.VisibleColumns.Count; i++)
         {
+            if (i == frozenCount)
+            {
+                frozenPanelRight = columnLeft;
+                columnLeft -= HorizontalOffset;
+            }
+
             var columnRight = columnLeft + Columns.VisibleColumns[i].ActualWidth;
-            if (x >= columnLeft && x < columnRight)
-                return i;
+            var effectiveLeft = i >= frozenCount ? Math.Max(columnLeft, frozenPanelRight) : columnLeft;
+
+            if (x <= columnRight)
+                return x < effectiveLeft ? null : i;
+
             columnLeft = columnRight;
         }
+
         return null;
     }
 
@@ -2220,37 +2338,18 @@ public partial class TableView : ListView
     /// column within the horizontal and vertical span of the current drag when the point falls in
     /// empty space. Returns <c>null</c> when no realized row or visible column falls in that span.
     /// </summary>
-    private TableViewCellSlot? GetSlotAtCanvasPoint(Point canvasPoint, bool exactMatch = false)
+    private TableViewCellSlot? GetSlotAtCanvasPoint(Point canvasPoint)
     {
         if (DragRectangleCanvas is null) return null;
 
-        if (GetRowIndexAtCanvasPoint(canvasPoint, exactMatch) is not int rowIndex) return null;
+        if (GetRowIndexAtCanvasPoint(canvasPoint) is not int rowIndex) return null;
 
         // Mirror the row snapping: find the nearest column within the horizontal drag span.
         var horizontalScrollDelta = HorizontalOffset - _dragStartHorizontalOffset;
         var adjustedPointerX = canvasPoint.X - horizontalScrollDelta;
+        var colIndex = GetColumnIndexAtCanvasX(adjustedPointerX);
 
-        var columnLeft = CellsHorizontalOffset - HorizontalOffset;
-
-        for (var i = 0; i < Columns.VisibleColumns.Count; i++)
-        {
-            var columnRight = columnLeft + Columns.VisibleColumns[i].ActualWidth;
-
-            if (adjustedPointerX <= columnRight)
-            {
-                // Require the pointer to actually be inside the cell.
-                if (exactMatch && adjustedPointerX < columnLeft)
-                    return null;
-
-                return new(rowIndex, i);
-            }
-
-            columnLeft = columnRight;
-        }
-
-        return exactMatch || Columns.VisibleColumns.Count == 0
-            ? null
-            : new(rowIndex, Columns.VisibleColumns.Count - 1);
+        return colIndex is null ? null : new TableViewCellSlot(rowIndex, colIndex.Value);
     }
 
     /// <summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -257,6 +257,11 @@ public partial class TableView : ListView
             UIElement? pressedElement = element.FindAscendant<TableViewCell>(); // Check if the pointer is over a TableViewCell
             pressedElement ??= element.FindAscendant<TableViewRow>(); // If not, check if the pointer is over a TableViewRow
 
+#if !WINDOWS
+            _dragStartCell = pressedElement as TableViewCell;
+            _dragStartRow = element.FindAscendant<TableViewRow>();
+#endif
+
             // Skip selection when the pointer is not over a Cell or Row, and ShowDragRectangle is false.
             if (pressedElement == null && !ShowDragRectangle) return;
 
@@ -1993,7 +1998,32 @@ public partial class TableView : ListView
             if (!(SelectionUnit is TableViewSelectionUnit.Row && IsReadOnly))
             {
                 CurrentCellSlot = endSlot;
+#if !WINDOWS
+                if (_dragStartCell is not null
+                    && _dragStartPoint is not null
+                    && endSlot != _dragStartCell.Slot)
+                {
+                    VisualStates.GoToState(_dragStartCell, false, VisualStates.StateNormal);
+
+                    if (_dragStartCell.IsSelected)
+                    {
+                        VisualStates.GoToState(_dragStartCell, false, VisualStates.StateSelected);
+                    }
+                }
+#endif
             }
+
+#if !WINDOWS
+            if (_dragStartRow is not null && _dragStartRow.Index != endSlot.Row)
+            {
+                VisualStates.GoToState(_dragStartRow, false, VisualStates.StateNormal);
+
+                if (_dragStartRow.IsSelected)
+                {
+                    VisualStates.GoToState(_dragStartRow, false, VisualStates.StateSelected);
+                }
+            }
+#endif
         }
     }
 

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -94,7 +94,9 @@ public partial class TableView : ListView
             }
             else
             {
-                var addedIndexes = e.AddedItems.Select(item => Items.IndexOf(item));
+                var addedIndexes = e.AddedItems
+                    .Select(item => Items.IndexOf(item))
+                    .Where(i => i >= 0);
 
                 if (Columns.VisibleColumns.Count == 0) return;
 
@@ -276,6 +278,15 @@ public partial class TableView : ListView
             _pointerCaptureElement.CapturePointer(e.Pointer);
             _tableViewDragPointer = e.Pointer;
             StartDragSelection(canvasPoint.Value);
+
+            if (!IsDragSelecting)
+            {
+                _pointerCaptureElement?.ReleasePointerCaptures();
+                _pointerCaptureElement = null;
+                _tableViewDragPointer = null;
+                return;
+            }
+
             MakeSelectionInDragRect();
         }
     }

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -160,7 +160,14 @@ public partial class TableView : ListView
 
                 row.TableView = this;
                 row.EnsureCellsStyle(default, item);
-                row.ApplyCellsSelectionState();
+
+                _pendingCellStateRows.Add(row.Index);
+                if (!_cellStateDispatchPending)
+                {
+                    _cellStateDispatchPending = true;
+                    DispatcherQueue.TryEnqueue(ApplyPendingCellStates);
+                }
+
                 row.RowPresenter?.ApplyDetailsPaneState(item);
 
                 if (CurrentCellSlot.HasValue)
@@ -244,9 +251,6 @@ public partial class TableView : ListView
         _lastDragSelectionCellRange = null;
         LastSelectionUnit = TableViewSelectionUnit.Row;
 
-        if (!ctrlKey && SelectionMode is not ListViewSelectionMode.Multiple)
-            DeselectAll();
-
         if (e.OriginalSource is UIElement element)
         {
             UIElement? clickedElement = element.FindAscendant<TableViewCell>(); // Check if the pointer is over a TableViewCell
@@ -277,6 +281,10 @@ public partial class TableView : ListView
 
             _pointerCaptureElement.CapturePointer(e.Pointer);
             _tableViewDragPointer = e.Pointer;
+
+            if (!ctrlKey && SelectionMode is not ListViewSelectionMode.Multiple && LastSelectionUnit is not TableViewSelectionUnit.Cell)
+                DeselectAll();
+
             StartDragSelection(canvasPoint.Value);
 
             if (!IsDragSelecting)
@@ -404,24 +412,34 @@ public partial class TableView : ListView
     {
         if (_lastDragSelectionCellRange == cells) return;
 
-        if (_lastDragSelectionCellRange is not null && cells is not null)
+        DispatcherQueue.TryEnqueue(() =>
         {
-            foreach (var range in _lastDragSelectionCellRange.Subtract(cells))
+            if (_lastDragSelectionCellRange is null
+            && !KeyboardHelper.IsCtrlKeyDown()
+            && SelectionMode is not ListViewSelectionMode.Multiple)
             {
-                SubtractCellRangeFromSelection(range);
+                DeselectAllItems();
+                SelectedCellRanges.Clear();
             }
-        }
+            else if (_lastDragSelectionCellRange is not null && cells is not null)
+            {
+                foreach (var range in _lastDragSelectionCellRange.Subtract(cells))
+                {
+                    SubtractCellRangeFromSelection(range);
+                }
+            }
 
-        if (SelectedCellRanges.Any(r => r == cells))
-        {
-            OnCellSelectionChanged();
-        }
-        else if (cells?.Length > 0)
-        {
-            SelectCellRange(cells);
-        }
+            if (SelectedCellRanges.Any(r => r == cells))
+            {
+                OnCellSelectionChanged();
+            }
+            else if (cells?.Length > 0)
+            {
+                SelectCellRange(cells);
+            }
 
-        _lastDragSelectionCellRange = cells;
+            _lastDragSelectionCellRange = cells;
+        });
     }
 
     /// <summary>
@@ -620,6 +638,7 @@ public partial class TableView : ListView
         DragRectangleCanvas = GetTemplateChild("DragRectangleCanvas") as Canvas;
         _dragRectangle = GetTemplateChild("DragRectangle") as Border;
         _scrollViewer?.Loaded += OnScrollViewerLoaded;
+        _scrollViewer?.ViewChanged += OnScrollViewerViewChanged;
 
         if (IsLoaded)
         {
@@ -629,6 +648,17 @@ public partial class TableView : ListView
         }
 
         SetHeadersVisibility();
+    }
+
+    /// <summary>
+    /// Handles the ViewChanged event of the ScrollViewer control, updating the position of each row when the view changes.
+    /// </summary>
+    private void OnScrollViewerViewChanged(object? sender, ScrollViewerViewChangedEventArgs e)
+    {
+        foreach (var row in _rows)
+        {
+            row.UpdatePosition();
+        }
     }
 
     /// <summary>
@@ -1813,9 +1843,9 @@ public partial class TableView : ListView
             {
                 _autoScrollTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(16) };
                 _autoScrollTimer.Tick += OnAutoScrollTimerTick;
+                _autoScrollTimer.Start();
             }
-
-            _autoScrollTimer.Start();
+            // else: timer already running — delta values above are picked up on the next tick
         }
         else
         {
@@ -1872,14 +1902,20 @@ public partial class TableView : ListView
             return;
         }
 
-        // Horizontal scroll via HorizontalOffset DP does not fire ViewChanged,
-        // so reposition rectangle and update selection here.
-        // Vertical scroll fires ViewChanged which handles it via OnScrollViewerViewChangedDuringDrag.
-        if (Math.Abs(_autoScrollHorizontalDelta) > 0.5 && _lastDragCanvasPoint is not null)
+        // Horizontal scroll does not fire ViewChanged, so reposition the rectangle here.
+        // Selection is updated for all scroll directions from the timer tick, not from ViewChanged,
+        // so that MakeSelectionInDragRect runs after ChangeView completes rather than inside the layout pass.
+        if (_lastDragCanvasPoint is not null)
         {
-            if (_dragStartPoint is not null && DragRectangleCanvas is not null && _dragRectangle is not null)
+            if (Math.Abs(_autoScrollHorizontalDelta) > 0.5 &&
+                _dragStartPoint is not null && DragRectangleCanvas is not null && _dragRectangle is not null)
             {
                 PositionDragRectangle(_lastDragCanvasPoint.Value);
+            }
+
+            if (_tableViewDragPointer is not null)
+            {
+                MakeSelectionInDragRect();
             }
         }
     }
@@ -1908,6 +1944,13 @@ public partial class TableView : ListView
         if (_dragStartPoint is not null && DragRectangleCanvas is not null && _dragRectangle is not null)
         {
             PositionDragRectangle(_lastDragCanvasPoint.Value);
+        }
+
+        // During auto-scroll the timer tick owns selection updates to keep MakeSelectionInDragRect
+        // out of the scroll layout pass. Only update here for non-auto-scroll scrolls (e.g. scroll wheel).
+        if (_autoScrollTimer is null && _tableViewDragPointer is not null)
+        {
+            MakeSelectionInDragRect();
         }
     }
 
@@ -2094,11 +2137,7 @@ public partial class TableView : ListView
 
         foreach (var row in _rows)
         {
-            Point rowOrigin;
-            try { rowOrigin = row.TransformToVisual(DragRectangleCanvas).TransformPoint(default); }
-            catch (ArgumentException) { continue; }
-
-            var rowTop = rowOrigin.Y;
+            var rowTop = row.Position;
             var rowBottom = rowTop + row.ActualHeight;
 
             if (rowBottom <= minY || rowTop >= maxY) continue;
@@ -2108,6 +2147,7 @@ public partial class TableView : ListView
             {
                 nearestDistance = distance;
                 nearestRow = row;
+                rowTop += row.ActualHeight;
             }
         }
 
@@ -2144,35 +2184,23 @@ public partial class TableView : ListView
 
         // Mirror the row snapping: find the nearest column within the horizontal drag span.
         var horizontalScrollDelta = HorizontalOffset - _dragStartHorizontalOffset;
-        var adjustedStartX = _dragStartPoint is not null
-            ? _dragStartPoint.Value.X - horizontalScrollDelta
-            : canvasPoint.X;
+        var adjustedPointerX = canvasPoint.X - horizontalScrollDelta;
 
-        var minX = Math.Min(adjustedStartX, canvasPoint.X);
-        var maxX = Math.Max(adjustedStartX, canvasPoint.X);
-
-        var nearestColIndex = -1;
-        var nearestDistance = double.MaxValue;
         var columnLeft = CellsHorizontalOffset - HorizontalOffset;
 
         for (var i = 0; i < Columns.VisibleColumns.Count; i++)
         {
             var columnRight = columnLeft + Columns.VisibleColumns[i].ActualWidth;
 
-            if (columnRight > minX && columnLeft < maxX)
-            {
-                var distance = Math.Max(0d, Math.Max(columnLeft - canvasPoint.X, canvasPoint.X - columnRight));
-                if (distance < nearestDistance)
-                {
-                    nearestDistance = distance;
-                    nearestColIndex = i;
-                }
-            }
+            if (adjustedPointerX <= columnRight)
+                return new TableViewCellSlot(rowIndex, i);
 
             columnLeft = columnRight;
         }
 
-        return nearestColIndex == -1 ? null : new TableViewCellSlot(rowIndex, nearestColIndex);
+        return Columns.VisibleColumns.Count > 0
+            ? new TableViewCellSlot(rowIndex, Columns.VisibleColumns.Count - 1)
+            : null;
     }
 
     /// <summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -96,6 +96,8 @@ public partial class TableView : ListView
             {
                 var addedIndexes = e.AddedItems.Select(item => Items.IndexOf(item));
 
+                if (Columns.VisibleColumns.Count == 0) return;
+
                 foreach (var range in IndexRangeHelper.GetRanges(addedIndexes))
                 {
                     var slotRange = TableViewCellSlotRange.FromCoordinates(range.FirstIndex, 0, range.LastIndex, Columns.VisibleColumns.Count - 1);
@@ -367,16 +369,16 @@ public partial class TableView : ListView
     /// </summary>
     private void SelectRowsInDragRect(ItemIndexRange rows)
     {
-        if (_lastDragSelectionRowRange?.FirstIndex == rows?.FirstIndex && _lastDragSelectionRowRange?.LastIndex == rows?.LastIndex) return;
+        if (_lastDragSelectionRowRange?.FirstIndex == rows.FirstIndex && _lastDragSelectionRowRange?.LastIndex == rows.LastIndex) return;
 
-        if (_lastDragSelectionRowRange is not null && rows is not null && _lastDragSelectionRowRange.Contains(rows))
+        if (_lastDragSelectionRowRange is not null && _lastDragSelectionRowRange.Value.Contains(rows))
         {
-            foreach (var slicedRange in _lastDragSelectionRowRange.Subtract(rows))
+            foreach (var slicedRange in _lastDragSelectionRowRange.Value.Subtract(rows))
             {
                 DeselectRange(slicedRange);
             }
         }
-        else if (rows?.Length > 0)
+        else if (rows.Length > 0)
         {
             SelectRange(rows);
         }
@@ -1515,10 +1517,16 @@ public partial class TableView : ListView
     /// </summary>
     internal void DeselectCell(TableViewCellSlot slot)
     {
-        var selectionRange = SelectedCellRanges.LastOrDefault(x => x.Contains(slot.Row, slot.Column));
-        if (selectionRange is not null)
+        var singleCellRange = TableViewCellSlotRange.FromSlots(slot);
+        var containingRanges = SelectedCellRanges.Where(x => x.Contains(slot.Row, slot.Column)).ToList();
+
+        foreach (var range in containingRanges)
         {
-            SelectedCellRanges.Remove(selectionRange);
+            SelectedCellRanges.Remove(range);
+            foreach (var remaining in range.Subtract(singleCellRange))
+            {
+                SelectedCellRanges.Add(remaining);
+            }
         }
 
         CurrentCellSlot = slot;
@@ -1902,6 +1910,7 @@ public partial class TableView : ListView
         StopAutoScroll();
 
         _pointerCaptureElement?.ReleasePointerCaptures();
+        _pointerCaptureElement = null;
         _tableViewDragPointer = null;
 
         _scrollViewer?.ViewChanged -= OnScrollViewerViewChangedDuringDrag;
@@ -1918,13 +1927,6 @@ public partial class TableView : ListView
             endSlot = new TableViewCellSlot(
                 rowsTopToBottom ? endRange.LastRow : endRange.FirstRow,
                 colsLeftToRight ? endRange.LastColumn : endRange.FirstColumn);
-        }
-
-        // Clean up any pointer capture the TableView itself held (empty-space drag path).
-        if (_tableViewDragPointer is not null)
-        {
-            _tableViewDragPointer = null;
-            ReleasePointerCaptures();
         }
 
         IsDragSelecting = false;

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -371,9 +371,9 @@ public partial class TableView : ListView
     {
         if (_lastDragSelectionRowRange?.FirstIndex == rows.FirstIndex && _lastDragSelectionRowRange?.LastIndex == rows.LastIndex) return;
 
-        if (_lastDragSelectionRowRange is not null && _lastDragSelectionRowRange.Value.Contains(rows))
+        if (_lastDragSelectionRowRange is not null && _lastDragSelectionRowRange.Contains(rows))
         {
-            foreach (var slicedRange in _lastDragSelectionRowRange.Value.Subtract(rows))
+            foreach (var slicedRange in _lastDragSelectionRowRange.Subtract(rows))
             {
                 DeselectRange(slicedRange);
             }

--- a/src/TableViewCell.cs
+++ b/src/TableViewCell.cs
@@ -5,10 +5,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Windows.Foundation;
 using WinUI.TableView.Extensions;
 using WinUI.TableView.Helpers;
@@ -29,7 +25,6 @@ namespace WinUI.TableView;
 #endif
 public partial class TableViewCell : ContentControl
 {
-    private ScrollViewer? _scrollViewer;
     private ContentPresenter? _contentPresenter;
     private Border? _selectionBorder;
     private Rectangle? _v_gridLine;
@@ -230,12 +225,6 @@ public partial class TableViewCell : ContentControl
             e.Handled = true;
             return;
         }
-
-        if (TableView?.CurrentCellSlot != Slot || TableView?.LastSelectionUnit is TableViewSelectionUnit.Row)
-        {
-            MakeSelection();
-            e.Handled = true;
-        }
     }
 
     /// <inheritdoc/>
@@ -248,76 +237,15 @@ public partial class TableViewCell : ContentControl
             e.Handled = true;
             return;
         }
-
-        if (!KeyboardHelper.IsShiftKeyDown() && TableView is not null)
-        {
-            TableView.SelectionStartCellSlot = TableView.SelectionUnit is not TableViewSelectionUnit.Row || !IsReadOnly ? Slot : default;
-            TableView.SelectionStartRowIndex = Index;
-            CapturePointer(e.Pointer);
-
-            // Start drag selection (auto-scroll + optional rectangle visual)
-            var point = e.GetCurrentPoint(this).Position;
-            var canvasPoint = TransformPointToCanvas(point);
-            if (canvasPoint.HasValue)
-            {
-                TableView.StartDragSelection(canvasPoint.Value);
-            }
-        }
     }
-
     /// <inheritdoc/>
     protected override void OnPointerReleased(PointerRoutedEventArgs e)
     {
         base.OnPointerReleased(e);
 
-        if (!KeyboardHelper.IsShiftKeyDown() && TableView is not null)
+        if(TableView?.SelectionUnit is not TableViewSelectionUnit.Row)
         {
-            var cell = FindCell(e.GetCurrentPoint(this).Position);
-            TableView.SelectionStartCellSlot = TableView.SelectionUnit is not TableViewSelectionUnit.Row || !IsReadOnly ? cell?.Slot : default;
-            TableView.SelectionStartRowIndex = cell?.Slot.Row;
-        }
-
-        TableView?.EndDragSelection();
-        ReleasePointerCaptures();
-
-        e.Handled = true;
-    }
-
-    /// <inheritdoc/>
-    protected override void OnPointerCaptureLost(PointerRoutedEventArgs e)
-    {
-        base.OnPointerCaptureLost(e);
-
-        TableView?.EndDragSelection();
-    }
-
-    /// <inheritdoc/>
-    protected override void OnManipulationDelta(ManipulationDeltaRoutedEventArgs e)
-    {
-        base.OnManipulationDelta(e);
-
-        if (PointerCaptures?.Any() is true)
-        {
-            // Update drag rectangle visual and auto-scroll
-            if (TableView?.IsDragSelecting is true)
-            {
-                var canvasPoint = TransformPointToCanvas(e.Position);
-                if (canvasPoint.HasValue)
-                {
-                    TableView.UpdateDragRectangleVisual(canvasPoint.Value);
-                }
-            }
-
-            // Selection via FindCell — same proven path whether rectangle is on or off.
-            // When the pointer is outside the viewport, FindCell returns null and selection
-            // is updated by the ViewChanged handler on the next auto-scroll tick.
-            var cell = FindCell(e.Position);
-
-            if (cell is not null && cell.Slot != TableView?.CurrentCellSlot)
-            {
-                var ctrlKey = KeyboardHelper.IsCtrlKeyDown();
-                TableView?.MakeSelection(cell.Slot, true, ctrlKey);
-            }
+            e.Handled = true;
         }
     }
 
@@ -350,45 +278,6 @@ public partial class TableViewCell : ContentControl
             ? TableView.HorizontalGridLinesStrokeThickness : 0d;
     }
 
-    /// <summary>
-    /// Finds the cell at the specified position.
-    /// </summary>
-    private TableViewCell? FindCell(Point position)
-    {
-        _scrollViewer ??= TableView?.FindDescendant<ScrollViewer>();
-        if (_scrollViewer is null) return null;
-
-        var transformedPoint = TransformToVisual(null).TransformPoint(position);
-#if WINDOWS
-        return VisualTreeHelper.FindElementsInHostCoordinates(transformedPoint, _scrollViewer)
-#else
-        return VisualTreeHelper.FindElementsInHostCoordinates(transformedPoint, _scrollViewer, true)
-                               .OfType<ContentPresenter>()
-                               .Where(x => x.Name is "Content")
-                               .Select(x => x.FindAscendant<TableViewCell>() is { } header ? header : default)
-#endif
-                               .OfType<TableViewCell>()
-                               .FirstOrDefault();
-    }
-
-    /// <summary>
-    /// Transforms a point relative to this cell to coordinates relative to the drag rectangle canvas.
-    /// </summary>
-    private Point? TransformPointToCanvas(Point position)
-    {
-        if (TableView?.DragRectangleCanvas is null) return null;
-
-        try
-        {
-            var transform = TransformToVisual(TableView.DragRectangleCanvas);
-            return transform.TransformPoint(position);
-        }
-        catch (ArgumentException)
-        {
-            return null;
-        }
-    }
-
     /// <inheritdoc/>
     protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
     {
@@ -400,49 +289,7 @@ public partial class TableViewCell : ContentControl
 
         base.OnDoubleTapped(e);
 
-        if (!IsReadOnly && TableView is not null && !TableView.IsEditing && !Column?.UseSingleElement is true)
-        {
-            e.Handled = BeginCellEditing(e);
-        }
-        else
-        {
-            e.Handled = true;
-        }
-    }
-
-    /// <summary>
-    /// Makes a selection based on the current cell.
-    /// </summary>
-    private void MakeSelection()
-    {
-        var shiftKey = KeyboardHelper.IsShiftKeyDown();
-        var ctrlKey = KeyboardHelper.IsCtrlKeyDown();
-
-        if (TableView is null || Column is null)
-        {
-            return;
-        }
-
-        if ((TableView.IsEditing || Column.UseSingleElement) && IsCurrent)
-        {
-            return;
-        }
-
-        if (IsSelected && (ctrlKey || TableView.SelectionMode is ListViewSelectionMode.Multiple) && !shiftKey)
-        {
-            TableView.DeselectCell(Slot);
-        }
-        else
-        {
-            if (Column.UseSingleElement)
-            {
-                TableView.DeselectCell(Slot);
-            }
-
-            TableView.MakeSelection(Slot, shiftKey, ctrlKey);
-        }
-
-        TableView.SetIsEditing(false);
+        e.Handled = IsReadOnly || TableView is null || TableView.IsEditing || !Column?.UseSingleElement is not true || BeginCellEditing(e);
     }
 
     /// <summary>

--- a/src/TableViewCellSlot.cs
+++ b/src/TableViewCellSlot.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public readonly record struct TableViewCellSlot(int Row, int Column)
 {
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"Row: {Row}, Col: {Column}";

--- a/src/TableViewCellSlot.cs
+++ b/src/TableViewCellSlot.cs
@@ -3,4 +3,10 @@
 /// <summary>
 /// Represents a slot of a TableView cell, identified by its row and column indices.
 /// </summary>
-public readonly record struct TableViewCellSlot(int Row, int Column);
+public readonly record struct TableViewCellSlot(int Row, int Column)
+{
+    public override string ToString()
+    {
+        return $"Row: {Row}, Col: {Column}";
+    }
+}

--- a/src/TableViewCellSlotRange.cs
+++ b/src/TableViewCellSlotRange.cs
@@ -77,10 +77,12 @@ public class TableViewCellSlotRange
     /// </summary>
     public static TableViewCellSlotRange FromCoordinates(int startRow, int startCol, int endRow, int endCol)
     {
+        var firstRow = Math.Min(startRow, endRow);
+        var firstCol = Math.Min(startCol, endCol);
         var rowCount = Math.Abs(endRow - startRow) + 1;
         var colCount = Math.Abs(endCol - startCol) + 1;
 
-        return new TableViewCellSlotRange(startRow, startCol, rowCount, colCount);
+        return new TableViewCellSlotRange(firstRow, firstCol, rowCount, colCount);
     }
 
     /// <summary>

--- a/src/TableViewCellSlotRange.cs
+++ b/src/TableViewCellSlotRange.cs
@@ -1,0 +1,131 @@
+﻿namespace WinUI.TableView;
+
+/// <summary>
+/// Represents a coordinate-based range of cell slots in a TableView.
+/// </summary>
+public class TableViewCellSlotRange
+{
+    /// <summary>
+    /// Gets the starting row index of the range.
+    /// </summary>
+    public int FirstRow { get; }
+
+    /// <summary>
+    /// Gets the starting column index of the range.
+    /// </summary>
+    public int FirstColumn { get; }
+
+    /// <summary>
+    /// Gets the first cell slot in the range.
+    /// </summary>
+    public TableViewCellSlot FirstSlot => new(FirstRow, FirstColumn);
+
+    /// <summary>
+    /// Gets the number of rows spanned by this range.
+    /// </summary>
+    public int Rows { get; }
+
+    /// <summary>
+    /// Gets the number of columns spanned by this range.
+    /// </summary>
+    public int Columns { get; }
+
+    /// <summary>
+    /// Gets the total number of cell slots in the range.
+    /// </summary>
+    public int Length => Rows * Columns;
+
+    /// <summary>
+    /// Gets the last row index included in the range.
+    /// </summary>
+    public int LastRow => FirstRow + Rows - 1;
+
+    /// <summary>
+    /// Gets the last column index included in the range.
+    /// </summary>
+    public int LastColumn => FirstColumn + Columns - 1;
+
+    /// <summary>
+    /// Gets the last cell slot in the range.
+    /// </summary>
+    public TableViewCellSlot LastSlot => new(LastRow, LastColumn);
+
+    /// <summary>
+    /// Initializes a new instance of the TableViewCellSlotRange class using starting indices and dimensions.
+    /// </summary>
+    public TableViewCellSlotRange(int firstRowIndex, int firstColumnIndex, int rowCount, int columnCount)
+    {
+        if (firstRowIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(firstRowIndex), "Index cannot be negative.");
+
+        if (firstColumnIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(firstColumnIndex), "Index cannot be negative.");
+
+        if (rowCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(rowCount), "Count must be at least 1.");
+        if (columnCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(columnCount), "Count must be at least 1.");
+
+        FirstRow = firstRowIndex;
+        FirstColumn = firstColumnIndex;
+        Rows = rowCount;
+        Columns = columnCount;
+    }
+
+    /// <summary>
+    /// Helper factory to initialize using start and end coordinates directly.
+    /// </summary>
+    public static TableViewCellSlotRange FromCoordinates(int startRow, int startCol, int endRow, int endCol)
+    {
+        var rowCount = Math.Abs(endRow - startRow) + 1;
+        var colCount = Math.Abs(endCol - startCol) + 1;
+
+        return new TableViewCellSlotRange(startRow, startCol, rowCount, colCount);
+    }
+
+    /// <summary>
+    /// Helper factory to initialize using two TableViewCellSlot instances.
+    /// </summary>
+    public static TableViewCellSlotRange FromSlots(TableViewCellSlot firstSlot, TableViewCellSlot? lastSlot = default)
+    {
+        lastSlot ??= firstSlot;
+        return FromCoordinates(firstSlot.Row, firstSlot.Column, lastSlot.Value.Row, lastSlot.Value.Column);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        if (obj is TableViewCellSlotRange other)
+        {
+            return FirstRow == other.FirstRow &&
+                   FirstColumn == other.FirstColumn &&
+                   Rows == other.Rows &&
+                   Columns == other.Columns;
+        }
+        return false;
+    }
+
+    /// <inheritdoc />
+    public static bool operator ==(TableViewCellSlotRange? left, TableViewCellSlotRange? right)
+    {
+        return Equals(left, right);
+    }
+
+    /// <inheritdoc />
+    public static bool operator !=(TableViewCellSlotRange? left, TableViewCellSlotRange? right)
+    {
+        return !Equals(left, right);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(FirstRow, FirstColumn, Rows, Columns);
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"[{FirstSlot}]..[{LastSlot}] ({Length})";
+    }
+}

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -192,7 +192,7 @@ public partial class TableViewRow : ListViewItem
             {
                 try
                 {
-                    Position = TransformToVisual(TableView.DragRectangleCanvas).TransformPoint(default).Y;
+                    Position = TransformToVisual(TableView.DragRectangleCanvas).TransformPoint(default);
                 }
                 catch { }
             }
@@ -202,7 +202,7 @@ public partial class TableViewRow : ListViewItem
     /// <summary>
     /// Gets or sets the position of the row relative to the TableView.
     /// </summary>
-    internal double Position { get; set; }
+    internal Point Position { get; set; }
 
     /// <summary>
     /// Ensures cells are created for the row.

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -157,44 +157,6 @@ public partial class TableViewRow : ListViewItem
     }
 
     /// <inheritdoc/>
-    protected override void OnPointerPressed(PointerRoutedEventArgs e)
-    {
-        if (TableView is { IsEditing: false })
-        {
-            base.OnPointerPressed(e);
-        }
-
-        if (!KeyboardHelper.IsShiftKeyDown() && TableView is not null)
-        {
-            TableView.SelectionStartRowIndex = Index;
-        }
-    }
-
-    /// <inheritdoc/>
-    protected override void OnPointerReleased(PointerRoutedEventArgs e)
-    {
-        base.OnPointerReleased(e);
-
-        if (!KeyboardHelper.IsShiftKeyDown() && TableView is not null)
-        {
-            TableView.SelectionStartCellSlot = null;
-            TableView.SelectionStartRowIndex = Index;
-        }
-    }
-
-    /// <inheritdoc/>
-    protected override void OnTapped(TappedRoutedEventArgs e)
-    {
-        base.OnTapped(e);
-
-        if (TableView?.SelectionUnit is TableViewSelectionUnit.Row or TableViewSelectionUnit.CellOrRow or TableViewSelectionUnit.CellWithRow)
-        {
-            TableView.CurrentRowIndex = Index;
-            TableView.LastSelectionUnit = TableViewSelectionUnit.Row;
-        }
-    }
-
-    /// <inheritdoc/>
     protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
     {
         var eventArgs = new TableViewRowDoubleTappedEventArgs(Index, this, Content);

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -186,17 +186,16 @@ public partial class TableViewRow : ListViewItem
     /// </summary>
     internal void UpdatePosition()
     {
-        DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
+        if (TableView is null) return;
+
+        try
         {
-            if (TableView is not null)
-            {
-                try
-                {
-                    Position = TransformToVisual(TableView.DragRectangleCanvas).TransformPoint(default);
-                }
-                catch { }
-            }
-        });
+            Position = TransformToVisual(TableView.DragRectangleCanvas).TransformPoint(default);
+        }
+        catch (Exception ex)
+        {
+            TableViewTrace.Write($"UpdatePosition failed: {ex.Message}");
+        }
     }
 
     /// <summary>

--- a/src/TableViewRow.cs
+++ b/src/TableViewRow.cs
@@ -175,9 +175,34 @@ public partial class TableViewRow : ListViewItem
         var left = Math.Max(cornerRadius.TopLeft, cornerRadius.BottomLeft);
 
         _itemPresenter?.Arrange(new Rect(-left, 0, _itemPresenter.ActualWidth + left, _itemPresenter.ActualHeight));
+                
+        UpdatePosition();
 
         return finalSize;
     }
+
+    /// <summary>
+    /// Updates the position of the row relative to the TableView.
+    /// </summary>
+    internal void UpdatePosition()
+    {
+        DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
+        {
+            if (TableView is not null)
+            {
+                try
+                {
+                    Position = TransformToVisual(TableView.DragRectangleCanvas).TransformPoint(default).Y;
+                }
+                catch { }
+            }
+        });
+    }
+
+    /// <summary>
+    /// Gets or sets the position of the row relative to the TableView.
+    /// </summary>
+    internal double Position { get; set; }
 
     /// <summary>
     /// Ensures cells are created for the row.

--- a/src/Tableview.Uno.cs
+++ b/src/Tableview.Uno.cs
@@ -17,6 +17,8 @@ partial class TableView
     private const BindingFlags BindingAttr = BindingFlags.NonPublic | BindingFlags.Instance;
     private PropertyInfo? _disableRaiseSelectionChangedPropertyInfo;
     private MethodInfo? _invokeSelectionChangedMethodInfo;
+    private TableViewRow? _dragStartRow;
+    private TableViewCell? _dragStartCell;
 
     private void SetDisableRaiseSelectionChanged(bool value)
     {

--- a/tests/DragSelectionRectangleTests.cs
+++ b/tests/DragSelectionRectangleTests.cs
@@ -192,4 +192,40 @@ public class DragSelectionRectangleTests
 
         Assert.IsFalse(tv.IsDragSelecting);
     }
+
+    [UITestMethod]
+    public async Task SelectCellRange_SelectsTheProvidedRangeAndRaisesOneSelectionChangedEvent()
+    {
+        var tv = await CreateAndLoadTableView();
+        var eventCount = 0;
+        tv.CellSelectionChanged += (_, _) => eventCount++;
+
+        tv.SelectCellRange(TableViewCellSlotRange.FromCoordinates(0, 0, 1, 1));
+
+        Assert.AreEqual(4, tv.SelectedCells.Count);
+        Assert.IsTrue(tv.SelectedCells.Contains(new TableViewCellSlot(0, 0)));
+        Assert.IsTrue(tv.SelectedCells.Contains(new TableViewCellSlot(0, 1)));
+        Assert.IsTrue(tv.SelectedCells.Contains(new TableViewCellSlot(1, 0)));
+        Assert.IsTrue(tv.SelectedCells.Contains(new TableViewCellSlot(1, 1)));
+        Assert.AreEqual(1, eventCount);
+
+        await UnitTestApp.Current.MainWindow.UnloadTestContentAsync(tv);
+    }
+
+    [UITestMethod]
+    public async Task DeselectCellRange_DeselectsTheProvidedRangeAndRaisesOneSelectionChangedEvent()
+    {
+        var tv = await CreateAndLoadTableView();
+        tv.SelectCellRange(TableViewCellSlotRange.FromCoordinates(0, 0, 1, 1));
+
+        var eventCount = 0;
+        tv.CellSelectionChanged += (_, _) => eventCount++;
+
+        tv.DeselectCellRange(TableViewCellSlotRange.FromCoordinates(0, 0, 1, 1));
+
+        Assert.AreEqual(0, tv.SelectedCells.Count);
+        Assert.AreEqual(1, eventCount);
+
+        await UnitTestApp.Current.MainWindow.UnloadTestContentAsync(tv);
+    }
 }

--- a/tests/TableViewSelectionUnitTests.cs
+++ b/tests/TableViewSelectionUnitTests.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 using System.Threading.Tasks;
-using Windows.Foundation;
 
 namespace WinUI.TableView.Tests;
 

--- a/tests/TableViewSelectionUnitTests.cs
+++ b/tests/TableViewSelectionUnitTests.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
 using System.Threading.Tasks;
+using Windows.Foundation;
 
 namespace WinUI.TableView.Tests;
 
@@ -15,10 +16,10 @@ public class TableViewSelectionUnitTests
     {
         var tableView = await CreateTableViewAsync(TableViewSelectionUnit.CellWithRow);
 
-        tableView.MakeSelection(new TableViewCellSlot(1, 0), false, false);
+        tableView.SelectCellRange(TableViewCellSlotRange.FromSlots(new TableViewCellSlot(1, 0), new TableViewCellSlot(1, 0)));
 
         await Task.Yield(); // Allow selection to propagate
-    
+
         Assert.IsTrue(tableView.SelectedCells.Contains(new TableViewCellSlot(1, 0)));
         Assert.AreEqual(1, tableView.SelectedItems.Count);
         Assert.AreSame(tableView.Items[1], tableView.SelectedItem);
@@ -29,7 +30,7 @@ public class TableViewSelectionUnitTests
     {
         var tableView = await CreateTableViewAsync(TableViewSelectionUnit.CellWithRow);
 
-        tableView.MakeSelection(new TableViewCellSlot(1, -1), false, false);
+        tableView.SelectRange(new ItemIndexRange(1, 1));
 
         Assert.AreEqual(0, tableView.SelectedCells.Count);
         Assert.AreEqual(1, tableView.SelectedItems.Count);
@@ -41,11 +42,11 @@ public class TableViewSelectionUnitTests
     {
         var tableView = await CreateTableViewAsync(TableViewSelectionUnit.Cell);
 
-        tableView.MakeSelection(new TableViewCellSlot(0, 0), false, false);
+        tableView.SelectCellRange(TableViewCellSlotRange.FromSlots(new TableViewCellSlot(0, 0), new TableViewCellSlot(0, 0)));
 
         await Task.Yield(); // Allow selection to propagate
 
-        tableView.MakeSelection(new TableViewCellSlot(1, 1), false, true);
+        tableView.SelectCellRange(TableViewCellSlotRange.FromSlots(new TableViewCellSlot(1, 1), new TableViewCellSlot(1, 1)));
 
         await Task.Yield(); // Allow selection to propagate
 
@@ -60,10 +61,10 @@ public class TableViewSelectionUnitTests
     {
         var tableView = await CreateTableViewAsync(TableViewSelectionUnit.CellOrRow);
 
-        tableView.MakeSelection(new TableViewCellSlot(1, 0), false, false);
+        tableView.SelectCellRange(TableViewCellSlotRange.FromSlots(new TableViewCellSlot(1, 0), new TableViewCellSlot(1, 0)));
         Assert.AreEqual(0, tableView.SelectedItems.Count);
 
-        tableView.MakeSelection(new TableViewCellSlot(0, -1), false, false);
+        tableView.SelectRange(new ItemIndexRange(0, 1));
         Assert.AreEqual(1, tableView.SelectedItems.Count);
         Assert.AreEqual(0, tableView.SelectedCells.Count);
     }
@@ -73,11 +74,11 @@ public class TableViewSelectionUnitTests
     {
         var tableView = await CreateTableViewAsync(TableViewSelectionUnit.CellWithRow, ListViewSelectionMode.Multiple);
 
-        tableView.MakeSelection(new TableViewCellSlot(0, 0), false, false);
+        tableView.SelectCellRange(TableViewCellSlotRange.FromSlots(new TableViewCellSlot(0, 0), new TableViewCellSlot(0, 0)));
 
         await Task.Yield(); // Allow selection to propagate
 
-        tableView.MakeSelection(new TableViewCellSlot(1, 1), false, true);
+        tableView.SelectCellRange(TableViewCellSlotRange.FromSlots(new TableViewCellSlot(1, 1), new TableViewCellSlot(1, 1)));
 
         await Task.Delay(200); // Allow selection to propagate
 


### PR DESCRIPTION
## Summary

Improves the drag-selection experience in `TableView` that was added in PR #344 by allowing selection gestures to begin from **row containers** and **empty space** — not just individual cells. This makes the control feel much more natural and consistent with other data-grid implementations.


https://github.com/user-attachments/assets/d60b9e0c-03a8-4967-b496-e7a741559608



## Changes

### New Types
| Type | Description |
|------|-------------|
| `TableViewCellSlotRange` | A coordinate-based, rectangular range of cell slots (first/last row + column). Includes `Equals`, `GetHashCode`, equality operators, and factory helpers (`FromCoordinates`, `FromSlots`). |
| `TableViewCellSlotRangeExtensions` | Extension methods for `TableViewCellSlotRange`: `IsInRange`, `IsRowInRange`, `IsColumnInRange`, `IsValid`, `GetSlots`, `Contains`, `IntersectsWith`, `Subtract`, `Merge`. |
| `IndexRangeHelper` | Utility helper for index-range arithmetic used internally during selection. |
| `TableViewTrace` | `[Conditional("DEBUG")]` trace helper that writes tagged messages to `Debug.WriteLine`. |

### Core Changes
- **`TableView.cs`** – Major rework of drag-selection hit-testing so that pointer-down events on `TableViewRow` containers and blank list areas correctly initiate a selection rectangle, with full row/column range tracking.
- **`TableViewCell.cs`** – Selection-related logic extracted out of the cell and centralised in `TableView`, reducing the cell to its display responsibilities.
- **`TableViewRow.cs`** – Removed redundant pointer-event handling that is now owned by `TableView`.
- **`TableViewCellSlot.cs`** – Minor adjustments to align with the new range types.
- **`ItemIndexRangeExtensions.cs`** – Extended to support the new selection model.

### Tests
- `DragSelectionRectangleTests.cs` – New tests covering drag-selection rectangle geometry.
- `TableViewSelectionUnitTests.cs` – Updated to cover selection scenarios that start outside individual cells.

### Sample App
- `OverviewPage` and `ExampleModelColumnsHelper` updated to demonstrate the improved drag-selection behaviour.

## Checklist
- [x] New public types have full XML documentation
- [x] Nullable reference types respected throughout
- [x] Debug-only tracing via `TableViewTrace` (no production overhead)
- [x] Unit tests added / updated
- [x] Tested on WinUI 3
- [x] Tested on Uno Platform