### PR TITLE
Add multi-level grouping

### DIFF
--- a/docs/docs/accessibility.md
+++ b/docs/docs/accessibility.md
@@ -12,6 +12,7 @@ You do not need to opt in. Accessibility support is always active. This page exp
 |---|---|
 | [`TableView`](xref:WinUI.TableView.TableView) | `GridPattern`, `TablePattern`, `SelectionPattern`, `ScrollPattern`, `ItemContainerPattern` |
 | [`TableViewRow`](xref:WinUI.TableView.TableViewRow) | `SelectionItemPattern`, `ExpandCollapsePattern` when `RowDetailsVisibilityMode` is `VisibleWhenExpanded` |
+| [`TableViewGroupRow`](xref:WinUI.TableView.TableViewGroupRow) | `ExpandCollapsePattern`, exposed as a `Group` |
 | [`TableViewCell`](xref:WinUI.TableView.TableViewCell) | `GridItemPattern`, `TableItemPattern`, `SelectionItemPattern` |
 | [`TableViewColumnHeader`](xref:WinUI.TableView.TableViewColumnHeader) | `InvokePattern` when [`CanSort`](xref:WinUI.TableView.TableViewColumn.CanSort) is `true` |
 | `TableViewRowHeader` | Structural header element |

--- a/docs/docs/datagrid-feature-comparison.md
+++ b/docs/docs/datagrid-feature-comparison.md
@@ -1,4 +1,4 @@
-# DataGrid Feature Comparison: WPF DataGrid, WCT DataGrid, and WinUI.TableView
+﻿# DataGrid Feature Comparison: WPF DataGrid, WCT DataGrid, and WinUI.TableView
 
 DataGrids are heavily used in business desktop applications. Many WPF and UWP applications depend on a grid control for editing, sorting, filtering, row details, validation, clipboard operations, and large data-entry screens.
 
@@ -49,7 +49,7 @@ WinUI.TableView is actively maintained and continues to add new features based o
 | Delete row | ✅ | ❌ | ❌ | |
 | Sorting | ✅ | ⚠️ | ✅ | No built-in sorting in WCT DataGrid but exposes sorting events. |
 | Filtering | ⚠️ | ❌ | ✅ | WPF commonly uses collection view/app logic. WCT docs explicitly say there is no built-in filtering. TableView provides Excel-like column filtering. |
-| Grouping | ✅ | ✅ | ❌ |  |
+| Grouping | ✅ | ✅ | ✅ |  |
 | Row selection | ✅ | ✅ | ✅ |  |
 | Cell selection | ✅ | ❌ | ✅ | |
 | Clipboard copy | ✅ | ✅ | ✅ |  |

--- a/docs/docs/grouping.md
+++ b/docs/docs/grouping.md
@@ -1,0 +1,135 @@
+# Grouping
+
+`TableView` can group rows by one or more properties. Group header rows are interleaved with the data rows and are
+virtualized like any other row, so collapsing a group that contains thousands of items costs a single row element.
+
+## Grouping by a property
+
+Add a [`GroupDescription`](xref:WinUI.TableView.GroupDescription) to
+[`GroupDescriptions`](xref:WinUI.TableView.TableView.GroupDescriptions):
+
+```csharp
+tableView.GroupDescriptions.Add(new GroupDescription(nameof(Employee.Department)));
+```
+
+Group descriptions are applied before the sort descriptions, so items land grouped and are then sorted within each
+group:
+
+```csharp
+tableView.GroupDescriptions.Add(new GroupDescription(nameof(Employee.Department)));
+tableView.SortDescriptions.Add(new SortDescription(nameof(Employee.LastName), SortDirection.Ascending));
+```
+
+### Multiple levels
+
+Add one description per level, outermost first:
+
+```csharp
+tableView.GroupDescriptions.Add(new GroupDescription(nameof(Employee.Department)));
+tableView.GroupDescriptions.Add(new GroupDescription(nameof(Employee.Location)));
+```
+
+### Ordering and custom keys
+
+`GroupDescription` derives from [`SortDescription`](xref:WinUI.TableView.SortDescription), so the same options
+apply: a direction, a custom `IComparer`, or a delegate that produces the key.
+
+```csharp
+// Order the groups descending.
+tableView.GroupDescriptions.Add(new GroupDescription(nameof(Order.Status), SortDirection.Descending));
+
+// Group by a computed key rather than a property.
+tableView.GroupDescriptions.Add(new GroupDescription(
+    propertyName: null,
+    valueDelegate: item => ((Order)item!).Placed.Year));
+```
+
+## Customising the header
+
+[`GroupHeaderTemplate`](xref:WinUI.TableView.TableView.GroupHeaderTemplate) presents the group. Its data context is
+the [`TableViewGroup`](xref:WinUI.TableView.TableViewGroup):
+
+```xml
+<tv:TableView ItemsSource="{x:Bind Employees}">
+    <tv:TableView.GroupHeaderTemplate>
+        <DataTemplate>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="{Binding Key}" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding ItemCount}" Opacity="0.7" />
+            </StackPanel>
+        </DataTemplate>
+    </tv:TableView.GroupHeaderTemplate>
+</tv:TableView>
+```
+
+Use [`GroupHeaderTemplateSelector`](xref:WinUI.TableView.TableView.GroupHeaderTemplateSelector) to vary the
+template, for example by [`Level`](xref:WinUI.TableView.TableViewGroup.Level).
+
+## Expanding and collapsing
+
+Users toggle a group by clicking its header, or by pressing Space or Enter when it has focus. In code:
+
+```csharp
+tableView.CollapseGroup(tableView.Groups[0]);
+tableView.ExpandGroup(tableView.Groups[0]);
+
+tableView.CollapseAllGroups();
+tableView.ExpandAllGroups();
+```
+
+Set [`AreGroupsExpandedByDefault`](xref:WinUI.TableView.TableView.AreGroupsExpandedByDefault) to `false` to start
+collapsed.
+
+Collapse state is remembered by the group's key path rather than by position, so it survives re-sorting,
+re-filtering and re-grouping. Only collapsed groups are tracked, so the common all-expanded case costs nothing.
+
+## Inspecting the groups
+
+[`Groups`](xref:WinUI.TableView.TableView.Groups) returns the groups in the order their headers appear — a group
+always precedes the groups and items it contains:
+
+```csharp
+foreach (var group in tableView.Groups)
+{
+    Debug.WriteLine($"{new string(' ', group.Level * 2)}{group.Key}: {group.ItemCount} items");
+}
+```
+
+A `TableViewGroup` describes a *span* of items rather than holding them:
+
+| Member | Description |
+|---|---|
+| [`Key`](xref:WinUI.TableView.TableViewGroup.Key) | The value the group description produced |
+| [`KeyPath`](xref:WinUI.TableView.TableViewGroup.KeyPath) | The keys from the outermost group down to this one |
+| [`Level`](xref:WinUI.TableView.TableViewGroup.Level) | Zero-based nesting level |
+| [`Parent`](xref:WinUI.TableView.TableViewGroup.Parent) | The enclosing group, or `null` |
+| [`FirstItemIndex`](xref:WinUI.TableView.TableViewGroup.FirstItemIndex) / [`ItemCount`](xref:WinUI.TableView.TableViewGroup.ItemCount) | The span of [`Items`](xref:WinUI.TableView.TableView.Items) the group covers |
+
+Because nothing is copied, grouping a million rows costs memory proportional to the number of groups.
+
+## Grouping and the rest of the control
+
+- **Selection and cell slots are unaffected.** They address items, not displayed rows, so collapsing a group never
+  changes which items are selected or what a [`TableViewCellSlot`](xref:WinUI.TableView.TableViewCellSlot) points
+  at.
+- **Group headers are not selectable** and carry no cell slot. Arrow-key navigation moves between data rows and
+  steps over them.
+- **Alternate row colours** follow the data row index, so the striping does not re-phase when a group above is
+  collapsed.
+- **Live shaping moves items between groups.** If an item's group key changes and
+  [`AllowLiveShaping`](xref:WinUI.TableView.TableView.AllowLiveShaping) is on, it moves to the right group; empty
+  groups disappear.
+- **Group headers do not scroll horizontally** with the columns.
+
+## Removing grouping
+
+```csharp
+tableView.GroupDescriptions.Clear();
+```
+
+## Related articles
+
+- [Sorting](sorting.md)
+- [Filtering](filtering.md)
+- [Selection](selection.md)
+- [Performance guidance](performance.md)

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -14,12 +14,26 @@ TableView (derives from Control)
 │   └── TableViewColumnHeader      ← one per column; handles sort, filter, resize, reorder
 ├── ScrollViewer
 │   └── ItemsRepeater              ← hosts only the rows the viewport needs
+│       ├── TableViewGroupRow      ← group header row, when grouping is applied
 │       └── TableViewRow           ← one per *visible* item, recycled as you scroll
 │           ├── TableViewRowHeader ← optional left gutter per row
 │           ├── TableViewCell[]    ← one per column
 │           └── RowDetails panel   ← optional collapsible detail area
 └── selection model                ← selected rows stored as index ranges
 ```
+
+### Two kinds of row index
+
+Because group header rows are interleaved with data rows, and collapsed groups hide theirs, the control works in
+two index spaces and is careful about which one it exposes:
+
+| Index | Means | Where you see it |
+|---|---|---|
+| **Item index** | Position in [`Items`](xref:WinUI.TableView.TableView.Items) | [`TableViewCellSlot.Row`](xref:WinUI.TableView.TableViewCellSlot), [`SelectedRanges`](xref:WinUI.TableView.TableView.SelectedRanges), [`TableViewRow.Index`](xref:WinUI.TableView.TableViewRow.Index), clipboard, automation |
+| **Visual index** | Position among the rows actually displayed | internal to layout, scrolling and hit testing |
+
+Everything public is in item indexes, so grouping and collapsing never change what a cell slot or a selection
+range refers to.
 
 ### What this buys you
 
@@ -28,6 +42,7 @@ TableView (derives from Control)
 - Selecting a large range is a range operation: no row has to exist for it, and
   [`SelectedItems`](xref:WinUI.TableView.TableView.SelectedItems) projects onto the items on demand.
 - Hit testing during drag selection is index arithmetic rather than a scan over rows.
+- Collapsing a group with thousands of items costs one realized element.
 
 ## Key concepts
 

--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -30,6 +30,8 @@
     href: editing.md
   - name: Selection
     href: selection.md
+  - name: Grouping
+    href: grouping.md
 - name: Layout
   items:
   - name: Row Headers

--- a/samples/WinUI.TableView.SampleApp/MainWindow.xaml
+++ b/samples/WinUI.TableView.SampleApp/MainWindow.xaml
@@ -78,6 +78,11 @@
                         <FontIcon Glyph="&#xE8A4;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem Content="Grouping">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xF168;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
                 <NavigationViewItem Content="Virtualization">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE9D9;" />

--- a/samples/WinUI.TableView.SampleApp/MainWindow.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/MainWindow.xaml.cs
@@ -60,6 +60,7 @@ public sealed partial class MainWindow : Window
                 "Corner Button" => typeof(CornerButtonPage),
                 "Alternate Row Color" => typeof(AlternateRowColorPage),
                 "Context Flyouts" => typeof(ContextFlyoutsPage),
+                "Grouping" => typeof(GroupingPage),
                 "Virtualization" => typeof(VirtualizationPage),
                 "Row Reorder" => typeof(ReorderRowsPage),
                 "Pagination" => typeof(PaginationPage),

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml
@@ -1,0 +1,114 @@
+<Page x:Class="WinUI.TableView.SampleApp.Pages.GroupingPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:WinUI.TableView.SampleApp"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:tv="using:WinUI.TableView"
+      xmlns:controls="using:WinUI.TableView.SampleApp.Controls"
+      d:DataContext="{d:DesignInstance Type=local:ExampleViewModel}"
+      mc:Ignorable="d">
+
+    <Grid>
+        <controls:SamplePresenter Header="Grouping"
+                                  Description="Showcasing multi-level grouping. Group header rows are virtualized like data rows, so collapsing a group with thousands of items costs one realized element.">
+            <controls:SamplePresenter.Example>
+                <tv:TableView x:Name="tableView"
+                              ItemsSource="{Binding Items}"
+                              AutoGenerateColumns="False"
+                              SelectionMode="Extended">
+                    <tv:TableView.GroupHeaderTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Key}"
+                                       FontWeight="SemiBold" />
+                        </DataTemplate>
+                    </tv:TableView.GroupHeaderTemplate>
+                    <tv:TableView.Columns>
+                        <tv:TableViewTextColumn Header="First Name"
+                                                Width="140"
+                                                Binding="{Binding FirstName}" />
+                        <tv:TableViewTextColumn Header="Last Name"
+                                                Width="140"
+                                                Binding="{Binding LastName}" />
+                        <tv:TableViewTextColumn Header="Department"
+                                                Width="160"
+                                                Binding="{Binding Department}" />
+                        <tv:TableViewTextColumn Header="Gender"
+                                                Width="100"
+                                                Binding="{Binding Gender}" />
+                        <tv:TableViewCheckBoxColumn Header="Is Active"
+                                                    Width="90"
+                                                    Binding="{Binding IsActive}" />
+                    </tv:TableView.Columns>
+                </tv:TableView>
+            </controls:SamplePresenter.Example>
+            <controls:SamplePresenter.Options>
+                <StackPanel Spacing="16"
+                            MaxWidth="350">
+                    <ComboBox x:Name="firstLevel"
+                              Header="Group by"
+                              HorizontalAlignment="Stretch"
+                              SelectionChanged="OnGroupingChanged" />
+                    <ComboBox x:Name="secondLevel"
+                              Header="Then group by"
+                              HorizontalAlignment="Stretch"
+                              SelectionChanged="OnGroupingChanged" />
+                    <ToggleSwitch x:Name="descending"
+                                  Header="Descending group order"
+                                  OnContent="True"
+                                  OffContent="False"
+                                  Toggled="OnGroupingChanged" />
+                    <StackPanel Orientation="Horizontal"
+                                Spacing="8">
+                        <Button Content="Expand all"
+                                Click="OnExpandAllClick" />
+                        <Button Content="Collapse all"
+                                Click="OnCollapseAllClick" />
+                    </StackPanel>
+                    <TextBlock TextWrapping="Wrap"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}">
+                        <Run Text="Groups:" />
+                        <Run x:Name="groupCountRun" />
+                        <LineBreak />
+                        <Run Text="Items:" />
+                        <Run x:Name="itemCountRun" />
+                        <LineBreak />
+                        <Run Text="Realized rows:" />
+                        <Run x:Name="realizedRowsRun" />
+                    </TextBlock>
+                    <TextBlock TextWrapping="Wrap"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Text="Selection uses item indexes, so collapsing a group never changes which items are selected. Click a header, or press Space or Enter on it, to toggle a group." />
+                </StackPanel>
+            </controls:SamplePresenter.Options>
+            <controls:SamplePresenter.Xaml>
+                <x:String xml:space="preserve">
+&lt;tv:TableView x:Name="tableView"
+    ItemsSource="{Binding Items}"&gt;
+    &lt;tv:TableView.GroupHeaderTemplate&gt;
+        &lt;DataTemplate&gt;
+            &lt;TextBlock Text="{Binding Key}" FontWeight="SemiBold" /&gt;
+        &lt;/DataTemplate&gt;
+    &lt;/tv:TableView.GroupHeaderTemplate&gt;
+&lt;/tv:TableView&gt;
+                </x:String>
+            </controls:SamplePresenter.Xaml>
+            <controls:SamplePresenter.CSharp>
+                <x:String xml:space="preserve">
+// Group by Department, then by Gender within each department.
+tableView.GroupDescriptions.Add(new GroupDescription(nameof(ExampleModel.Department)));
+tableView.GroupDescriptions.Add(new GroupDescription(nameof(ExampleModel.Gender)));
+
+// Groups are spans over the item view, so this never materializes the items.
+foreach (var group in tableView.Groups)
+{
+    Debug.WriteLine($"{group.Key} at level {group.Level} covers {group.ItemCount} items");
+}
+
+tableView.CollapseAllGroups();
+tableView.ExpandGroup(tableView.Groups[0]);
+                </x:String>
+            </controls:SamplePresenter.CSharp>
+        </controls:SamplePresenter>
+    </Grid>
+</Page>

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace WinUI.TableView.SampleApp.Pages;
+
+public sealed partial class GroupingPage : Page
+{
+    private const string None = "(none)";
+
+    private static readonly string[] GroupableProperties =
+    [
+        None,
+        nameof(ExampleModel.Department),
+        nameof(ExampleModel.Gender),
+        nameof(ExampleModel.IsActive)
+    ];
+
+    private bool _isInitialized;
+
+    public GroupingPage()
+    {
+        InitializeComponent();
+
+        firstLevel.ItemsSource = GroupableProperties;
+        secondLevel.ItemsSource = GroupableProperties;
+        firstLevel.SelectedItem = nameof(ExampleModel.Department);
+        secondLevel.SelectedItem = None;
+
+        _isInitialized = true;
+
+        Loaded += (_, _) => ApplyGrouping();
+    }
+
+    private void OnGroupingChanged(object sender, RoutedEventArgs e)
+    {
+        if (_isInitialized)
+        {
+            ApplyGrouping();
+        }
+    }
+
+    private void OnExpandAllClick(object sender, RoutedEventArgs e)
+    {
+        tableView.ExpandAllGroups();
+        UpdateStats();
+    }
+
+    private void OnCollapseAllClick(object sender, RoutedEventArgs e)
+    {
+        tableView.CollapseAllGroups();
+        UpdateStats();
+    }
+
+    private void ApplyGrouping()
+    {
+        var direction = descending.IsOn ? SortDirection.Descending : SortDirection.Ascending;
+
+        tableView.GroupDescriptions.Clear();
+
+        foreach (var comboBox in new[] { firstLevel, secondLevel })
+        {
+            if (comboBox.SelectedItem is string property && property != None)
+            {
+                tableView.GroupDescriptions.Add(new GroupDescription(property, direction));
+            }
+        }
+
+        UpdateStats();
+    }
+
+    private void UpdateStats()
+    {
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            groupCountRun.Text = tableView.Groups.Count.ToString();
+            itemCountRun.Text = tableView.Items.Count.ToString();
+            realizedRowsRun.Text = CountRealizedRows(tableView).ToString();
+        });
+    }
+
+    /// <summary>
+    /// Counts the realized row elements by walking the visual tree, which is what the counters are about: how
+    /// many row elements actually exist for the current item count.
+    /// </summary>
+    private static int CountRealizedRows(DependencyObject root)
+    {
+        var count = 0;
+
+        for (var i = 0; i < VisualTreeHelper.GetChildrenCount(root); i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+
+            if (child is TableViewRow { IsLoaded: true })
+            {
+                count++;
+            }
+
+            count += CountRealizedRows(child);
+        }
+
+        return count;
+    }
+}

--- a/src/AutomationPeers/TableViewGroupRowAutomationPeer.cs
+++ b/src/AutomationPeers/TableViewGroupRowAutomationPeer.cs
@@ -1,0 +1,86 @@
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+
+namespace WinUI.TableView.AutomationPeers;
+
+/// <summary>
+/// Exposes <see cref="TableViewGroupRow"/> to UI Automation as an expandable group.
+/// </summary>
+public partial class TableViewGroupRowAutomationPeer : FrameworkElementAutomationPeer, IExpandCollapseProvider
+{
+    private readonly TableViewGroupRow _owner;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableViewGroupRowAutomationPeer"/> class.
+    /// </summary>
+    /// <param name="owner">The <see cref="TableViewGroupRow"/> that is associated with this peer.</param>
+    public TableViewGroupRowAutomationPeer(TableViewGroupRow owner) : base(owner)
+    {
+        _owner = owner;
+    }
+
+    /// <inheritdoc/>
+    protected override string GetClassNameCore()
+    {
+        return nameof(TableViewGroupRow);
+    }
+
+    /// <inheritdoc/>
+    protected override AutomationControlType GetAutomationControlTypeCore()
+    {
+        return AutomationControlType.Group;
+    }
+
+    /// <inheritdoc/>
+    protected override string GetLocalizedControlTypeCore()
+    {
+        return "group header";
+    }
+
+    /// <inheritdoc/>
+    protected override string GetNameCore()
+    {
+        var name = AutomationProperties.GetName(_owner);
+
+        if (!string.IsNullOrEmpty(name))
+        {
+            return name;
+        }
+
+        if (_owner.Group is not { } group)
+        {
+            return "Group";
+        }
+
+        return $"{group.Key}, {group.ItemCount} items";
+    }
+
+    /// <inheritdoc/>
+    protected override object GetPatternCore(PatternInterface patternInterface)
+    {
+        return patternInterface is PatternInterface.ExpandCollapse ? this : base.GetPatternCore(patternInterface);
+    }
+
+    /// <inheritdoc/>
+    public ExpandCollapseState ExpandCollapseState =>
+        _owner.IsExpanded ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed;
+
+    /// <inheritdoc/>
+    public void Expand()
+    {
+        if (_owner is { Group: { } group, TableView: { } tableView })
+        {
+            tableView.ExpandGroup(group);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Collapse()
+    {
+        if (_owner is { Group: { } group, TableView: { } tableView })
+        {
+            tableView.CollapseGroup(group);
+        }
+    }
+}

--- a/src/ItemsSource/CollectionView.Grouping.cs
+++ b/src/ItemsSource/CollectionView.Grouping.cs
@@ -1,0 +1,207 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Grouping support for <see cref="CollectionView"/>.
+/// </summary>
+/// <remarks>
+/// Grouping is expressed entirely as spans over the flat item view: <c>_view</c> stays a flat list of data items
+/// ordered by group key and then by the sort descriptions, and <see cref="Groups"/> describes where each group
+/// starts and how many items it covers. Item indexes therefore remain contiguous within a group and every
+/// index-based API (cell slots, selection ranges, the clipboard) keeps working unchanged.
+/// </remarks>
+partial class CollectionView
+{
+    private readonly ObservableCollection<GroupDescription> _groupDescriptions = [];
+    private readonly List<TableViewGroup> _groups = [];
+    private bool _suspendGroupMaintenance;
+
+    /// <summary>
+    /// Gets the collection of group descriptions applied to the items, outermost level first.
+    /// </summary>
+    public IList<GroupDescription> GroupDescriptions => _groupDescriptions;
+
+    /// <summary>
+    /// Gets the groups in document order: for every group, at every level, the span of items it covers.
+    /// </summary>
+    /// <remarks>
+    /// Ordered so that a group always appears before the groups and items it contains, which is the order group
+    /// header rows appear in.
+    /// </remarks>
+    internal IReadOnlyList<TableViewGroup> Groups => _groups;
+
+    /// <summary>
+    /// Gets a value indicating whether any grouping is applied.
+    /// </summary>
+    public bool IsGrouped => _groupDescriptions.Count > 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the view has to be ordered. Group keys order items just as sort
+    /// descriptions do, so either one requires the ordering pass.
+    /// </summary>
+    private bool NeedsSorting => _sortDescriptions.Count > 0 || _groupDescriptions.Count > 0;
+
+    /// <summary>
+    /// Re-evaluates the grouping applied to the view.
+    /// </summary>
+    public void RefreshGrouping()
+    {
+        HandleSourceChanged();
+    }
+
+    /// <summary>
+    /// Handles changes to the group descriptions collection.
+    /// </summary>
+    private void OnGroupDescriptionsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (_deferCounter > 0) return;
+
+        HandleSourceChanged();
+    }
+
+    /// <summary>
+    /// Rebuilds <see cref="Groups"/> from the current view in a single pass.
+    /// </summary>
+    private void RebuildGroups()
+    {
+        _groups.Clear();
+
+        var levels = _groupDescriptions.Count;
+
+        if (levels is 0 || _view.Count is 0)
+        {
+            return;
+        }
+
+        var openGroups = new TableViewGroup?[levels];
+
+        for (var index = 0; index < _view.Count; index++)
+        {
+            var item = _view[index];
+            var startedNewGroup = false;
+
+            for (var level = 0; level < levels; level++)
+            {
+                var key = _groupDescriptions[level].GetPropertyValue(item);
+
+                // A new group at one level forces a new group at every deeper level, even when the deeper key
+                // happens to repeat the previous group's key.
+                if (!startedNewGroup && openGroups[level] is { } openGroup && Equals(openGroup.Key, key))
+                {
+                    continue;
+                }
+
+                startedNewGroup = true;
+                openGroups[level] = new TableViewGroup(key, level, index, level is 0 ? null : openGroups[level - 1]);
+                _groups.Add(openGroups[level]!);
+            }
+
+            for (var level = 0; level < levels; level++)
+            {
+                openGroups[level]!.ItemCount++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Grows the groups covering a newly inserted item, or rebuilds when the item starts a new group.
+    /// </summary>
+    /// <param name="viewIndex">The index the item was inserted at; the view already contains it.</param>
+    private void OnItemAddedToGroups(int viewIndex)
+    {
+        if (_groupDescriptions.Count is 0 || _suspendGroupMaintenance)
+        {
+            return;
+        }
+
+        // The neighbour whose groups the new item could join. Group spans are still expressed in pre-insert
+        // indexes at this point, and the neighbour's pre-insert index is the one below.
+        var neighbourIndex = viewIndex > 0 ? viewIndex - 1 : 1;
+
+        if (neighbourIndex >= _view.Count || !HasSameGroupKeys(_view[viewIndex], _view[neighbourIndex]))
+        {
+            RebuildGroups();
+            return;
+        }
+
+        var anchor = viewIndex > 0 ? viewIndex - 1 : 0;
+
+        foreach (var group in _groups)
+        {
+            if (group.FirstItemIndex > anchor)
+            {
+                group.FirstItemIndex++;
+            }
+            else if (group.LastItemIndex >= anchor)
+            {
+                group.ItemCount++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Shrinks the groups that covered a removed item, dropping any that became empty.
+    /// </summary>
+    /// <param name="viewIndex">The index the item was removed from; the view no longer contains it.</param>
+    private void OnItemRemovedFromGroups(int viewIndex)
+    {
+        if (_groupDescriptions.Count is 0 || _suspendGroupMaintenance)
+        {
+            return;
+        }
+
+        for (var i = _groups.Count - 1; i >= 0; i--)
+        {
+            var group = _groups[i];
+
+            if (group.FirstItemIndex > viewIndex)
+            {
+                group.FirstItemIndex--;
+            }
+            else if (group.LastItemIndex >= viewIndex)
+            {
+                group.ItemCount--;
+
+                if (group.ItemCount is 0)
+                {
+                    _groups.RemoveAt(i);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether two items belong in the same group at every level.
+    /// </summary>
+    private bool HasSameGroupKeys(object? x, object? y)
+    {
+        foreach (var description in _groupDescriptions)
+        {
+            if (!Equals(description.GetPropertyValue(x), description.GetPropertyValue(y)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether a property change on an item can move it between groups.
+    /// </summary>
+    private bool AffectsGrouping(string propertyName)
+    {
+        foreach (var description in _groupDescriptions)
+        {
+            if (string.IsNullOrEmpty(description.PropertyName) || description.PropertyName == propertyName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/ItemsSource/CollectionView.cs
+++ b/src/ItemsSource/CollectionView.cs
@@ -31,6 +31,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     {
         _filterDescriptions.CollectionChanged += OnFilterDescriptionsCollectionChanged;
         _sortDescriptions.CollectionChanged += OnSortDescriptionsCollectionChanged;
+        _groupDescriptions.CollectionChanged += OnGroupDescriptionsCollectionChanged;
 
         AllowLiveShaping = liveShapingEnabled;
         Source = source ?? new List<object>();
@@ -269,7 +270,8 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
             }
         }
 
-        if (SortDescriptions.Any(sd => string.IsNullOrEmpty(sd.PropertyName) || sd.PropertyName == e.PropertyName))
+        if (SortDescriptions.Any(sd => string.IsNullOrEmpty(sd.PropertyName) || sd.PropertyName == e.PropertyName)
+            || AffectsGrouping(e.PropertyName))
         {
             var oldIndex = _view.IndexOf(item);
 
@@ -280,6 +282,8 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
             }
 
             _view.RemoveAt(oldIndex);
+            OnItemRemovedFromGroups(oldIndex);
+
             var targetIndex = _view.BinarySearch(item, this);
             if (targetIndex < 0)
             {
@@ -292,12 +296,14 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
                 OnVectorChanged(new VectorChangedEventArgs(CollectionChange.ItemRemoved, oldIndex, item));
 
                 _view.Insert(targetIndex, item);
+                OnItemAddedToGroups(targetIndex);
 
                 OnVectorChanged(new VectorChangedEventArgs(CollectionChange.ItemInserted, targetIndex, item));
             }
             else
             {
                 _view.Insert(targetIndex, item);
+                OnItemAddedToGroups(targetIndex);
             }
         }
         else if (string.IsNullOrEmpty(e.PropertyName))
@@ -329,9 +335,11 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
                 _view.AddRange(Source.OfType<object>());
             }
 
-            if (SortDescriptions.Count > 0)
+            if (NeedsSorting)
                 _view.Sort(this);
         }
+
+        RebuildGroups();
 
         OnVectorChanged(new VectorChangedEventArgs(CollectionChange.Reset));
         MoveCurrentTo(currentItem);
@@ -342,6 +350,10 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     /// </summary>
     private void HandleFilterChanged()
     {
+        // Per-item group maintenance would fall back to a full rebuild for every item that starts a new group,
+        // so suspend it and rebuild once at the end.
+        _suspendGroupMaintenance = true;
+
         if (FilterDescriptions.Count > 0)
         {
             for (var index = 0; index < _view.Count; index++)
@@ -375,6 +387,9 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
 
             i++;
         }
+
+        _suspendGroupMaintenance = false;
+        RebuildGroups();
     }
 
     /// <summary>
@@ -382,9 +397,10 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     /// </summary>
     private void HandleSortChanged()
     {
-        if (SortDescriptions.Count > 0)
+        if (NeedsSorting)
         {
             _view.Sort(this);
+            RebuildGroups();
         }
         else
         {
@@ -406,7 +422,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
 
         var newViewIndex = newStartingIndex;
 
-        if (_sortDescriptions.Any())
+        if (NeedsSorting)
         {
             newViewIndex = _view.BinarySearch(newItem!, this);
             if (newViewIndex < 0)
@@ -425,6 +441,8 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
         }
 
         _view.Insert(newViewIndex, newItem!);
+        OnItemAddedToGroups(newViewIndex);
+
         if (newViewIndex <= CurrentPosition)
         {
             CurrentPosition++;
@@ -465,6 +483,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     private void RemoveFromView(int itemIndex, object? item)
     {
         _view.RemoveAt(itemIndex);
+        OnItemRemovedFromGroups(itemIndex);
 
         if (itemIndex <= CurrentPosition)
         {
@@ -670,19 +689,40 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     /// <returns>An integer that indicates the relative order of the objects being compared.</returns>
     public int Compare(object? x, object? y)
     {
-        foreach (var sortDescription in SortDescriptions)
+        // Group keys order the items first, so items land grouped and then sorted within each group.
+        foreach (var groupDescription in _groupDescriptions)
         {
-            var xValue = sortDescription.GetPropertyValue(x);
-            var yValue = sortDescription.GetPropertyValue(y);
-            var cmp = sortDescription.Compare(xValue, yValue);
+            var cmp = Compare(groupDescription, x, y);
 
             if (cmp != 0)
             {
-                return sortDescription.Direction is SortDirection.Ascending ? +cmp : -cmp;
+                return cmp;
+            }
+        }
+
+        foreach (var sortDescription in SortDescriptions)
+        {
+            var cmp = Compare(sortDescription, x, y);
+
+            if (cmp != 0)
+            {
+                return cmp;
             }
         }
 
         return 0;
+    }
+
+    /// <summary>
+    /// Compares two items using a single description, honouring its direction.
+    /// </summary>
+    private static int Compare(SortDescription description, object? x, object? y)
+    {
+        var xValue = description.GetPropertyValue(x);
+        var yValue = description.GetPropertyValue(y);
+        var cmp = description.Compare(xValue, yValue);
+
+        return cmp is 0 ? 0 : description.Direction is SortDirection.Ascending ? +cmp : -cmp;
     }
 
     /// <summary>

--- a/src/ItemsSource/GroupDescription.cs
+++ b/src/ItemsSource/GroupDescription.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Describes a grouping level applied to TableView items.
+/// </summary>
+/// <remarks>
+/// A group description is a <see cref="SortDescription"/>: the value it extracts is both the group key and the
+/// key the items are ordered by, so grouping needs no sorting mechanism of its own. Group descriptions are
+/// applied before <see cref="CollectionView.SortDescriptions"/>, so items are laid out group by group and sorted
+/// within each group.
+/// </remarks>
+public class GroupDescription : SortDescription
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GroupDescription"/> class.
+    /// </summary>
+    /// <param name="propertyName">The name of the property to group by.</param>
+    /// <param name="direction">The direction the groups are ordered in.</param>
+    /// <param name="comparer">An optional comparer used to order the groups.</param>
+    /// <param name="valueDelegate">An optional delegate that produces the group key for an item.</param>
+    public GroupDescription(string? propertyName,
+                           SortDirection direction = SortDirection.Ascending,
+                           IComparer? comparer = null,
+                           Func<object?, object?>? valueDelegate = null)
+        : base(propertyName, direction, comparer, valueDelegate)
+    {
+    }
+}

--- a/src/ItemsSource/TableViewGroup.cs
+++ b/src/ItemsSource/TableViewGroup.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Represents one group of items produced by the <see cref="TableView"/>'s grouping.
+/// </summary>
+/// <remarks>
+/// A group is a span of consecutive items in the item view, described by <see cref="FirstItemIndex"/> and
+/// <see cref="ItemCount"/> rather than by holding the items. Nothing is copied, so grouping a million rows costs
+/// memory proportional to the number of groups, and a group header row can be realized from a group without
+/// touching the items it covers.
+/// </remarks>
+public sealed class TableViewGroup
+{
+    private readonly object?[] _keyPath;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableViewGroup"/> class.
+    /// </summary>
+    internal TableViewGroup(object? key, int level, int firstItemIndex, TableViewGroup? parent)
+    {
+        Key = key;
+        Level = level;
+        FirstItemIndex = firstItemIndex;
+        Parent = parent;
+
+        _keyPath = parent is null ? [key] : [.. parent.KeyPath, key];
+    }
+
+    /// <summary>
+    /// Gets the group key: the value the group description produced for the items in this group.
+    /// </summary>
+    public object? Key { get; }
+
+    /// <summary>
+    /// Gets the zero-based grouping level, matching the index of the owning group description.
+    /// </summary>
+    public int Level { get; }
+
+    /// <summary>
+    /// Gets the enclosing group, or <see langword="null"/> for a top-level group.
+    /// </summary>
+    public TableViewGroup? Parent { get; }
+
+    /// <summary>
+    /// Gets the group keys from the top-level group down to and including this one.
+    /// </summary>
+    public IReadOnlyList<object?> KeyPath => _keyPath;
+
+    /// <summary>
+    /// Gets the index, in the item view, of the first item this group covers.
+    /// </summary>
+    public int FirstItemIndex { get; internal set; }
+
+    /// <summary>
+    /// Gets the number of items this group covers, including those covered by nested groups.
+    /// </summary>
+    public int ItemCount { get; internal set; }
+
+    /// <summary>
+    /// Gets the index, in the item view, of the last item this group covers.
+    /// </summary>
+    public int LastItemIndex => FirstItemIndex + ItemCount - 1;
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return $"{Key} (level {Level}, {ItemCount} items from {FirstItemIndex})";
+    }
+}

--- a/src/ItemsSource/TableViewGroupPath.cs
+++ b/src/ItemsSource/TableViewGroupPath.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Identifies a group by the keys leading to it, so the group can be recognised again after the view is
+/// re-sorted, re-filtered or re-grouped and the <see cref="TableViewGroup"/> instances have been rebuilt.
+/// </summary>
+internal readonly struct TableViewGroupPath : IEquatable<TableViewGroupPath>
+{
+    private readonly object?[] _keys;
+    private readonly int _hashCode;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableViewGroupPath"/> struct from a group's key path.
+    /// </summary>
+    public TableViewGroupPath(IReadOnlyList<object?> keys)
+    {
+        _keys = new object?[keys.Count];
+
+        var hash = new HashCode();
+
+        for (var i = 0; i < keys.Count; i++)
+        {
+            _keys[i] = keys[i];
+            hash.Add(keys[i]);
+        }
+
+        _hashCode = hash.ToHashCode();
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(TableViewGroupPath other)
+    {
+        if (_keys is null || other._keys is null)
+        {
+            return _keys is null && other._keys is null;
+        }
+
+        if (_keys.Length != other._keys.Length || _hashCode != other._hashCode)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < _keys.Length; i++)
+        {
+            if (!Equals(_keys[i], other._keys[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is TableViewGroupPath other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => _hashCode;
+
+    /// <inheritdoc/>
+    public override string ToString() => _keys is null ? string.Empty : string.Join(" / ", _keys);
+}

--- a/src/ItemsSource/TableViewVisualRows.cs
+++ b/src/ItemsSource/TableViewVisualRows.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -6,82 +6,330 @@ using System.Collections.Specialized;
 namespace WinUI.TableView;
 
 /// <summary>
-/// The sequence of rows the row host displays.
+/// The flattened sequence of rows the row host displays: group header rows interleaved with the data rows they
+/// cover, with the contents of collapsed groups left out.
 /// </summary>
 /// <remarks>
-/// This is the boundary between the table's item view and the row host: it adapts <see cref="CollectionView"/> to
-/// the shape <c>ItemsSourceView</c> recognises (a non-generic <see cref="IList"/> plus plain
-/// <see cref="INotifyCollectionChanged"/>, rather than the WinRT vector-changed shape <see cref="ICollectionView"/>
-/// exposes) on both Windows App SDK and Uno.
+/// This is the boundary between the two index spaces the control works in. An <em>item index</em> is a position
+/// in the item view and is what cell slots, selection ranges, the clipboard and automation mean by "row". A
+/// <em>visual index</em> is a position in this sequence and is what the layout, the repeater, scrolling and hit
+/// testing use. Conversion is a binary search over a run list whose length is proportional to the number of
+/// visible groups, and is a single comparison when nothing is grouped.
 /// <para>
-/// Today every visual index is also an item index — what <see cref="TableViewCellSlot.Row"/>,
-/// <see cref="TableView.SelectedRanges"/>, the clipboard and automation all mean by "row". The distinction exists
-/// so a future feature that displays rows the item view does not (such as group header rows) has a single seam to
-/// extend rather than a page of call sites to update.
+/// Exposes the non-generic <see cref="IList"/> plus <see cref="INotifyCollectionChanged"/> because that is the
+/// shape <c>ItemsSourceView</c> recognises on both Windows App SDK and Uno.
 /// </para>
 /// </remarks>
 internal sealed class TableViewVisualRows : IList, INotifyCollectionChanged
 {
     private readonly CollectionView _collectionView;
+    private readonly Func<TableViewGroup, bool> _isCollapsed;
+    private readonly List<Run> _runs = [];
+    private int _count;
+    private bool _hasGroups;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TableViewVisualRows"/> class.
     /// </summary>
     /// <param name="collectionView">The item view to project.</param>
-    public TableViewVisualRows(CollectionView collectionView)
+    /// <param name="isCollapsed">Decides whether a group's contents are hidden.</param>
+    public TableViewVisualRows(CollectionView collectionView, Func<TableViewGroup, bool> isCollapsed)
     {
         _collectionView = collectionView;
+        _isCollapsed = isCollapsed;
+
+        Rebuild();
     }
 
     /// <inheritdoc/>
     public event NotifyCollectionChangedEventHandler? CollectionChanged;
 
     /// <inheritdoc/>
-    public int Count => _collectionView.Count;
+    public int Count => _count;
+
+    /// <summary>
+    /// Gets a value indicating whether any group header rows are present.
+    /// </summary>
+    public bool HasGroups => _hasGroups;
 
     /// <inheritdoc/>
     public object? this[int index]
     {
-        get => _collectionView[index];
+        get
+        {
+            var run = FindRunByVisualIndex(index);
+
+            if (run < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            var entry = _runs[run];
+
+            return entry.GroupIndex >= 0
+                ? _collectionView.Groups[entry.GroupIndex]
+                : _collectionView[entry.ItemStart + (index - entry.VisualStart)];
+        }
         set => throw new NotSupportedException();
     }
 
     /// <summary>
-    /// Returns the item index the given visual index maps to.
+    /// Returns the item index the given visual index maps to, or -1 when it is a group header row.
     /// </summary>
-    public int GetItemIndex(int visualIndex) => visualIndex;
+    public int GetItemIndex(int visualIndex)
+    {
+        var run = FindRunByVisualIndex(visualIndex);
+
+        if (run < 0)
+        {
+            return -1;
+        }
+
+        var entry = _runs[run];
+
+        return entry.GroupIndex >= 0 ? -1 : entry.ItemStart + (visualIndex - entry.VisualStart);
+    }
 
     /// <summary>
-    /// Returns the visual index the given item index maps to.
+    /// Returns the visual index the given item index maps to, or -1 when the item is inside a collapsed group.
     /// </summary>
-    public int GetVisualIndex(int itemIndex) => itemIndex;
+    public int GetVisualIndex(int itemIndex)
+    {
+        if (itemIndex < 0)
+        {
+            return -1;
+        }
+
+        // Data runs are ordered by item index, so this is the mirror of FindRunByVisualIndex.
+        var low = 0;
+        var high = _runs.Count - 1;
+
+        while (low <= high)
+        {
+            var middle = low + ((high - low) >> 1);
+            var entry = _runs[middle];
+
+            if (entry.GroupIndex >= 0 || itemIndex < entry.ItemStart)
+            {
+                // Header runs carry the item index of the row that follows them, which lets the search skip
+                // past them in the right direction.
+                if (entry.ItemStart > itemIndex)
+                {
+                    high = middle - 1;
+                }
+                else
+                {
+                    low = middle + 1;
+                }
+            }
+            else if (itemIndex >= entry.ItemStart + entry.Length)
+            {
+                low = middle + 1;
+            }
+            else
+            {
+                return entry.VisualStart + (itemIndex - entry.ItemStart);
+            }
+        }
+
+        return -1;
+    }
 
     /// <summary>
-    /// Reprojects after the item view changed shape in a way that is not a single insert or remove, and reports a
-    /// reset.
+    /// Returns the group whose header sits at the given visual index, or <see langword="null"/> for a data row.
+    /// </summary>
+    public TableViewGroup? GetGroup(int visualIndex)
+    {
+        var run = FindRunByVisualIndex(visualIndex);
+
+        if (run < 0)
+        {
+            return null;
+        }
+
+        var entry = _runs[run];
+
+        return entry.GroupIndex >= 0 ? _collectionView.Groups[entry.GroupIndex] : null;
+    }
+
+    /// <summary>
+    /// Rebuilds the run list from the current groups and collapse state, and reports a reset.
     /// </summary>
     public void Reset()
     {
+        Rebuild();
         CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
     }
 
     /// <summary>
-    /// Reports that an item was inserted at the given item index.
+    /// Reprojects after an item was inserted into the item view.
     /// </summary>
+    /// <remarks>
+    /// Raises a single-item add when the projection grew by exactly one row, so the host realizes one row rather
+    /// than re-realizing the viewport. When the insertion also created group header rows the shape changed by
+    /// more than one row and a reset is the honest report.
+    /// </remarks>
     public void OnItemInserted(int itemIndex)
     {
-        CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(
-            NotifyCollectionChangedAction.Add, this[itemIndex], itemIndex));
+        var previousCount = _count;
+
+        Rebuild();
+
+        var visualIndex = GetVisualIndex(itemIndex);
+
+        if (_count == previousCount + 1 && visualIndex >= 0)
+        {
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(
+                NotifyCollectionChangedAction.Add, this[visualIndex], visualIndex));
+        }
+        else
+        {
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
     }
 
     /// <summary>
-    /// Reports that an item was removed. <paramref name="visualIndex"/> is the visual index the row occupied,
-    /// captured before the removal.
+    /// Reprojects after an item was removed from the item view.
     /// </summary>
+    /// <param name="visualIndex">The visual index the removed row occupied, captured before the removal.</param>
+    /// <param name="item">The removed item.</param>
     public void OnItemRemoved(int visualIndex, object? item)
     {
-        CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(
-            NotifyCollectionChangedAction.Remove, item, visualIndex));
+        var previousCount = _count;
+
+        Rebuild();
+
+        if (_count == previousCount - 1 && visualIndex >= 0)
+        {
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(
+                NotifyCollectionChangedAction.Remove, item, visualIndex));
+        }
+        else
+        {
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds the run list. Costs one pass over the groups, never over the items.
+    /// </summary>
+    private void Rebuild()
+    {
+        _runs.Clear();
+        _count = 0;
+        _hasGroups = false;
+
+        var itemCount = _collectionView.Count;
+        var groups = _collectionView.Groups;
+
+        if (groups.Count is 0)
+        {
+            if (itemCount > 0)
+            {
+                AddDataRun(0, itemCount);
+            }
+
+            return;
+        }
+
+        var nextItem = 0;
+        var hiddenUntil = -1;
+
+        for (var g = 0; g < groups.Count; g++)
+        {
+            var group = groups[g];
+
+            // Groups nested inside a collapsed group contribute neither a header nor their items.
+            if (group.FirstItemIndex < hiddenUntil)
+            {
+                continue;
+            }
+
+            if (group.FirstItemIndex > nextItem)
+            {
+                AddDataRun(nextItem, group.FirstItemIndex - nextItem);
+            }
+
+            nextItem = group.FirstItemIndex;
+            AddHeaderRun(g, nextItem);
+
+            if (_isCollapsed(group))
+            {
+                hiddenUntil = group.LastItemIndex + 1;
+                nextItem = hiddenUntil;
+            }
+        }
+
+        if (itemCount > nextItem)
+        {
+            AddDataRun(nextItem, itemCount - nextItem);
+        }
+    }
+
+    private void AddDataRun(int itemStart, int length)
+    {
+        _runs.Add(new Run(_count, itemStart, length, -1));
+        _count += length;
+    }
+
+    private void AddHeaderRun(int groupIndex, int itemStart)
+    {
+        _runs.Add(new Run(_count, itemStart, 1, groupIndex));
+        _count++;
+        _hasGroups = true;
+    }
+
+    /// <summary>
+    /// Returns the index of the run containing <paramref name="visualIndex"/>, or -1 when out of range.
+    /// </summary>
+    private int FindRunByVisualIndex(int visualIndex)
+    {
+        if (visualIndex < 0 || visualIndex >= _count)
+        {
+            return -1;
+        }
+
+        var low = 0;
+        var high = _runs.Count - 1;
+
+        while (low <= high)
+        {
+            var middle = low + ((high - low) >> 1);
+            var entry = _runs[middle];
+
+            if (visualIndex < entry.VisualStart)
+            {
+                high = middle - 1;
+            }
+            else if (visualIndex >= entry.VisualStart + entry.Length)
+            {
+                low = middle + 1;
+            }
+            else
+            {
+                return middle;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// A stretch of consecutive visual rows: either one group header, or a span of data rows.
+    /// </summary>
+    private readonly struct Run(int visualStart, int itemStart, int length, int groupIndex)
+    {
+        /// <summary>The first visual index this run covers.</summary>
+        public int VisualStart { get; } = visualStart;
+
+        /// <summary>For a data run, the first item index; for a header, the item index the header precedes.</summary>
+        public int ItemStart { get; } = itemStart;
+
+        /// <summary>The number of visual rows in this run; always 1 for a header.</summary>
+        public int Length { get; } = length;
+
+        /// <summary>The index into the view's groups for a header run, or -1 for a data run.</summary>
+        public int GroupIndex { get; } = groupIndex;
     }
 
     // Mutation and the rest of IList are not supported: this is a projection.
@@ -101,22 +349,43 @@ internal sealed class TableViewVisualRows : IList, INotifyCollectionChanged
     /// <inheritdoc/>
     public IEnumerator GetEnumerator()
     {
-        for (var i = 0; i < Count; i++)
+        for (var i = 0; i < _count; i++)
         {
             yield return this[i];
         }
     }
 
     /// <inheritdoc/>
-    public bool Contains(object? value) => _collectionView.IndexOf(value) >= 0;
+    public bool Contains(object? value) => IndexOf(value) >= 0;
 
     /// <inheritdoc/>
-    public int IndexOf(object? value) => _collectionView.IndexOf(value);
+    public int IndexOf(object? value)
+    {
+        if (value is TableViewGroup group)
+        {
+            // Header runs are few (one per visible group), and looking a group up by identity is not a hot path.
+            var groups = _collectionView.Groups;
+
+            foreach (var run in _runs)
+            {
+                if (run.GroupIndex >= 0 && ReferenceEquals(groups[run.GroupIndex], group))
+                {
+                    return run.VisualStart;
+                }
+            }
+
+            return -1;
+        }
+
+        var itemIndex = _collectionView.IndexOf(value);
+
+        return itemIndex < 0 ? -1 : GetVisualIndex(itemIndex);
+    }
 
     /// <inheritdoc/>
     public void CopyTo(Array array, int index)
     {
-        for (var i = 0; i < Count; i++)
+        for (var i = 0; i < _count; i++)
         {
             array.SetValue(this[i], index + i);
         }

--- a/src/Layout/TableViewRowElementFactory.cs
+++ b/src/Layout/TableViewRowElementFactory.cs
@@ -4,10 +4,11 @@ using System.Collections.Generic;
 namespace WinUI.TableView.Layout;
 
 /// <summary>
-/// Creates and recycles the <see cref="TableViewRow"/> elements the row host displays.
+/// Creates and recycles the elements the row host displays: a <see cref="TableViewRow"/> for a data row and a
+/// <see cref="TableViewGroupRow"/> for a group header row.
 /// </summary>
 /// <remarks>
-/// The repeater delegates recycling entirely to the factory, so this owns the pool. Rows are the expensive
+/// The repeater delegates recycling entirely to the factory, so this owns the pools. Rows are the expensive
 /// element — each one builds a cell per visible column — which is exactly why they are pooled and reused rather
 /// than recreated as the viewport moves.
 /// </remarks>
@@ -17,6 +18,7 @@ internal sealed class TableViewRowElementFactory : IElementFactory
 
     private readonly TableView _tableView;
     private readonly Stack<TableViewRow> _rowPool = new();
+    private readonly Stack<TableViewGroupRow> _groupRowPool = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TableViewRowElementFactory"/> class.
@@ -29,6 +31,15 @@ internal sealed class TableViewRowElementFactory : IElementFactory
     /// <inheritdoc/>
     public UIElement GetElement(ElementFactoryGetArgs args)
     {
+        if (args.Data is TableViewGroup group)
+        {
+            var groupRow = _groupRowPool.Count > 0 ? _groupRowPool.Pop() : new TableViewGroupRow();
+            groupRow.TableView = _tableView;
+            groupRow.PrepareForGroup(group, _tableView.ResolveGroupHeaderTemplate(group), !_tableView.IsGroupCollapsed(group));
+
+            return groupRow;
+        }
+
         var row = _rowPool.Count > 0 ? _rowPool.Pop() : _tableView.CreateRow();
         row.TableView = _tableView;
 
@@ -41,16 +52,27 @@ internal sealed class TableViewRowElementFactory : IElementFactory
     /// <inheritdoc/>
     public void RecycleElement(ElementFactoryRecycleArgs args)
     {
-        if (args.Element is not TableViewRow row)
+        switch (args.Element)
         {
-            return;
-        }
+            case TableViewRow row:
+                row.PrepareForRecycle();
 
-        row.PrepareForRecycle();
+                if (_rowPool.Count < MaxPooledElements)
+                {
+                    _rowPool.Push(row);
+                }
 
-        if (_rowPool.Count < MaxPooledElements)
-        {
-            _rowPool.Push(row);
+                break;
+
+            case TableViewGroupRow groupRow:
+                groupRow.PrepareForRecycle();
+
+                if (_groupRowPool.Count < MaxPooledElements)
+                {
+                    _groupRowPool.Push(groupRow);
+                }
+
+                break;
         }
     }
 
@@ -61,5 +83,6 @@ internal sealed class TableViewRowElementFactory : IElementFactory
     public void ClearPools()
     {
         _rowPool.Clear();
+        _groupRowPool.Clear();
     }
 }

--- a/src/TableView.Grouping.cs
+++ b/src/TableView.Grouping.cs
@@ -1,0 +1,187 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System.Collections.Generic;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Grouping for <see cref="TableView"/>.
+/// </summary>
+public partial class TableView
+{
+    private readonly HashSet<TableViewGroupPath> _collapsedGroups = [];
+
+    /// <summary>
+    /// Identifies the <see cref="GroupHeaderTemplate"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty GroupHeaderTemplateProperty = DependencyProperty.Register(
+        nameof(GroupHeaderTemplate), typeof(DataTemplate), typeof(TableView), new PropertyMetadata(null, OnGroupHeaderTemplateChanged));
+
+    /// <summary>
+    /// Identifies the <see cref="GroupHeaderTemplateSelector"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty GroupHeaderTemplateSelectorProperty = DependencyProperty.Register(
+        nameof(GroupHeaderTemplateSelector), typeof(DataTemplateSelector), typeof(TableView), new PropertyMetadata(null, OnGroupHeaderTemplateChanged));
+
+    /// <summary>
+    /// Identifies the <see cref="AreGroupsExpandedByDefault"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty AreGroupsExpandedByDefaultProperty = DependencyProperty.Register(
+        nameof(AreGroupsExpandedByDefault), typeof(bool), typeof(TableView), new PropertyMetadata(true));
+
+    /// <summary>
+    /// Gets the collection of group descriptions applied to the items, outermost level first.
+    /// </summary>
+    public IList<GroupDescription> GroupDescriptions => _collectionView.GroupDescriptions;
+
+    /// <summary>
+    /// Gets a value indicating whether the items are grouped.
+    /// </summary>
+    public bool IsGrouped => _collectionView.IsGrouped;
+
+    /// <summary>
+    /// Gets the groups currently produced by the grouping, in the order their header rows appear.
+    /// </summary>
+    public IReadOnlyList<TableViewGroup> Groups => _collectionView.Groups;
+
+    /// <summary>
+    /// Gets or sets the template used to present a group header's key.
+    /// </summary>
+    public DataTemplate? GroupHeaderTemplate
+    {
+        get => (DataTemplate?)GetValue(GroupHeaderTemplateProperty);
+        set => SetValue(GroupHeaderTemplateProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the template selector used to present a group header's key.
+    /// </summary>
+    public DataTemplateSelector? GroupHeaderTemplateSelector
+    {
+        get => (DataTemplateSelector?)GetValue(GroupHeaderTemplateSelectorProperty);
+        set => SetValue(GroupHeaderTemplateSelectorProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether groups start out expanded.
+    /// </summary>
+    public bool AreGroupsExpandedByDefault
+    {
+        get => (bool)GetValue(AreGroupsExpandedByDefaultProperty);
+        set => SetValue(AreGroupsExpandedByDefaultProperty, value);
+    }
+
+    /// <summary>
+    /// Re-applies the group header template to the realized group header rows.
+    /// </summary>
+    private static void OnGroupHeaderTemplateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView)
+        {
+            // The template is resolved per group as the header row is prepared, so a full reprojection is the
+            // simplest way to push a new template onto the headers that are already on screen.
+            tableView.RefreshVisualRows();
+        }
+    }
+
+    /// <summary>
+    /// Re-evaluates the grouping applied to the items.
+    /// </summary>
+    public void RefreshGrouping()
+    {
+        _collectionView.RefreshGrouping();
+    }
+
+    /// <summary>
+    /// Shows the contents of the specified group.
+    /// </summary>
+    /// <param name="group">The group to expand.</param>
+    public void ExpandGroup(TableViewGroup group)
+    {
+        SetGroupExpanded(group, isExpanded: true);
+    }
+
+    /// <summary>
+    /// Hides the contents of the specified group.
+    /// </summary>
+    /// <param name="group">The group to collapse.</param>
+    public void CollapseGroup(TableViewGroup group)
+    {
+        SetGroupExpanded(group, isExpanded: false);
+    }
+
+    /// <summary>
+    /// Shows the contents of every group.
+    /// </summary>
+    public void ExpandAllGroups()
+    {
+        if (_collapsedGroups.Count is 0)
+        {
+            return;
+        }
+
+        _collapsedGroups.Clear();
+        RefreshVisualRows();
+    }
+
+    /// <summary>
+    /// Hides the contents of every group.
+    /// </summary>
+    public void CollapseAllGroups()
+    {
+        var changed = false;
+
+        foreach (var group in _collectionView.Groups)
+        {
+            changed |= _collapsedGroups.Add(new TableViewGroupPath(group.KeyPath));
+        }
+
+        if (changed)
+        {
+            RefreshVisualRows();
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the specified group's contents are hidden.
+    /// </summary>
+    internal bool IsGroupCollapsed(TableViewGroup group)
+    {
+        return _collapsedGroups.Count > 0 && _collapsedGroups.Contains(new TableViewGroupPath(group.KeyPath));
+    }
+
+    /// <summary>
+    /// Expands the specified group when collapsed and collapses it when expanded.
+    /// </summary>
+    internal void ToggleGroup(TableViewGroup group)
+    {
+        SetGroupExpanded(group, IsGroupCollapsed(group));
+    }
+
+    /// <summary>
+    /// Resolves the template a group header row should present its key with.
+    /// </summary>
+    internal DataTemplate? ResolveGroupHeaderTemplate(TableViewGroup group)
+    {
+        return GroupHeaderTemplateSelector?.SelectTemplate(group) ?? GroupHeaderTemplate;
+    }
+
+    /// <summary>
+    /// Expands or collapses a group.
+    /// </summary>
+    /// <remarks>
+    /// A group's header row sits above everything the collapse adds or removes, so its own offset does not move
+    /// and it stays put on screen without any scroll correction. Only the content below it shifts, which is what
+    /// collapsing a group is supposed to look like.
+    /// </remarks>
+    private void SetGroupExpanded(TableViewGroup group, bool isExpanded)
+    {
+        var path = new TableViewGroupPath(group.KeyPath);
+        var changed = isExpanded ? _collapsedGroups.Remove(path) : _collapsedGroups.Add(path);
+
+        if (changed)
+        {
+            RefreshVisualRows();
+        }
+    }
+}

--- a/src/TableView.ItemsHost.cs
+++ b/src/TableView.ItemsHost.cs
@@ -1,4 +1,4 @@
-using Microsoft.UI.Xaml;
+﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using System;
@@ -22,11 +22,12 @@ public partial class TableView
     private bool _isLoadingMoreItems;
 
     /// <summary>
-    /// Gets the items produced by the current sorting and filtering.
+    /// Gets the items produced by the current sorting, filtering and grouping.
     /// </summary>
     /// <remarks>
-    /// Positions in this collection are what <see cref="TableViewCellSlot.Row"/>, <see cref="SelectedRanges"/>,
-    /// the clipboard and automation all mean by "row".
+    /// Positions in this collection are <em>item indexes</em>: what <see cref="TableViewCellSlot.Row"/>,
+    /// <see cref="SelectedRanges"/>, the clipboard and automation all mean by "row". They are unaffected by group
+    /// headers and by groups being collapsed.
     /// </remarks>
     public IList<object> Items => _collectionView;
 
@@ -36,7 +37,7 @@ public partial class TableView
     internal IReadOnlyList<TableViewRow> Rows => _rows;
 
     /// <summary>
-    /// Gets the number of visual rows.
+    /// Gets the number of visual rows, counting group headers and excluding collapsed groups' contents.
     /// </summary>
     internal int VisualRowCount => _visualRows?.Count ?? 0;
 
@@ -88,7 +89,7 @@ public partial class TableView
     }
 
     /// <summary>
-    /// Converts an item index to the visual row index showing it.
+    /// Converts an item index to the visual row index showing it, or -1 when it is inside a collapsed group.
     /// </summary>
     internal int GetVisualIndexFromItemIndex(int itemIndex)
     {
@@ -101,11 +102,19 @@ public partial class TableView
     }
 
     /// <summary>
-    /// Converts a visual row index to the item index it shows.
+    /// Converts a visual row index to the item index it shows, or -1 for a group header row.
     /// </summary>
     internal int GetItemIndexFromVisualIndex(int visualIndex)
     {
         return _visualRows?.GetItemIndex(visualIndex) ?? visualIndex;
+    }
+
+    /// <summary>
+    /// Returns the group whose header sits at a visual row index, or <see langword="null"/> for a data row.
+    /// </summary>
+    internal TableViewGroup? GetGroupFromVisualIndex(int visualIndex)
+    {
+        return _visualRows?.GetGroup(visualIndex);
     }
 
     /// <summary>
@@ -146,7 +155,7 @@ public partial class TableView
         _rowsRepeater = repeater;
         _rowsLayout = new TableViewRowsLayout { TableView = this };
         _rowElementFactory = new TableViewRowElementFactory(this);
-        _visualRows = new TableViewVisualRows(_collectionView);
+        _visualRows = new TableViewVisualRows(_collectionView, IsGroupCollapsed);
 
         // A small cache keeps the realized row count close to the viewport. The repeater's default of two
         // viewports either side would triple the number of live rows, and rows are not cheap elements.
@@ -185,15 +194,29 @@ public partial class TableView
     }
 
     /// <summary>
+    /// Reprojects the flattened row sequence, for when grouping or collapse state changes.
+    /// </summary>
+    private void RefreshVisualRows()
+    {
+        _visualRows?.Reset();
+    }
+
+    /// <summary>
     /// Applies the table's state to a row as it becomes visible. Everything a row needs to look right is pushed
     /// here rather than pulled per row from the whole table, which is what keeps realization proportional to the
     /// viewport.
     /// </summary>
     private void OnRowElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
     {
-        if (args.Element is TableViewRow row)
+        switch (args.Element)
         {
-            AttachRow(row, args.Index);
+            case TableViewRow row:
+                AttachRow(row, args.Index);
+                break;
+
+            case TableViewGroupRow groupRow:
+                groupRow.VisualIndex = args.Index;
+                break;
         }
     }
 
@@ -221,9 +244,15 @@ public partial class TableView
     /// </summary>
     private void OnRowElementIndexChanged(ItemsRepeater sender, ItemsRepeaterElementIndexChangedEventArgs args)
     {
-        if (args.Element is TableViewRow row)
+        switch (args.Element)
         {
-            AttachRow(row, args.NewIndex);
+            case TableViewRow row:
+                AttachRow(row, args.NewIndex);
+                break;
+
+            case TableViewGroupRow groupRow:
+                groupRow.VisualIndex = args.NewIndex;
+                break;
         }
     }
 
@@ -286,8 +315,8 @@ public partial class TableView
                 break;
 
             case CollectionChange.ItemRemoved:
-                // The visual index has to be read before the projection is rebuilt, while it still describes
-                // where the removed row was.
+                // The visual index has to be read before the projection is rebuilt, while the run list still
+                // describes where the removed row was.
                 var removedVisualIndex = _visualRows?.GetVisualIndex(index) ?? index;
                 _rowSelection.OnItemsRemoved(index, 1);
                 _visualRows?.OnItemRemoved(removedVisualIndex, (args as VectorChangedEventArgs)?.Item);

--- a/src/TableViewGroupRow.cs
+++ b/src/TableViewGroupRow.cs
@@ -1,0 +1,247 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
+using System.Windows.Input;
+using Windows.System;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Represents a group header row in a <see cref="WinUI.TableView.TableView"/>.
+/// </summary>
+/// <remarks>
+/// Group header rows are visual only: they carry no cell slot, take no part in item selection, and are stepped
+/// over by cell navigation. They are realized and recycled by the same row host as data rows, so a collapsed
+/// group costs one realized element regardless of how many items it hides.
+/// </remarks>
+#if WINDOWS
+[WinRT.GeneratedBindableCustomProperty]
+#endif
+[TemplateVisualState(Name = VisualStates.StateExpanded, GroupName = VisualStates.GroupExpandCollapse)]
+[TemplateVisualState(Name = VisualStates.StateCollapsed, GroupName = VisualStates.GroupExpandCollapse)]
+public partial class TableViewGroupRow : Control
+{
+    private const double DefaultIndentSize = 20d;
+    private ToggleButton? _expanderButton;
+
+    /// <summary>
+    /// Identifies the <see cref="Indent"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty IndentProperty = DependencyProperty.Register(
+        nameof(Indent), typeof(double), typeof(TableViewGroupRow), new PropertyMetadata(0d));
+
+    /// <summary>
+    /// Identifies the <see cref="ItemCount"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty ItemCountProperty = DependencyProperty.Register(
+        nameof(ItemCount), typeof(int), typeof(TableViewGroupRow), new PropertyMetadata(0));
+
+    /// <summary>
+    /// Identifies the <see cref="IsExpanded"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty IsExpandedProperty = DependencyProperty.Register(
+        nameof(IsExpanded), typeof(bool), typeof(TableViewGroupRow), new PropertyMetadata(true, OnIsExpandedChanged));
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableViewGroupRow"/> class.
+    /// </summary>
+    public TableViewGroupRow()
+    {
+        DefaultStyleKey = typeof(TableViewGroupRow);
+    }
+
+    /// <summary>
+    /// Gets the group this row is the header for.
+    /// </summary>
+    public TableViewGroup? Group { get; private set; }
+
+    /// <summary>
+    /// Gets the index of this row within the flattened visual row sequence, or -1 when not realized.
+    /// </summary>
+    internal int VisualIndex { get; set; } = -1;
+
+    /// <summary>
+    /// Gets the <see cref="WinUI.TableView.TableView"/> that owns this row.
+    /// </summary>
+    public TableView? TableView { get; internal set; }
+
+    /// <summary>
+    /// Gets the horizontal indent, in pixels, produced by the group's nesting level.
+    /// </summary>
+    public double Indent
+    {
+        get => (double)GetValue(IndentProperty);
+        private set => SetValue(IndentProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the number of items the group covers.
+    /// </summary>
+    public int ItemCount
+    {
+        get => (int)GetValue(ItemCountProperty);
+        private set => SetValue(ItemCountProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the group's contents are shown.
+    /// </summary>
+    public bool IsExpanded
+    {
+        get => (bool)GetValue(IsExpandedProperty);
+        set => SetValue(IsExpandedProperty, value);
+    }
+
+    /// <summary>
+    /// Binds this row to a group. Called by the row host when the element is prepared or reused.
+    /// </summary>
+    internal void PrepareForGroup(TableViewGroup group, DataTemplate? headerTemplate, bool isExpanded)
+    {
+        Group = group;
+        Indent = group.Level * DefaultIndentSize;
+        ItemCount = group.ItemCount;
+        Content = group;
+        ContentTemplate = headerTemplate;
+
+        SetValue(IsExpandedProperty, isExpanded);
+        UpdateVisualState();
+    }
+
+    /// <summary>
+    /// Clears the per-group state so the element can be reused for a different group.
+    /// </summary>
+    internal void PrepareForRecycle()
+    {
+        Group = null;
+        Content = null;
+    }
+
+    /// <summary>
+    /// Gets or sets the content shown in the header, which is the group itself.
+    /// </summary>
+    internal object? Content
+    {
+        get;
+        set
+        {
+            field = value;
+
+            if (GetTemplateChild(HeaderPresenterPart) is ContentPresenter presenter)
+            {
+                presenter.Content = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the template used to present the group key.
+    /// </summary>
+    internal DataTemplate? ContentTemplate
+    {
+        get;
+        set
+        {
+            field = value;
+
+            if (GetTemplateChild(HeaderPresenterPart) is ContentPresenter presenter)
+            {
+                presenter.ContentTemplate = value;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        if (_expanderButton is not null)
+        {
+            _expanderButton.Click -= OnExpanderButtonClick;
+        }
+
+        _expanderButton = GetTemplateChild(ExpanderButtonPart) as ToggleButton;
+
+        if (_expanderButton is not null)
+        {
+            _expanderButton.Click += OnExpanderButtonClick;
+        }
+
+        if (GetTemplateChild(HeaderPresenterPart) is ContentPresenter presenter)
+        {
+            presenter.Content = Content;
+            presenter.ContentTemplate = ContentTemplate;
+        }
+
+        UpdateVisualState();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnKeyDown(KeyRoutedEventArgs e)
+    {
+        // Space and Enter toggle the group, which is the only interaction a header row offers.
+        if (e.Key is VirtualKey.Space or VirtualKey.Enter)
+        {
+            Toggle();
+            e.Handled = true;
+
+            return;
+        }
+
+        base.OnKeyDown(e);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
+    {
+        base.OnDoubleTapped(e);
+
+        Toggle();
+        e.Handled = true;
+    }
+
+    /// <inheritdoc/>
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return new AutomationPeers.TableViewGroupRowAutomationPeer(this);
+    }
+
+    /// <summary>
+    /// Expands the group when it is collapsed, and collapses it when it is expanded.
+    /// </summary>
+    internal void Toggle()
+    {
+        if (Group is { } group)
+        {
+            TableView?.ToggleGroup(group);
+        }
+    }
+
+    private void OnExpanderButtonClick(object sender, RoutedEventArgs e)
+    {
+        Toggle();
+    }
+
+    private static void OnIsExpandedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableViewGroupRow row)
+        {
+            row.UpdateVisualState();
+        }
+    }
+
+    private void UpdateVisualState()
+    {
+        if (_expanderButton is not null)
+        {
+            _expanderButton.IsChecked = IsExpanded;
+        }
+
+        VisualStates.GoToState(this, true, IsExpanded ? VisualStates.StateExpanded : VisualStates.StateCollapsed);
+    }
+
+    private const string ExpanderButtonPart = "ExpanderButton";
+    private const string HeaderPresenterPart = "HeaderPresenter";
+}

--- a/src/Themes/Generic.xaml
+++ b/src/Themes/Generic.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:WinUI.TableView"
                     xmlns:controls="using:WinUI.TableView.Controls">
@@ -11,6 +11,7 @@
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewHeaderRow.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewRow.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewRowHeader.xaml" />
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewGroupRow.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewTimePicker.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
@@ -34,6 +35,9 @@
 
     <Style TargetType="local:TableViewRow"
            BasedOn="{StaticResource DefaultTableViewRowStyle}" />
+
+    <Style TargetType="local:TableViewGroupRow"
+           BasedOn="{StaticResource DefaultTableViewGroupRowStyle}" />
 
     <Style TargetType="local:TableView"
            BasedOn="{StaticResource DefaultTableViewStyle}" />

--- a/src/Themes/Resources.xaml
+++ b/src/Themes/Resources.xaml
@@ -76,6 +76,8 @@
             <SolidColorBrush x:Key="TableViewDragRectangleFill" Color="{StaticResource SystemAccentColor}" Opacity="0.2" />
             <StaticResource x:Key="TableViewDragRectangleStroke" ResourceKey="AccentFillColorDefaultBrush" />
             <CornerRadius x:Key="TableViewDragRectangleCornerRadius">0</CornerRadius>
+            <StaticResource x:Key="TableViewGroupRowBackground" ResourceKey="CardBackgroundFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewGroupRowForeground" ResourceKey="TextFillColorPrimaryBrush" />
         </ResourceDictionary>
         
         <ResourceDictionary x:Key="Dark">
@@ -147,6 +149,8 @@
             <SolidColorBrush x:Key="TableViewDragRectangleFill" Color="{StaticResource SystemAccentColor}" Opacity="0.2" />
             <StaticResource x:Key="TableViewDragRectangleStroke" ResourceKey="AccentFillColorDefaultBrush" />
             <CornerRadius x:Key="TableViewDragRectangleCornerRadius">0</CornerRadius>
+            <StaticResource x:Key="TableViewGroupRowBackground" ResourceKey="CardBackgroundFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewGroupRowForeground" ResourceKey="TextFillColorPrimaryBrush" />
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
@@ -218,8 +222,14 @@
             <SolidColorBrush x:Key="TableViewDragRectangleFill" Color="{ThemeResource SystemColorHighlightColor}" Opacity="0.3" />
             <SolidColorBrush x:Key="TableViewDragRectangleStroke" Color="{ThemeResource SystemColorHighlightColor}" />
             <CornerRadius x:Key="TableViewDragRectangleCornerRadius">0</CornerRadius>
+            <SolidColorBrush x:Key="TableViewGroupRowBackground" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="TableViewGroupRowForeground" Color="{ThemeResource SystemColorWindowTextColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
+
+    <x:Double x:Key="TableViewGroupRowMinHeight">36</x:Double>
+    <Thickness x:Key="TableViewGroupRowExpanderMargin">4,0,0,0</Thickness>
+    <Thickness x:Key="TableViewGroupRowContentMargin">8,0</Thickness>
 
     <Style x:Key="DetailsExpanderToggleButtonStyle"
            TargetType="ToggleButton">

--- a/src/Themes/TableViewGroupRow.xaml
+++ b/src/Themes/TableViewGroupRow.xaml
@@ -1,0 +1,90 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="using:WinUI.TableView">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <Style x:Key="DefaultTableViewGroupRowStyle"
+           TargetType="local:TableViewGroupRow">
+        <Setter Property="Background"
+                Value="{ThemeResource TableViewGroupRowBackground}" />
+        <Setter Property="Foreground"
+                Value="{ThemeResource TableViewGroupRowForeground}" />
+        <Setter Property="MinHeight"
+                Value="{ThemeResource TableViewGroupRowMinHeight}" />
+        <Setter Property="HorizontalContentAlignment"
+                Value="Stretch" />
+        <Setter Property="VerticalContentAlignment"
+                Value="Center" />
+        <Setter Property="IsTabStop"
+                Value="True" />
+        <Setter Property="UseSystemFocusVisuals"
+                Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="local:TableViewGroupRow">
+                    <Grid x:Name="RootGrid"
+                          Background="{TemplateBinding Background}">
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="ExpandCollapseStates">
+                                <VisualState x:Name="Expanded" />
+                                <VisualState x:Name="Collapsed" />
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition x:Name="IndentColumn"
+                                              Width="Auto" />
+                            <ColumnDefinition x:Name="ExpanderColumn"
+                                              Width="Auto" />
+                            <ColumnDefinition x:Name="HeaderColumn"
+                                              Width="*" />
+                            <ColumnDefinition x:Name="ItemCountColumn"
+                                              Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <Border Width="{Binding Indent, RelativeSource={RelativeSource TemplatedParent}}" />
+
+                        <ToggleButton x:Name="ExpanderButton"
+                                      Grid.Column="1"
+                                      VerticalAlignment="Center"
+                                      Margin="{ThemeResource TableViewGroupRowExpanderMargin}"
+                                      Style="{StaticResource DetailsExpanderToggleButtonStyle}" />
+
+                        <ContentPresenter x:Name="HeaderPresenter"
+                                          Grid.Column="2"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          HorizontalAlignment="Left"
+                                          Margin="{ThemeResource TableViewGroupRowContentMargin}"
+                                          Foreground="{TemplateBinding Foreground}" />
+
+                        <TextBlock x:Name="ItemCountText"
+                                   Grid.Column="3"
+                                   VerticalAlignment="Center"
+                                   Margin="{ThemeResource TableViewGroupRowContentMargin}"
+                                   Opacity="0.7"
+                                   Foreground="{TemplateBinding Foreground}"
+                                   Text="{Binding ItemCount, RelativeSource={RelativeSource TemplatedParent}}" />
+
+                        <Rectangle x:Name="HorizontalGridLine"
+                                   Grid.Row="1"
+                                   Grid.ColumnSpan="4"
+                                   HorizontalAlignment="Stretch"
+                                   IsHitTestVisible="False"
+                                   Height="{ThemeResource TableViewHorizontalGridLineStrokeThickness}"
+                                   Fill="{ThemeResource TableViewHorizontalGridLineStroke}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/VisualStates.cs
+++ b/src/VisualStates.cs
@@ -76,6 +76,11 @@ internal static class VisualStates
     /// <summary>
     /// Expanded state
     /// </summary>
+    /// <summary>
+    /// The name of the visual state group holding <see cref="StateExpanded"/> and <see cref="StateCollapsed"/>.
+    /// </summary>
+    public const string GroupExpandCollapse = "ExpandCollapseStates";
+
     public const string StateExpanded = "Expanded";
 
     /// <summary>

--- a/tests/CollectionViewGroupingTests.cs
+++ b/tests/CollectionViewGroupingTests.cs
@@ -1,0 +1,331 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+
+namespace WinUI.TableView.Tests;
+
+[TestClass]
+public class CollectionViewGroupingTests
+{
+    [UITestMethod]
+    public void NoGroupDescriptions_MeansNoGroups()
+    {
+        var view = new CollectionView(CreateItems());
+
+        Assert.IsFalse(view.IsGrouped);
+        Assert.AreEqual(0, view.Groups.Count);
+    }
+
+    [UITestMethod]
+    public void SingleLevel_GroupsItemsAndOrdersThemByKey()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        Assert.IsTrue(view.IsGrouped);
+
+        var groups = view.Groups;
+        Assert.AreEqual(2, groups.Count);
+
+        Assert.AreEqual("Fruit", groups[0].Key);
+        Assert.AreEqual(0, groups[0].Level);
+        Assert.AreEqual(0, groups[0].FirstItemIndex);
+        Assert.AreEqual(3, groups[0].ItemCount);
+        Assert.AreEqual(2, groups[0].LastItemIndex);
+        Assert.IsNull(groups[0].Parent);
+
+        Assert.AreEqual("Veg", groups[1].Key);
+        Assert.AreEqual(3, groups[1].FirstItemIndex);
+        Assert.AreEqual(2, groups[1].ItemCount);
+
+        // Items are laid out grouped, so every item in a group sits inside that group's span.
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.AreEqual("Fruit", ((GroupItem)view[i]!).Category);
+        }
+
+        for (var i = 3; i < 5; i++)
+        {
+            Assert.AreEqual("Veg", ((GroupItem)view[i]!).Category);
+        }
+    }
+
+    [UITestMethod]
+    public void GroupDescriptionDirection_OrdersTheGroups()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category), SortDirection.Descending));
+
+        Assert.AreEqual("Veg", view.Groups[0].Key);
+        Assert.AreEqual("Fruit", view.Groups[1].Key);
+    }
+
+    [UITestMethod]
+    public void MultiLevel_ProducesNestedGroupsInDocumentOrder()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Colour)));
+
+        var groups = view.Groups;
+
+        // Fruit(3) > Green(1), Red(2) ; Veg(2) > Green(1), Red(1)
+        Assert.AreEqual(6, groups.Count);
+
+        Assert.AreEqual("Fruit", groups[0].Key);
+        Assert.AreEqual(0, groups[0].Level);
+        Assert.AreEqual(3, groups[0].ItemCount);
+
+        Assert.AreEqual("Green", groups[1].Key);
+        Assert.AreEqual(1, groups[1].Level);
+        Assert.AreSame(groups[0], groups[1].Parent);
+        Assert.AreEqual(1, groups[1].ItemCount);
+
+        Assert.AreEqual("Red", groups[2].Key);
+        Assert.AreEqual(1, groups[2].Level);
+        Assert.AreSame(groups[0], groups[2].Parent);
+        Assert.AreEqual(2, groups[2].ItemCount);
+
+        Assert.AreEqual("Veg", groups[3].Key);
+        Assert.AreEqual(0, groups[3].Level);
+
+        // The inner "Green" key repeats under a different outer group, which must be a separate group.
+        Assert.AreEqual("Green", groups[4].Key);
+        Assert.AreEqual(1, groups[4].Level);
+        Assert.AreSame(groups[3], groups[4].Parent);
+        Assert.AreNotSame(groups[1], groups[4]);
+
+        CollectionAssert.AreEqual(new object?[] { "Veg", "Green" }, groups[4].KeyPath.ToArray());
+    }
+
+    [UITestMethod]
+    public void SortDescriptions_OrderItemsWithinEachGroup()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+        view.SortDescriptions.Add(new SortDescription(nameof(GroupItem.Name), SortDirection.Ascending));
+
+        var names = view.Cast<GroupItem>().Select(x => x.Name).ToArray();
+
+        CollectionAssert.AreEqual(new[] { "Apple", "Banana", "Cherry", "Broccoli", "Tomato" }, names);
+    }
+
+    [UITestMethod]
+    public void Filtering_ExcludesItemsAndDropsEmptyGroups()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+        view.FilterDescriptions.Add(new FilterDescription(nameof(GroupItem.Category), o => ((GroupItem)o!).Category == "Veg"));
+
+        Assert.AreEqual(2, view.Count);
+        Assert.AreEqual(1, view.Groups.Count);
+        Assert.AreEqual("Veg", view.Groups[0].Key);
+        Assert.AreEqual(0, view.Groups[0].FirstItemIndex);
+        Assert.AreEqual(2, view.Groups[0].ItemCount);
+    }
+
+    [UITestMethod]
+    public void AddingAnItemToAnExistingGroup_GrowsItAndShiftsLaterGroups()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        source.Add(new GroupItem { Category = "Fruit", Colour = "Red", Name = "Plum" });
+
+        Assert.AreEqual(2, view.Groups.Count);
+        Assert.AreEqual(4, view.Groups[0].ItemCount);
+        Assert.AreEqual(0, view.Groups[0].FirstItemIndex);
+        Assert.AreEqual(4, view.Groups[1].FirstItemIndex);
+        Assert.AreEqual(2, view.Groups[1].ItemCount);
+    }
+
+    [UITestMethod]
+    public void AddingAnItemThatStartsANewGroup_CreatesTheGroup()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        source.Add(new GroupItem { Category = "Grain", Colour = "Brown", Name = "Rice" });
+
+        Assert.AreEqual(3, view.Groups.Count);
+        Assert.AreEqual("Fruit", view.Groups[0].Key);
+        Assert.AreEqual("Grain", view.Groups[1].Key);
+        Assert.AreEqual(1, view.Groups[1].ItemCount);
+        Assert.AreEqual("Veg", view.Groups[2].Key);
+        Assert.AreEqual(4, view.Groups[2].FirstItemIndex);
+    }
+
+    [UITestMethod]
+    public void RemovingTheLastItemOfAGroup_RemovesTheGroup()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        foreach (var item in source.Where(x => x.Category == "Veg").ToList())
+        {
+            source.Remove(item);
+        }
+
+        Assert.AreEqual(1, view.Groups.Count);
+        Assert.AreEqual("Fruit", view.Groups[0].Key);
+        Assert.AreEqual(3, view.Groups[0].ItemCount);
+    }
+
+    [UITestMethod]
+    public void RemovingAnItemFromTheMiddle_ShrinksItsGroupAndShiftsLaterGroups()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        source.Remove(source.First(x => x.Category == "Fruit"));
+
+        Assert.AreEqual(2, view.Groups.Count);
+        Assert.AreEqual(2, view.Groups[0].ItemCount);
+        Assert.AreEqual(2, view.Groups[1].FirstItemIndex);
+        Assert.AreEqual(2, view.Groups[1].ItemCount);
+    }
+
+    [UITestMethod]
+    public void ChangingAnItemsGroupKey_MovesItBetweenGroups()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        var apple = source.First(x => x.Name == "Apple");
+        apple.Category = "Veg";
+
+        Assert.AreEqual(2, view.Groups.Count);
+        Assert.AreEqual("Fruit", view.Groups[0].Key);
+        Assert.AreEqual(2, view.Groups[0].ItemCount);
+        Assert.AreEqual("Veg", view.Groups[1].Key);
+        Assert.AreEqual(3, view.Groups[1].ItemCount);
+
+        // The item really moved into the Veg span.
+        Assert.IsTrue(view.IndexOf(apple) >= view.Groups[1].FirstItemIndex);
+    }
+
+    [UITestMethod]
+    public void ChangingTheLastItemOfAGroup_RemovesTheEmptiedGroup()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        foreach (var item in source.Where(x => x.Category == "Veg").ToList())
+        {
+            item.Category = "Fruit";
+        }
+
+        Assert.AreEqual(1, view.Groups.Count);
+        Assert.AreEqual("Fruit", view.Groups[0].Key);
+        Assert.AreEqual(5, view.Groups[0].ItemCount);
+    }
+
+    [UITestMethod]
+    public void ClearingGroupDescriptions_RemovesAllGroups()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        Assert.AreEqual(2, view.Groups.Count);
+
+        view.GroupDescriptions.Clear();
+
+        Assert.IsFalse(view.IsGrouped);
+        Assert.AreEqual(0, view.Groups.Count);
+    }
+
+    [UITestMethod]
+    public void DeferRefresh_DelaysGroupingUntilDisposed()
+    {
+        var view = new CollectionView(CreateItems());
+
+        using (view.DeferRefresh())
+        {
+            view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+            Assert.AreEqual(0, view.Groups.Count, "grouping should not have been applied yet");
+        }
+
+        Assert.AreEqual(2, view.Groups.Count);
+    }
+
+    [UITestMethod]
+    public void RefreshGrouping_RebuildsGroupsAfterAnUntrackedChange()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source, liveShapingEnabled: false);
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        source.First(x => x.Name == "Apple").Category = "Veg";
+        Assert.AreEqual(3, view.Groups[0].ItemCount, "live shaping is off, so nothing moved yet");
+
+        view.RefreshGrouping();
+
+        Assert.AreEqual(2, view.Groups[0].ItemCount);
+        Assert.AreEqual(3, view.Groups[1].ItemCount);
+    }
+
+    [UITestMethod]
+    public void GroupSpansStayContiguousAndCoverEveryItem()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Colour)));
+
+        // Every top-level group's span, concatenated, must exactly cover the view.
+        var expectedStart = 0;
+
+        foreach (var group in view.Groups.Where(g => g.Level is 0))
+        {
+            Assert.AreEqual(expectedStart, group.FirstItemIndex);
+            expectedStart += group.ItemCount;
+        }
+
+        Assert.AreEqual(view.Count, expectedStart);
+    }
+
+    private static ObservableCollection<GroupItem> CreateItems()
+    {
+        return
+        [
+            new GroupItem { Category = "Veg", Colour = "Red", Name = "Tomato" },
+            new GroupItem { Category = "Fruit", Colour = "Red", Name = "Cherry" },
+            new GroupItem { Category = "Fruit", Colour = "Green", Name = "Apple" },
+            new GroupItem { Category = "Veg", Colour = "Green", Name = "Broccoli" },
+            new GroupItem { Category = "Fruit", Colour = "Red", Name = "Banana" },
+        ];
+    }
+}
+
+internal sealed class GroupItem : INotifyPropertyChanged
+{
+    private string _category = string.Empty;
+
+    public string Category
+    {
+        get => _category;
+        set
+        {
+            if (_category != value)
+            {
+                _category = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Category)));
+            }
+        }
+    }
+
+    public string Colour { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public override string ToString() => $"{Category}/{Colour}/{Name}";
+}

--- a/tests/TableViewRowHostTests.cs
+++ b/tests/TableViewRowHostTests.cs
@@ -15,7 +15,7 @@ namespace WinUI.TableView.Tests;
 
 /// <summary>
 /// Tests the ItemsRepeater-based row host: that realization tracks the viewport rather than the item count, that
-/// rows are recycled, and that selection does not force rows to be realized.
+/// rows are recycled, and that grouping and selection do not force rows to be realized.
 /// </summary>
 [TestClass]
 public class TableViewRowHostTests
@@ -74,6 +74,61 @@ public class TableViewRowHostTests
         for (var i = 1; i < ordered.Count; i++)
         {
             Assert.AreEqual(ordered[i - 1].Index + 1, ordered[i].Index, "realized rows should be a contiguous run");
+        }
+
+        await UnitTestApp.Current.MainWindow.UnloadTestContentAsync(tableView);
+    }
+
+    [UITestMethod]
+    public async Task GroupHeaderTemplate_AppliesAndTracksExpandState()
+    {
+        var tableView = await CreateTableViewAsync(itemCount: 60);
+        tableView.GroupDescriptions.Add(new GroupDescription(nameof(HostItem.Category)));
+
+        await WaitForLayoutAsync(tableView);
+
+        var headerRows = tableView.FindDescendants().OfType<TableViewGroupRow>().Where(x => x.IsLoaded).ToList();
+        Assert.IsTrue(headerRows.Count > 0);
+
+        var first = headerRows.OrderBy(x => x.VisualIndex).First();
+
+        Assert.IsNotNull(first.Group);
+        Assert.IsTrue(first.IsExpanded);
+        Assert.AreEqual(first.Group!.ItemCount, first.ItemCount);
+        Assert.AreEqual(0d, first.Indent, "a top-level group is not indented");
+        Assert.IsTrue(first.ActualHeight > 0, "a realized group header should have been arranged");
+
+        tableView.CollapseGroup(first.Group);
+        await WaitForLayoutAsync(tableView);
+
+        var afterCollapse = tableView.FindDescendants()
+                                     .OfType<TableViewGroupRow>()
+                                     .FirstOrDefault(x => x.IsLoaded && ReferenceEquals(x.Group, first.Group));
+
+        Assert.IsNotNull(afterCollapse, "the collapsed group keeps its header row");
+        Assert.IsFalse(afterCollapse!.IsExpanded);
+
+        await UnitTestApp.Current.MainWindow.UnloadTestContentAsync(tableView);
+    }
+
+    [UITestMethod]
+    public async Task NestedGroups_AreIndentedByLevel()
+    {
+        var tableView = await CreateTableViewAsync(itemCount: 60);
+        tableView.GroupDescriptions.Add(new GroupDescription(nameof(HostItem.Category)));
+        tableView.GroupDescriptions.Add(new GroupDescription(nameof(HostItem.Name)));
+
+        await WaitForLayoutAsync(tableView);
+
+        var headerRows = tableView.FindDescendants().OfType<TableViewGroupRow>().Where(x => x.IsLoaded).ToList();
+
+        Assert.IsTrue(headerRows.Any(x => x.Group?.Level is 0));
+        Assert.IsTrue(headerRows.Any(x => x.Group?.Level is 1));
+
+        foreach (var headerRow in headerRows)
+        {
+            Assert.IsTrue(headerRow.Indent > 0 == headerRow.Group?.Level > 0,
+                "indent should follow the nesting level");
         }
 
         await UnitTestApp.Current.MainWindow.UnloadTestContentAsync(tableView);
@@ -173,6 +228,83 @@ public class TableViewRowHostTests
         await UnitTestApp.Current.MainWindow.UnloadTestContentAsync(tableView);
     }
 
+    [UITestMethod]
+    public async Task Grouping_AddsHeaderRowsWithoutChangingItemIndexes()
+    {
+        var tableView = await CreateTableViewAsync(itemCount: 60);
+        tableView.GroupDescriptions.Add(new GroupDescription(nameof(HostItem.Category)));
+
+        await WaitForLayoutAsync(tableView);
+
+        Assert.IsTrue(tableView.IsGrouped);
+        Assert.AreEqual(3, tableView.Groups.Count, "60 items across 3 categories");
+        Assert.AreEqual(60, tableView.Items.Count, "grouping must not change the item count");
+
+        var groupRows = tableView.FindDescendants().OfType<TableViewGroupRow>().Where(x => x.IsLoaded).ToList();
+        Assert.IsTrue(groupRows.Count > 0, "group header rows should be realized");
+        Assert.IsTrue(groupRows.All(x => x.Group is not null));
+
+        // Cell slots still address items, so every realized row's index still points at the item it shows even
+        // though header rows have been interleaved into the visual sequence.
+        var dataRows = RealizedRows(tableView).Where(x => x.Index >= 0).ToList();
+
+        Assert.IsTrue(dataRows.Count > 0, "data rows should be realized alongside the headers");
+
+        foreach (var dataRow in dataRows)
+        {
+            Assert.AreSame(tableView.Items[dataRow.Index], dataRow.Content, $"row {dataRow.Index} shows the wrong item");
+        }
+
+        await UnitTestApp.Current.MainWindow.UnloadTestContentAsync(tableView);
+    }
+
+    [UITestMethod]
+    public async Task CollapsingAGroup_HidesItsRowsAndKeepsSelectionIndexes()
+    {
+        var tableView = await CreateTableViewAsync(itemCount: 60);
+        tableView.GroupDescriptions.Add(new GroupDescription(nameof(HostItem.Category)));
+
+        await WaitForLayoutAsync(tableView);
+
+        tableView.SelectRange(new ItemIndexRange(0, 5));
+        var expandedVisualCount = VisualRowCount(tableView);
+
+        tableView.CollapseGroup(tableView.Groups[0]);
+        await WaitForLayoutAsync(tableView);
+
+        Assert.IsTrue(VisualRowCount(tableView) < expandedVisualCount, "collapsing must shorten the visual sequence");
+        Assert.AreEqual(60, tableView.Items.Count, "collapsing must not change the items");
+        Assert.AreEqual(5, tableView.SelectedItems.Count, "collapsing must not change the selection");
+        Assert.IsTrue(tableView.IsRowSelected(0));
+
+        tableView.ExpandGroup(tableView.Groups[0]);
+        await WaitForLayoutAsync(tableView);
+
+        Assert.AreEqual(expandedVisualCount, VisualRowCount(tableView));
+
+        await UnitTestApp.Current.MainWindow.UnloadTestContentAsync(tableView);
+    }
+
+    [UITestMethod]
+    public async Task CollapseAndExpandAllGroups_Work()
+    {
+        var tableView = await CreateTableViewAsync(itemCount: 60);
+        tableView.GroupDescriptions.Add(new GroupDescription(nameof(HostItem.Category)));
+
+        await WaitForLayoutAsync(tableView);
+
+        tableView.CollapseAllGroups();
+        await WaitForLayoutAsync(tableView);
+
+        Assert.AreEqual(3, VisualRowCount(tableView), "only the three headers should remain");
+
+        tableView.ExpandAllGroups();
+        await WaitForLayoutAsync(tableView);
+
+        Assert.AreEqual(63, VisualRowCount(tableView), "three headers plus sixty items");
+
+        await UnitTestApp.Current.MainWindow.UnloadTestContentAsync(tableView);
+    }
 
     [UITestMethod]
     public async Task AddingAndRemovingOneItem_KeepsTheRealizedSetSmall()
@@ -214,6 +346,12 @@ public class TableViewRowHostTests
     private static List<TableViewRow> RealizedRows(TableView tableView)
     {
         return [.. tableView.FindDescendants().OfType<TableViewRow>().Where(x => x.IsLoaded)];
+    }
+
+    private static int VisualRowCount(TableView tableView)
+    {
+        // Header rows plus visible data rows, which is what the layout works in.
+        return tableView.VisualRowCount;
     }
 
     private static async Task ScrollToAsync(TableView tableView, double verticalOffset)

--- a/tests/TableViewVisualRowsTests.cs
+++ b/tests/TableViewVisualRowsTests.cs
@@ -1,0 +1,282 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+
+namespace WinUI.TableView.Tests;
+
+[TestClass]
+public class TableViewVisualRowsTests
+{
+    [UITestMethod]
+    public void Ungrouped_IsAOneToOneProjection()
+    {
+        var view = new CollectionView(CreateItems());
+        var rows = new TableViewVisualRows(view, _ => false);
+
+        Assert.IsFalse(rows.HasGroups);
+        Assert.AreEqual(5, rows.Count);
+
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.AreEqual(i, rows.GetItemIndex(i));
+            Assert.AreEqual(i, rows.GetVisualIndex(i));
+            Assert.AreSame(view[i], rows[i]);
+            Assert.IsNull(rows.GetGroup(i));
+        }
+
+        Assert.AreEqual(-1, rows.GetItemIndex(5));
+        Assert.AreEqual(-1, rows.GetVisualIndex(5));
+        Assert.AreEqual(-1, rows.GetVisualIndex(-1));
+    }
+
+    [UITestMethod]
+    public void Grouped_InterleavesHeaderRows()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        var rows = new TableViewVisualRows(view, _ => false);
+
+        // header(Fruit) 3 items header(Veg) 2 items
+        Assert.IsTrue(rows.HasGroups);
+        Assert.AreEqual(7, rows.Count);
+
+        Assert.IsNotNull(rows.GetGroup(0));
+        Assert.AreEqual("Fruit", rows.GetGroup(0)!.Key);
+        Assert.AreEqual(-1, rows.GetItemIndex(0));
+
+        Assert.AreEqual(0, rows.GetItemIndex(1));
+        Assert.AreEqual(1, rows.GetItemIndex(2));
+        Assert.AreEqual(2, rows.GetItemIndex(3));
+
+        Assert.IsNotNull(rows.GetGroup(4));
+        Assert.AreEqual("Veg", rows.GetGroup(4)!.Key);
+
+        Assert.AreEqual(3, rows.GetItemIndex(5));
+        Assert.AreEqual(4, rows.GetItemIndex(6));
+
+        // And back the other way.
+        Assert.AreEqual(1, rows.GetVisualIndex(0));
+        Assert.AreEqual(3, rows.GetVisualIndex(2));
+        Assert.AreEqual(5, rows.GetVisualIndex(3));
+        Assert.AreEqual(6, rows.GetVisualIndex(4));
+    }
+
+    [UITestMethod]
+    public void MultiLevel_EmitsAHeaderPerLevel()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Colour)));
+
+        var rows = new TableViewVisualRows(view, _ => false);
+
+        // Fruit > Green(1) Red(2) ; Veg > Green(1) Red(1)  =>  6 headers + 5 items
+        Assert.AreEqual(11, rows.Count);
+
+        Assert.AreEqual(0, rows.GetGroup(0)!.Level);
+        Assert.AreEqual(1, rows.GetGroup(1)!.Level);
+        Assert.AreEqual(0, rows.GetItemIndex(2));
+
+        // Every item still maps to exactly one visual row and back.
+        for (var itemIndex = 0; itemIndex < view.Count; itemIndex++)
+        {
+            var visualIndex = rows.GetVisualIndex(itemIndex);
+            Assert.IsTrue(visualIndex >= 0, $"item {itemIndex} should be visible");
+            Assert.AreEqual(itemIndex, rows.GetItemIndex(visualIndex));
+        }
+    }
+
+    [UITestMethod]
+    public void CollapsedGroup_HidesItsItemsButKeepsItsHeader()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        var rows = new TableViewVisualRows(view, group => Equals(group.Key, "Fruit"));
+
+        // header(Fruit) header(Veg) 2 items
+        Assert.AreEqual(4, rows.Count);
+        Assert.AreEqual("Fruit", rows.GetGroup(0)!.Key);
+        Assert.AreEqual("Veg", rows.GetGroup(1)!.Key);
+        Assert.AreEqual(3, rows.GetItemIndex(2));
+        Assert.AreEqual(4, rows.GetItemIndex(3));
+
+        // The hidden items map to no visual row.
+        Assert.AreEqual(-1, rows.GetVisualIndex(0));
+        Assert.AreEqual(-1, rows.GetVisualIndex(1));
+        Assert.AreEqual(-1, rows.GetVisualIndex(2));
+        Assert.AreEqual(2, rows.GetVisualIndex(3));
+    }
+
+    [UITestMethod]
+    public void CollapsingAnOuterGroup_AlsoHidesItsNestedHeaders()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Colour)));
+
+        var rows = new TableViewVisualRows(view, group => group.Level is 0 && Equals(group.Key, "Fruit"));
+
+        // header(Fruit) then header(Veg) header(Green) item header(Red) item
+        Assert.AreEqual(6, rows.Count);
+        Assert.AreEqual("Fruit", rows.GetGroup(0)!.Key);
+        Assert.AreEqual("Veg", rows.GetGroup(1)!.Key);
+        Assert.AreEqual(1, rows.GetGroup(2)!.Level);
+    }
+
+    [UITestMethod]
+    public void EverythingCollapsed_LeavesOnlyTopLevelHeaders()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        var rows = new TableViewVisualRows(view, _ => true);
+
+        Assert.AreEqual(2, rows.Count);
+        Assert.AreEqual(-1, rows.GetItemIndex(0));
+        Assert.AreEqual(-1, rows.GetItemIndex(1));
+    }
+
+    [UITestMethod]
+    public void EmptyView_ProjectsNothing()
+    {
+        var view = new CollectionView(new ObservableCollection<GroupItem>());
+        var rows = new TableViewVisualRows(view, _ => false);
+
+        Assert.AreEqual(0, rows.Count);
+        Assert.IsFalse(rows.HasGroups);
+        Assert.AreEqual(-1, rows.GetItemIndex(0));
+        Assert.AreEqual(-1, rows.GetVisualIndex(0));
+    }
+
+    [UITestMethod]
+    public void IndexOf_FindsItemsAndGroupHeaders()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        var rows = new TableViewVisualRows(view, _ => false);
+        var vegGroup = view.Groups[1];
+
+        Assert.AreEqual(4, rows.IndexOf(vegGroup));
+        Assert.AreEqual(1, rows.IndexOf(view[0]));
+        Assert.AreEqual(-1, rows.IndexOf(new GroupItem()));
+    }
+
+    [UITestMethod]
+    public void OnItemInserted_IntoAnExistingGroup_ReportsASingleAdd()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        var rows = new TableViewVisualRows(view, _ => false);
+        var events = Record(rows);
+
+        source.Add(new GroupItem { Category = "Fruit", Colour = "Red", Name = "Plum" });
+        rows.OnItemInserted(view.IndexOf(source[^1]));
+
+        Assert.AreEqual(8, rows.Count);
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(NotifyCollectionChangedAction.Add, events[0].Action);
+    }
+
+    [UITestMethod]
+    public void OnItemInserted_ThatCreatesAGroup_ReportsAReset()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        var rows = new TableViewVisualRows(view, _ => false);
+        var events = Record(rows);
+
+        source.Add(new GroupItem { Category = "Grain", Colour = "Brown", Name = "Rice" });
+        rows.OnItemInserted(view.IndexOf(source[^1]));
+
+        // A new header row plus the item: two more rows, so a single add cannot describe it.
+        Assert.AreEqual(9, rows.Count);
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(NotifyCollectionChangedAction.Reset, events[0].Action);
+    }
+
+    [UITestMethod]
+    public void OnItemInserted_Ungrouped_ReportsASingleAdd()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        var rows = new TableViewVisualRows(view, _ => false);
+        var events = Record(rows);
+
+        source.Add(new GroupItem { Category = "Fruit", Colour = "Red", Name = "Plum" });
+        rows.OnItemInserted(view.IndexOf(source[^1]));
+
+        Assert.AreEqual(6, rows.Count);
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(NotifyCollectionChangedAction.Add, events[0].Action);
+        Assert.AreEqual(5, events[0].NewStartingIndex);
+    }
+
+    [UITestMethod]
+    public void OnItemRemoved_Ungrouped_ReportsASingleRemove()
+    {
+        var source = CreateItems();
+        var view = new CollectionView(source);
+        var rows = new TableViewVisualRows(view, _ => false);
+        var events = Record(rows);
+
+        var removed = view[2];
+        var visualIndex = rows.GetVisualIndex(2);
+        source.Remove((GroupItem)removed!);
+        rows.OnItemRemoved(visualIndex, removed);
+
+        Assert.AreEqual(4, rows.Count);
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(NotifyCollectionChangedAction.Remove, events[0].Action);
+        Assert.AreEqual(2, events[0].OldStartingIndex);
+    }
+
+    [UITestMethod]
+    public void Reset_RebuildsAfterCollapseStateChanges()
+    {
+        var view = new CollectionView(CreateItems());
+        view.GroupDescriptions.Add(new GroupDescription(nameof(GroupItem.Category)));
+
+        var collapsed = new HashSet<object?>();
+        var rows = new TableViewVisualRows(view, group => collapsed.Contains(group.Key));
+        var events = Record(rows);
+
+        Assert.AreEqual(7, rows.Count);
+
+        collapsed.Add("Fruit");
+        rows.Reset();
+
+        Assert.AreEqual(4, rows.Count);
+        Assert.AreEqual(1, events.Count);
+        Assert.AreEqual(NotifyCollectionChangedAction.Reset, events[0].Action);
+    }
+
+    private static List<NotifyCollectionChangedEventArgs> Record(TableViewVisualRows rows)
+    {
+        List<NotifyCollectionChangedEventArgs> events = [];
+        rows.CollectionChanged += (_, e) => events.Add(e);
+
+        return events;
+    }
+
+    private static ObservableCollection<GroupItem> CreateItems()
+    {
+        return
+        [
+            new GroupItem { Category = "Veg", Colour = "Red", Name = "Tomato" },
+            new GroupItem { Category = "Fruit", Colour = "Red", Name = "Cherry" },
+            new GroupItem { Category = "Fruit", Colour = "Green", Name = "Apple" },
+            new GroupItem { Category = "Veg", Colour = "Green", Name = "Broccoli" },
+            new GroupItem { Category = "Fruit", Colour = "Red", Name = "Banana" },
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #423 (the ItemsRepeater row-hosting migration). Adds multi-level grouping to the item view and to the row host that PR introduced.

**Data layer (`CollectionView`):**
- `GroupDescription : SortDescription` describes a grouping level. Deriving from `SortDescription` reuses its compiled property-value getter and comparer, and lets `CollectionView.Compare` order by group keys before sort descriptions in the same pass — grouped order falls out of the existing single `_view.Sort` call rather than a second sorting mechanism.
- `TableViewGroup` is a **span** over the flat item view (`FirstItemIndex`, `ItemCount`, `Level`, `Parent`, `KeyPath`) rather than a container of items, so grouping a million rows costs memory proportional to the number of groups, not to the number of items.
- `CollectionView.Grouping.cs` builds the group list in one pass and maintains it incrementally on single item add/remove and on live-shaping group-key changes, falling back to a full rebuild only when a change affects the shape of the groups themselves (and even then, only the groups are touched — never the items).

**Row host (`TableViewVisualRows`):**
- Extended from the 1:1 item/visual index projection introduced in #423 to a run-based projection that interleaves group header rows and omits the contents of collapsed groups. Index conversion is a binary search over a run list proportional to the number of *visible groups* — O(1) with no grouping, since there is exactly one run.
- Collapse state is a set of collapsed group key-paths (`TableViewGroupPath`, structural equality), so it survives re-sort/re-filter/re-group and the common all-expanded case costs nothing to track.

**New public API on `TableView`:** `GroupDescriptions`, `Groups`, `IsGrouped`, `GroupHeaderTemplate`/`GroupHeaderTemplateSelector`, `AreGroupsExpandedByDefault`, `ExpandGroup`/`CollapseGroup`/`ExpandAllGroups`/`CollapseAllGroups`, `RefreshGrouping`.

**New `TableViewGroupRow` control** (expander, level indent, item count, Space/Enter/double-tap to toggle) with its own theme and automation peer (`AutomationControlType.Group` + `IExpandCollapseProvider`).

Group headers are visual-only: no cell slot, not selectable, stepped over by arrow-key navigation. Selection and cell slots are item-indexed, so collapsing a group never changes what is selected. Alternate-row striping follows the item index, so it does not re-phase around a collapsed group.

## What's included

- New sample page **Grouping**: level pickers, ascending/descending order, expand/collapse all, live group/item/realized-row counters.
- New `docs/docs/grouping.md`; `datagrid-feature-comparison.md`'s Grouping row flips to supported.

## Test plan

- [x] `msbuild /restore /t:Build,Pack src/WinUI.TableView.csproj` — green on all 6 target frameworks
- [x] `WinUI.TableView.Tests` — **395/395** pass (361 from #423 + 16 `CollectionView` grouping tests + 13 `TableViewVisualRows` tests + 5 grouping-specific row-host UI tests)
- [x] WinUI sample app builds (x64)
- [x] Uno sample builds for `net10.0-desktop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
