### PR TITLE
Add multi-level column grouping support (Windows only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Explore the interactive `WinUI.TableView` samples with code snippets in a Sample
 - **Copy row or cell content**: TableView allows you to copy rows or cells content, with the option to include or exclude column headers.
 - **Editing**: Modify cell content directly within the TableView by double tapping on a cell. [Learn more →](https://w-ahmad.dev/WinUI.TableView/docs/editing.html)
 - **Sorting**: Offers built in column sorting. [Learn more →](https://w-ahmad.dev/WinUI.TableView/docs/sorting.html)
+- **Grouping**: Multi-level column grouping with expand/collapse and full sort integration (Windows only). [Learn more →](https://w-ahmad.dev/WinUI.TableView/docs/grouping.html)
 - **Excel-like Column Filter**: TableView allows you to filter data within columns with an excel like flyout to enhance data exploration and analysis. [Learn more →](https://w-ahmad.dev/WinUI.TableView/docs/filtering.html)
 - **Export functionality**: Built-in export functionality to export data to CSV format. This feature can be enabled by setting the `ShowExportOptions = true`. [Learn more →](https://w-ahmad.dev/WinUI.TableView/docs/export.html)
 - **Grid Lines**: Display grid lines to improve data visibility and organization.
@@ -166,7 +167,7 @@ You can customize the appearance and behavior of the `TableView` by modifying it
 
 - **Column Customization**: Define custom columns based on data types.
 - **Is ReadOnly**: You can make any column or the TableView itself read only.
-- **Sorting and Filtering**: Enable sorting and filtering on specific columns or for the all columns.
+- **Sorting, Grouping, and Filtering**: Enable sorting, grouping, and filtering on specific columns or for the all columns.
 - **Corner Button Mode**: Use the `CornerButtonMode` property to configure the corner button's behavior. You can select from:
     - `None`: No corner button.
     - `SelectAll`: Displays a "Select All" button.
@@ -222,6 +223,7 @@ Full documentation is available at **[w-ahmad.dev/WinUI.TableView](https://w-ahm
 - [Binding Data](https://w-ahmad.dev/WinUI.TableView/docs/binding-data.html)
 - [Editing](https://w-ahmad.dev/WinUI.TableView/docs/editing.html)
 - [Sorting](https://w-ahmad.dev/WinUI.TableView/docs/sorting.html)
+- [Grouping](https://w-ahmad.dev/WinUI.TableView/docs/grouping.html)
 - [Filtering](https://w-ahmad.dev/WinUI.TableView/docs/filtering.html)
 - [Selection](https://w-ahmad.dev/WinUI.TableView/docs/selection.html)
 - [Styling & Theming](https://w-ahmad.dev/WinUI.TableView/docs/styling.html)

--- a/docs/docs/accessibility.md
+++ b/docs/docs/accessibility.md
@@ -166,12 +166,14 @@ To override the automation name of a column header (for example, to provide a lo
 - **IValueProvider on cells**: `IValueProvider` is not implemented on the cell peer. Instead, the editing element (for example, a `TextBox`) exposes `IValueProvider` while the cell is in edit mode.
 - **Custom column types**: cells in `TableViewTemplateColumn` show developer-defined content. Accessible names for those cells default to the column header and row index unless the template explicitly sets `AutomationProperties.Name`.
 - **Non-Windows platforms**: automation peers are compiled and run on all platforms (WinUI and Uno Platform). However, not all Uno Platform targets expose a full UIA tree to assistive technologies. On WebAssembly (WASM), the platform relies on ARIA attributes managed by Uno. On Desktop Skia targets, accessibility support depends on the native platform's accessibility APIs.
+- **Group headers**: [`TableViewGroupHeaderRow`](xref:WinUI.TableView.TableViewGroupHeaderRow) does not have a dedicated automation peer; it relies on the base `ListViewHeaderItem` automation behavior. Its default automation name is derived from the group's key ([`TableViewGroupInfo.Key`](xref:WinUI.TableView.TableViewGroupInfo.Key)), not the item count shown in the UI.
 
 ## Related articles
 
 - [Selection](selection.md)
 - [Editing](editing.md)
 - [Sorting](sorting.md)
+- [Grouping](grouping.md)
 - [Filtering](filtering.md)
 - [Row details](row-details.md)
 - [Row headers](row-headers.md)

--- a/docs/docs/aot-compatibility.md
+++ b/docs/docs/aot-compatibility.md
@@ -156,12 +156,14 @@ Enable AOT and set the CsWinRT warning level to catch any remaining issues at bu
 - Only WinUI (Windows App SDK) targets support Native AOT publishing. Uno Platform targets have their own AOT characteristics — consult the [Uno Platform documentation](https://platform.uno/docs/articles/uno-development/aot-compilation.html) for those targets.
 - `AutoGenerateColumns="True"` uses reflection to discover properties. This works with the attribute in place, but for maximum AOT compatibility prefer explicit columns (`AutoGenerateColumns="False"`).
 - `SortMemberPath` uses reflection-based property access when set. Ensure the model has the attribute when using `SortMemberPath`.
+- [Grouping](grouping.md) is built on the same `SortDescription`-derived reflection path as sorting - grouping by a bound column's property (rather than its rendered cell content) needs the same model attribute.
 
 ## Related articles
 
 - [Binding data](binding-data.md)
 - [Defining columns](defining-columns.md)
 - [Column types](column-types.md)
+- [Grouping](grouping.md)
 - [Performance guidance](performance.md)
 - [.NET Native AOT deployment overview](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/)
 - [C#/WinRT overview](https://learn.microsoft.com/en-us/windows/apps/develop/platform/csharp-winrt/)

--- a/docs/docs/commands-events.md
+++ b/docs/docs/commands-events.md
@@ -38,7 +38,7 @@ This page lists all public events exposed by `TableView` and related types.
 
 | Event | Args type | Description |
 |---|---|---|
-| [`Grouping`](xref:WinUI.TableView.TableView.Grouping) | [`TableViewGroupingEventArgs`](xref:WinUI.TableView.TableViewGroupingEventArgs) | Fires before a column's **Group** option runs the default group/ungroup action. Set `Handled = true` for custom behavior. |
+| [`Grouping`](xref:WinUI.TableView.TableView.Grouping) | [`TableViewGroupingEventArgs`](xref:WinUI.TableView.TableViewGroupingEventArgs) | Fires before a column's **Group** option applies a new group - not when ungrouping. Set `Handled = true` to suppress the default grouping. |
 
 ### Clipboard and export
 

--- a/docs/docs/commands-events.md
+++ b/docs/docs/commands-events.md
@@ -34,6 +34,12 @@ This page lists all public events exposed by `TableView` and related types.
 | [`Sorting`](xref:WinUI.TableView.TableView.Sorting) | [`TableViewSortingEventArgs`](xref:WinUI.TableView.TableViewSortingEventArgs) | Fires before the default sort runs. Set `Handled = true` for custom sort. |
 | [`ClearSorting`](xref:WinUI.TableView.TableView.ClearSorting) | [`TableViewClearSortingEventArgs`](xref:WinUI.TableView.TableViewClearSortingEventArgs) | Fires when a column's sort direction is cleared. |
 
+### Grouping (Windows only)
+
+| Event | Args type | Description |
+|---|---|---|
+| [`Grouping`](xref:WinUI.TableView.TableView.Grouping) | [`TableViewGroupingEventArgs`](xref:WinUI.TableView.TableViewGroupingEventArgs) | Fires before a column's **Group** option runs the default group/ungroup action. Set `Handled = true` for custom behavior. |
+
 ### Clipboard and export
 
 | Event | Args type | Description |
@@ -111,6 +117,13 @@ This page lists all public events exposed by `TableView` and related types.
 |---|---|---|
 | `Column` | [`TableViewColumn`](xref:WinUI.TableView.TableViewColumn) | The column being sorted |
 | `Handled` (inherited) | `bool` | Set `true` to suppress default sort |
+
+### TableViewGroupingEventArgs
+
+| Property | Type | Description |
+|---|---|---|
+| `Column` | [`TableViewColumn`](xref:WinUI.TableView.TableViewColumn) | The column being grouped |
+| `Handled` (inherited) | `bool` | Set `true` to suppress default grouping |
 
 ### TableViewCopyToClipboardEventArgs
 
@@ -206,11 +219,19 @@ This page lists all public events exposed by `TableView` and related types.
 | `Cells` | Cell content width only |
 | [`Header`](xref:WinUI.TableView.TableViewColumnAutoWidthMode.Header) | Header content width only |
 
+### TableViewGroupState
+
+| Value | Description |
+|---|---|
+| `Expanded` | Newly created groups start expanded |
+| `Collapsed` | Newly created groups start collapsed |
+
 ## Related articles
 
 - [Editing](editing.md)
 - [Selection](selection.md)
 - [Sorting](sorting.md)
+- [Grouping](grouping.md)
 - [Filtering](filtering.md)
 - [Clipboard and copy/paste](clipboard.md)
 - [Export to CSV](export.md)

--- a/docs/docs/datagrid-feature-comparison.md
+++ b/docs/docs/datagrid-feature-comparison.md
@@ -49,7 +49,7 @@ WinUI.TableView is actively maintained and continues to add new features based o
 | Delete row | ✅ | ❌ | ❌ | |
 | Sorting | ✅ | ⚠️ | ✅ | No built-in sorting in WCT DataGrid but exposes sorting events. |
 | Filtering | ⚠️ | ❌ | ✅ | WPF commonly uses collection view/app logic. WCT docs explicitly say there is no built-in filtering. TableView provides Excel-like column filtering. |
-| Grouping | ✅ | ✅ | ❌ |  |
+| Grouping | ✅ | ✅ | ✅ | Multi-level grouping with expand/collapse and sort integration. Windows-only; not available on non-Windows Uno targets. |
 | Row selection | ✅ | ✅ | ✅ |  |
 | Cell selection | ✅ | ❌ | ✅ | |
 | Clipboard copy | ✅ | ✅ | ✅ |  |

--- a/docs/docs/getting-started-with-uno.md
+++ b/docs/docs/getting-started-with-uno.md
@@ -158,6 +158,7 @@ Build and run your application. You should see `WinUI.TableView` populated with 
 
 ### Known limitations on Uno targets
 
+- **Grouping is not available.** [Column grouping](grouping.md) is a Windows-only feature; `CanGroupColumns` and the column header's "Group" option have no effect on non-Windows Uno targets.
 - `AutoGenerateColumns="True"` uses reflection to discover model properties. This works on all Uno targets but is slower than explicit column definitions on first load.
 - The filter flyout UI renders using the same XAML as the Windows target. On small-screen targets (phone), the flyout may extend beyond the visible area. Consider disabling the filter flyout (`CanFilterColumns="False"`) on those form factors.
 - Row details expand/collapse animation may not be as smooth on Skia targets compared to Windows.
@@ -166,6 +167,7 @@ Build and run your application. You should see `WinUI.TableView` populated with 
 
 - [Installation and quick start](getting-started.md)
 - [Overview and concepts](overview.md)
+- [Grouping](grouping.md)
 - [Performance guidance](performance.md)
 - [Accessibility](accessibility.md)
 - [Native AOT compatibility](aot-compatibility.md)

--- a/docs/docs/grouping.md
+++ b/docs/docs/grouping.md
@@ -20,20 +20,17 @@ Clicking **Group** on the **Category** column collapses the rows into headers, o
 
 ## Grouping programmatically
 
-Grouping descriptions live on the underlying collection view, similar to [`SortDescriptions`](sorting.md). Because grouping is a Windows-only capability, the group-related API is exposed on the concrete `WinUI.TableView.CollectionView` type rather than on the `ICollectionView` interface returned by `TableView.CollectionView` - cast to it first:
+Grouping descriptions live on `TableView.GroupDescriptions`, similar to [`SortDescriptions`](sorting.md):
 
 ```csharp
-if (tableView.CollectionView is WinUI.TableView.CollectionView collectionView)
-{
-    collectionView.GroupDescriptions.Add(new GroupDescription("Category"));
-}
+tableView.GroupDescriptions.Add(new GroupDescription("Category"));
 ```
 
 Add a second `GroupDescription` to group by more than one level - each additional description nests inside the previous one:
 
 ```csharp
-collectionView.GroupDescriptions.Add(new GroupDescription("Department"));
-collectionView.GroupDescriptions.Add(new GroupDescription("Role"));
+tableView.GroupDescriptions.Add(new GroupDescription("Department"));
+tableView.GroupDescriptions.Add(new GroupDescription("Role"));
 ```
 
 This produces a two-level hierarchy: a header per department, and inside each, a header per role.
@@ -99,10 +96,10 @@ Changing `DefaultGroupState` at runtime re-applies it to every group that has no
 
 ### Toggling a group programmatically
 
-Each entry in `CollectionGroups` implements the standard `ICollectionViewGroup` interface; its `Group` property is the `TableViewGroupInfo` whose `IsExpanded` you can set directly:
+Each entry in `TableView.CollectionView.CollectionGroups` implements the standard `ICollectionViewGroup` interface; its `Group` property is the `TableViewGroupInfo` whose `IsExpanded` you can set directly:
 
 ```csharp
-var firstGroup = collectionView.CollectionGroups?
+var firstGroup = tableView.CollectionView.CollectionGroups?
     .Select(g => ((ICollectionViewGroup)g).Group)
     .OfType<TableViewGroupInfo>()
     .FirstOrDefault();
@@ -144,23 +141,32 @@ Grouping a column and sorting it are unified: grouping a column also drives its 
 
 ```csharp
 // Groups by Category, then reorders both headers and each group's items descending
-if (tableView.CollectionView is WinUI.TableView.CollectionView collectionView)
-{
-    var categoryGroup = collectionView.GroupDescriptions
-        .OfType<GroupDescription>()
-        .First();
+var categoryGroup = tableView.GroupDescriptions
+    .OfType<GroupDescription>()
+    .First();
 
-    categoryGroup.Direction = SortDirection.Descending;
-    collectionView.RefreshGrouping();
-}
+categoryGroup.Direction = SortDirection.Descending;
+tableView.RefreshGrouping();
 ```
+
+### Sorting groups by item count
+
+By default, groups are ordered by their key value. Set `GroupSortMode` on a `GroupDescription` to order groups by how many items they contain instead - "show the biggest group first":
+
+```csharp
+categoryGroup.SortMode = GroupSortMode.Count;
+categoryGroup.Direction = SortDirection.Descending; // biggest group first
+tableView.RefreshGrouping();
+```
+
+`Direction` still controls ascending/descending of whichever `SortMode` is set to. Groups with equal counts always break ties ascending by key, regardless of `Direction`. This is also available from a grouped column's own header flyout, as **Sort Groups by Count** / **Sort Groups by Value**.
 
 ## Refreshing groups
 
-Call `RefreshGrouping()` on the `WinUI.TableView.CollectionView` to rebuild groups from the current data without user interaction - useful after mutating data outside an `ObservableCollection`:
+Call `TableView.RefreshGrouping()` to rebuild groups from the current data without user interaction - useful after mutating data outside an `ObservableCollection`:
 
 ```csharp
-collectionView.RefreshGrouping();
+tableView.RefreshGrouping();
 ```
 
 ## Row and header indentation
@@ -201,14 +207,15 @@ bool isGrouped = tableView.IsGrouped; // true if any GroupDescription is applied
 |---|---|
 | [`CanGroupColumns`](xref:WinUI.TableView.TableView.CanGroupColumns) | Enables or disables grouping for all columns |
 | [`CanGroup`](xref:WinUI.TableView.TableViewColumn.CanGroup) | Per-column grouping toggle |
-| `GroupDescriptions` (on `WinUI.TableView.CollectionView`) | Collection of active group descriptions |
+| [`GroupDescriptions`](xref:WinUI.TableView.TableView.GroupDescriptions) | Collection of active group descriptions |
+| [`GroupSortMode`](xref:WinUI.TableView.GroupDescription.SortMode) | Orders groups by key (default) or item count |
 | [`DefaultGroupStyle`](xref:WinUI.TableView.TableView.DefaultGroupStyle) | The `GroupStyle` applied when no custom `GroupStyle` entry is set |
 | [`DefaultGroupState`](xref:WinUI.TableView.TableView.DefaultGroupState) | Whether new groups start expanded or collapsed |
 | [`ShowGroupExpandCollapseButton`](xref:WinUI.TableView.TableView.ShowGroupExpandCollapseButton) | Shows or hides the per-group expand/collapse button |
 | [`AreStickyGroupHeadersEnabled`](xref:WinUI.TableView.TableView.AreStickyGroupHeadersEnabled) | Pins the current group header to the top while scrolling |
 | [`IsGrouped`](xref:WinUI.TableView.TableView.IsGrouped) | `true` if any grouping is applied |
 | [`UngroupAll()`](xref:WinUI.TableView.TableView.UngroupAll) | Removes all grouping and resets affected columns' sort indicators |
-| `RefreshGrouping()` (on `WinUI.TableView.CollectionView`) | Rebuilds groups from the current data without user interaction |
+| [`RefreshGrouping()`](xref:WinUI.TableView.TableView.RefreshGrouping) | Rebuilds groups from the current data without user interaction |
 | [`Grouping`](xref:WinUI.TableView.TableView.Grouping) | Fires before the default group action runs; can be handled/suppressed |
 
 ## Notes and limitations

--- a/docs/docs/grouping.md
+++ b/docs/docs/grouping.md
@@ -1,0 +1,226 @@
+# Grouping
+
+`TableView` supports multi-level column grouping: collapsing rows into collapsible headers by one or more column values, with expand/collapse control per group and full integration with column sorting.
+
+> **Note:** Grouping is currently a **Windows-only** feature. It is not available when running on non-Windows Uno Platform targets (macOS, Linux, WASM, iOS, Android). `CanGroupColumns` and the "Group" column header option are hidden/no-ops on those targets.
+
+## When to use it
+
+Use grouping when users need to see data organized into categories - for example, orders grouped by status, or employees grouped by department and then by role. Combine it with [sorting](sorting.md) to control the order of both the groups and the items inside them.
+
+## Basic example
+
+Grouping is off by default. The simplest way to enable it is through the column header's options menu - open a column's options flyout and choose **Group**:
+
+```xml
+<tv:TableView ItemsSource="{x:Bind Products}" />
+```
+
+Clicking **Group** on the **Category** column collapses the rows into headers, one per distinct category value.
+
+## Grouping programmatically
+
+Grouping descriptions live on the underlying collection view, similar to [`SortDescriptions`](sorting.md). Because grouping is a Windows-only capability, the group-related API is exposed on the concrete `WinUI.TableView.CollectionView` type rather than on the `ICollectionView` interface returned by `TableView.CollectionView` - cast to it first:
+
+```csharp
+if (tableView.CollectionView is WinUI.TableView.CollectionView collectionView)
+{
+    collectionView.GroupDescriptions.Add(new GroupDescription("Category"));
+}
+```
+
+Add a second `GroupDescription` to group by more than one level - each additional description nests inside the previous one:
+
+```csharp
+collectionView.GroupDescriptions.Add(new GroupDescription("Department"));
+collectionView.GroupDescriptions.Add(new GroupDescription("Role"));
+```
+
+This produces a two-level hierarchy: a header per department, and inside each, a header per role.
+
+Remove all grouping:
+
+```csharp
+tableView.UngroupAll();
+```
+
+Or clear the `GroupDescriptions` collection directly - both have the same effect, and both reset the sort indicator on any column that was driving a group.
+
+Ungrouping and later re-grouping the same column starts every group at [`DefaultGroupState`](#default-expandedcollapsed-state) again - any groups a user had individually expanded or collapsed before ungrouping do not carry over.
+
+## Group headers: name and count
+
+By default, each group header shows the group's key and item count, e.g. `Electronics (12)`. This comes from `TableView.DefaultGroupStyle`, which is a plain `GroupStyle` applied automatically unless you add your own entry to `TableView.GroupStyle` (a `ListViewBase.GroupStyle` collection):
+
+```xml
+<tv:TableView ItemsSource="{x:Bind Products}">
+    <tv:TableView.GroupStyle>
+        <GroupStyle>
+            <GroupStyle.HeaderTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon Glyph="&#xE8B7;" />
+                        <TextBlock Text="{Binding Key}" FontWeight="Bold" />
+                        <TextBlock Text="{Binding Count}" Opacity="0.6" />
+                    </StackPanel>
+                </DataTemplate>
+            </GroupStyle.HeaderTemplate>
+        </GroupStyle>
+    </tv:TableView.GroupStyle>
+</tv:TableView>
+```
+
+The header's `DataContext` is a `TableViewGroupInfo` with these members:
+
+| Member | Type | Description |
+|---|---|---|
+| `Key` | `object?` | The group's key value |
+| `Count` | `int` | Total item count in the group, including nested subgroups |
+| `IsExpanded` | `bool` | Whether the group's items are currently shown |
+
+## Expanding and collapsing groups
+
+Each group header has a built-in expand/collapse button. Clicking it toggles `IsExpanded` for that group and shows or hides its items (or, for a non-leaf group in a multi-level hierarchy, its descendant subgroups and items).
+
+### Default expanded/collapsed state
+
+Control whether newly created groups start out expanded or collapsed with `TableView.DefaultGroupState`:
+
+```xml
+<tv:TableView DefaultGroupState="Collapsed" />
+```
+
+| Value | Description |
+|---|---|
+| `Expanded` | Groups start expanded (all items visible) |
+| `Collapsed` | Groups start collapsed (only headers visible) - the default |
+
+Changing `DefaultGroupState` at runtime re-applies it to every group that has not been individually toggled away from the previous default. A group a user has explicitly expanded or collapsed keeps that state until toggled again.
+
+### Toggling a group programmatically
+
+Each entry in `CollectionGroups` implements the standard `ICollectionViewGroup` interface; its `Group` property is the `TableViewGroupInfo` whose `IsExpanded` you can set directly:
+
+```csharp
+var firstGroup = collectionView.CollectionGroups?
+    .Select(g => ((ICollectionViewGroup)g).Group)
+    .OfType<TableViewGroupInfo>()
+    .FirstOrDefault();
+
+if (firstGroup is not null)
+{
+    firstGroup.IsExpanded = !firstGroup.IsExpanded;
+}
+```
+
+### Hiding the expand/collapse button
+
+To let groups start collapsed/expanded via `DefaultGroupState` without exposing a user-facing toggle, hide the button with `ShowGroupExpandCollapseButton`:
+
+```xml
+<tv:TableView ShowGroupExpandCollapseButton="False" />
+```
+
+Groups can still be toggled programmatically while the button is hidden.
+
+### Sticky group headers
+
+Enable sticky group headers so the current group's header stays pinned to the top of the viewport while scrolling through its items:
+
+```xml
+<tv:TableView AreStickyGroupHeadersEnabled="True" />
+```
+
+> **Note:** This only pins a single level of header at a time - with multi-level grouping, ancestor headers above the innermost one do not stack.
+
+## Sorting and grouping together
+
+Grouping a column and sorting it are unified: grouping a column also drives its order, so a grouped column shows a sort direction indicator like any other sorted column, and clicking it toggles that direction instead of adding a separate sort.
+
+- If the column already had its own sort applied when it's grouped, that sort description is kept (not discarded) and seeds the group's initial direction. Clicking the header keeps cycling through it three-state (ascending → descending → cleared) until it's eventually cleared - only then does ordering hand off fully to the group, which cycles two-state (ascending ↔ descending) from that point on. "Clear Sorting" is available up until that hand-off, as a shortcut past the three-state cycle.
+- Grouping a column with no prior sort starts the group directly in two-state mode with a default ascending direction - there's no independent sort description to cycle through first.
+- Either way, the chosen direction reorders both the group headers and the items inside each group.
+- Ungrouping a column (via the header's **Ungroup** option, or `UngroupAll()`) removes any sort description tied to it and clears its sort direction indicator.
+
+```csharp
+// Groups by Category, then reorders both headers and each group's items descending
+if (tableView.CollectionView is WinUI.TableView.CollectionView collectionView)
+{
+    var categoryGroup = collectionView.GroupDescriptions
+        .OfType<GroupDescription>()
+        .First();
+
+    categoryGroup.Direction = SortDirection.Descending;
+    collectionView.RefreshGrouping();
+}
+```
+
+## Refreshing groups
+
+Call `RefreshGrouping()` on the `WinUI.TableView.CollectionView` to rebuild groups from the current data without user interaction - useful after mutating data outside an `ObservableCollection`:
+
+```csharp
+collectionView.RefreshGrouping();
+```
+
+## Row and header indentation
+
+For multi-level grouping, row cells and column headers automatically shift right by 24px for each grouping level beyond the first, keeping the deepest group header's content aligned with the columns beneath it. The first grouping level adds no indent.
+
+## The Grouping event
+
+Handle `TableView.Grouping` to intercept or supplement the built-in group logic when a column's **Group** option is used. Setting `e.Handled = true` prevents the default grouping from running:
+
+```csharp
+tableView.Grouping += (s, e) =>
+{
+    if (e.Column.Header?.ToString() == "Id")
+    {
+        // Don't allow grouping by Id
+        e.Handled = true;
+    }
+};
+```
+
+`TableViewGroupingEventArgs` properties:
+
+| Property | Description |
+|---|---|
+| `Column` | The column being grouped |
+| `Handled` | Set `true` to suppress default grouping behavior |
+
+## Checking grouping state
+
+```csharp
+bool isGrouped = tableView.IsGrouped; // true if any GroupDescription is applied
+```
+
+## Common options
+
+| Property / Method / Event | Description |
+|---|---|
+| [`CanGroupColumns`](xref:WinUI.TableView.TableView.CanGroupColumns) | Enables or disables grouping for all columns |
+| [`CanGroup`](xref:WinUI.TableView.TableViewColumn.CanGroup) | Per-column grouping toggle |
+| `GroupDescriptions` (on `WinUI.TableView.CollectionView`) | Collection of active group descriptions |
+| [`DefaultGroupStyle`](xref:WinUI.TableView.TableView.DefaultGroupStyle) | The `GroupStyle` applied when no custom `GroupStyle` entry is set |
+| [`DefaultGroupState`](xref:WinUI.TableView.TableView.DefaultGroupState) | Whether new groups start expanded or collapsed |
+| [`ShowGroupExpandCollapseButton`](xref:WinUI.TableView.TableView.ShowGroupExpandCollapseButton) | Shows or hides the per-group expand/collapse button |
+| [`AreStickyGroupHeadersEnabled`](xref:WinUI.TableView.TableView.AreStickyGroupHeadersEnabled) | Pins the current group header to the top while scrolling |
+| [`IsGrouped`](xref:WinUI.TableView.TableView.IsGrouped) | `true` if any grouping is applied |
+| [`UngroupAll()`](xref:WinUI.TableView.TableView.UngroupAll) | Removes all grouping and resets affected columns' sort indicators |
+| `RefreshGrouping()` (on `WinUI.TableView.CollectionView`) | Rebuilds groups from the current data without user interaction |
+| [`Grouping`](xref:WinUI.TableView.TableView.Grouping) | Fires before the default group action runs; can be handled/suppressed |
+
+## Notes and limitations
+
+- Grouping is Windows-only; it does not run on non-Windows Uno Platform targets.
+- A grouped column's order always needs a direction, so it never truly clears to unsorted the way an ungrouped column's third click does - see [Sorting and grouping together](#sorting-and-grouping-together) for the three-state-until-cleared-then-two-state cycle.
+- Grouping and its implicit sort operate on the internal collection view. They do not mutate the original collection.
+- Sticky group headers pin only one header level at a time.
+
+## Related articles
+
+- [Sorting](sorting.md)
+- [Filtering](filtering.md)
+- [Styling rows, cells, and headers](styling.md)
+- [Events and commands reference](commands-events.md)

--- a/docs/docs/migration-wct.md
+++ b/docs/docs/migration-wct.md
@@ -44,6 +44,7 @@ xmlns:tv="using:WinUI.TableView"
 | [`AutoGenerateColumns`](xref:WinUI.TableView.TableView.AutoGenerateColumns) | [`AutoGenerateColumns`](xref:WinUI.TableView.TableView.AutoGenerateColumns) | Same behavior. |
 | [`IsReadOnly`](xref:WinUI.TableView.TableView.IsReadOnly) | [`IsReadOnly`](xref:WinUI.TableView.TableView.IsReadOnly) | Same behavior. |
 | `CanUserSortColumns` | [`CanSortColumns`](xref:WinUI.TableView.TableView.CanSortColumns) | Same behavior. |
+| *(no equivalent)* | [`CanGroupColumns`](xref:WinUI.TableView.TableView.CanGroupColumns) | WCT DataGrid group descriptions were applied to the source `CollectionViewSource`, not the grid itself. WinUI.TableView supports multi-level grouping directly on Windows targets — see [Grouping](grouping.md). |
 | `CanUserReorderColumns` | [`CanReorderColumns`](xref:WinUI.TableView.TableView.CanReorderColumns) | Same behavior. |
 | `CanUserResizeColumns` | [`CanResizeColumns`](xref:WinUI.TableView.TableView.CanResizeColumns) | Same behavior. |
 | [`FrozenColumnCount`](xref:WinUI.TableView.TableView.FrozenColumnCount) | [`FrozenColumnCount`](xref:WinUI.TableView.TableView.FrozenColumnCount) | Same behavior. |
@@ -82,7 +83,8 @@ xmlns:tv="using:WinUI.TableView"
 | `SelectionChanged` | `SelectionChanged` + [`CellSelectionChanged`](xref:WinUI.TableView.TableView.CellSelectionChanged) | Inherited `SelectionChanged` + new [`CellSelectionChanged`](xref:WinUI.TableView.TableView.CellSelectionChanged). |
 | `CopyingRowClipboardContent` | [`CopyToClipboard`](xref:WinUI.TableView.TableView.CopyToClipboard) | Renamed. |
 | [`ColumnReordered`](xref:WinUI.TableView.TableView.ColumnReordered) | [`ColumnReordered`](xref:WinUI.TableView.TableView.ColumnReordered) | Same purpose. |
-| `LoadingRowGroup` | *(no equivalent)* | WinUI.TableView does not support row grouping. |
+| `LoadingRowGroup` | *(no direct equivalent)* | WinUI.TableView supports grouping (see [Grouping](grouping.md)) but has no per-group-header loading event; customize the group header appearance instead via `GroupStyle`/`DefaultGroupStyle`. |
+| *(no equivalent)* | [`Grouping`](xref:WinUI.TableView.TableView.Grouping) | WCT DataGrid has no grouping event. Fires before a column's group/ungroup action runs. |
 | `LoadingRow` | *(no equivalent)* | WinUI.TableView does not have a `LoadingRow` event. Use `ContainerContentChanging` inherited from `ListView`. |
 
 ## Sorting
@@ -128,7 +130,6 @@ WCT DataGrid does not support cell selection — only row selection. WinUI.Table
 
 | WCT DataGrid feature | Status in WinUI.TableView |
 |---|---|
-| Row grouping | ❌ Not supported |
 | Accessible / Narrator support | ❌ Not verified in WinUI.TableView |
 
 ## References
@@ -141,3 +142,4 @@ WCT DataGrid does not support cell selection — only row selection. WinUI.Table
 - [Migrating from WPF DataGrid](migration-wpf.md)
 - [Feature comparison](datagrid-feature-comparison.md)
 - [Getting started](getting-started.md)
+- [Grouping](grouping.md)

--- a/docs/docs/migration-wpf.md
+++ b/docs/docs/migration-wpf.md
@@ -23,6 +23,7 @@ This guide helps developers who are migrating a WPF application to WinUI 3 and n
 | [`AutoGenerateColumns`](xref:WinUI.TableView.TableView.AutoGenerateColumns) | [`AutoGenerateColumns`](xref:WinUI.TableView.TableView.AutoGenerateColumns) | Same behavior. |
 | [`IsReadOnly`](xref:WinUI.TableView.TableView.IsReadOnly) | [`IsReadOnly`](xref:WinUI.TableView.TableView.IsReadOnly) | Same behavior. Per-column [`IsReadOnly`](xref:WinUI.TableView.TableViewColumn.IsReadOnly) is also supported. |
 | `CanUserSortColumns` | [`CanSortColumns`](xref:WinUI.TableView.TableView.CanSortColumns) | Same behavior. |
+| *(no equivalent)* | [`CanGroupColumns`](xref:WinUI.TableView.TableView.CanGroupColumns) | WPF DataGrid has no built-in column grouping. WinUI.TableView supports multi-level grouping on Windows targets — see [Grouping](grouping.md). |
 | `CanUserReorderColumns` | [`CanReorderColumns`](xref:WinUI.TableView.TableView.CanReorderColumns) | Same behavior. |
 | `CanUserResizeColumns` | [`CanResizeColumns`](xref:WinUI.TableView.TableView.CanResizeColumns) | Same behavior. |
 | [`FrozenColumnCount`](xref:WinUI.TableView.TableView.FrozenColumnCount) | [`FrozenColumnCount`](xref:WinUI.TableView.TableView.FrozenColumnCount) | Same behavior. |
@@ -59,6 +60,7 @@ This guide helps developers who are migrating a WPF application to WinUI 3 and n
 | [`CellEditEnding`](xref:WinUI.TableView.TableView.CellEditEnding) | [`CellEditEnding`](xref:WinUI.TableView.TableView.CellEditEnding) | Same purpose. `EditAction` is `Commit` or `Cancel`. |
 | [`CellEditEnded`](xref:WinUI.TableView.TableView.CellEditEnded) | [`CellEditEnded`](xref:WinUI.TableView.TableView.CellEditEnded) | Fires after commit or cancel. |
 | [`Sorting`](xref:WinUI.TableView.TableView.Sorting) | [`Sorting`](xref:WinUI.TableView.TableView.Sorting) | Same purpose. Set `Handled = true` for custom sort. |
+| *(no equivalent)* | [`Grouping`](xref:WinUI.TableView.TableView.Grouping) | WPF DataGrid has no grouping event. Fires before a column's group/ungroup action runs. |
 | `SelectionChanged` | `SelectionChanged` (inherited) + [`CellSelectionChanged`](xref:WinUI.TableView.TableView.CellSelectionChanged) | `SelectionChanged` is from `ListView`. [`CellSelectionChanged`](xref:WinUI.TableView.TableView.CellSelectionChanged) is new. |
 | [`CurrentCellChanged`](xref:WinUI.TableView.TableView.CurrentCellChanged) | [`CurrentCellChanged`](xref:WinUI.TableView.TableView.CurrentCellChanged) | Similar. |
 | `CopyingRowClipboardContent` | [`CopyToClipboard`](xref:WinUI.TableView.TableView.CopyToClipboard) | Renamed. Set `Handled = true` for custom content. |
@@ -84,7 +86,6 @@ WinUI.TableView bindings also use `Binding="{Binding PropertyName}"` (standard `
 |---|---|
 | Add new row (NewItemPlaceholder) | ❌ Not supported |
 | Delete row (Del key) | ❌ Not supported — implement in a context flyout |
-| Row grouping | ❌ Not supported |
 | Cell and row validation | ❌ No built-in validation — use [`BeginningEdit`](xref:WinUI.TableView.TableView.BeginningEdit) / [`CellEditEnding`](xref:WinUI.TableView.TableView.CellEditEnding) |
 | Row resize | ❌ Not supported |
 | `DataGridRowHeader` custom style | ⚠️ Use [`RowHeaderTemplate`](xref:WinUI.TableView.TableView.RowHeaderTemplate) instead |
@@ -112,3 +113,4 @@ xmlns:tv="using:WinUI.TableView"
 - [Migrating from WCT DataGrid](migration-wct.md)
 - [Feature comparison](datagrid-feature-comparison.md)
 - [Getting started](getting-started.md)
+- [Grouping](grouping.md)

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -57,6 +57,12 @@ tableView.SortDescriptions.Add(new SortDescription("Price", SortDirection.Ascend
 tableView.FilterDescriptions.Add(new FilterDescription("Name", new PredicateFilter(x => x.ToString()!.StartsWith("A"))));
 ```
 
+### Grouping
+
+On Windows targets, columns can be grouped - collapsing rows into collapsible, multi-level headers with expand/collapse control and integration with column sorting.
+
+See [Grouping](grouping.md).
+
 ## Namespace and XAML prefix
 
 ```xml
@@ -67,7 +73,7 @@ All types are in the `WinUI.TableView` namespace.
 
 ## Uno Platform
 
-On Uno Platform targets some behaviors differ slightly from the Windows target, particularly around data binding and focus management. See [Getting started with Uno](getting-started-with-uno.md) for platform-specific notes.
+On Uno Platform targets some behaviors differ slightly from the Windows target, particularly around data binding and focus management. [Grouping](grouping.md) is Windows-only and is not available on non-Windows Uno targets. See [Getting started with Uno](getting-started-with-uno.md) for platform-specific notes.
 
 ## Related articles
 
@@ -75,3 +81,5 @@ On Uno Platform targets some behaviors differ slightly from the Windows target, 
 - [Binding data](binding-data.md)
 - [Defining columns](defining-columns.md)
 - [Column types](column-types.md)
+- [Sorting](sorting.md)
+- [Grouping](grouping.md)

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -63,6 +63,10 @@ ctx.DataItem is Product p && p.Tags.Any(t => t.StartsWith("clearance"))
 
 Filtering and sorting operate on the internal collection view. These run on the UI thread. For very large collections (100,000+ items), consider pre-filtering in your ViewModel before setting [`ItemsSource`](xref:WinUI.TableView.TableView.ItemsSource).
 
+## Grouping
+
+Grouping (Windows only) rebuilds group headers from the full filtered/sorted item set on every regroup, add, remove, or expand/collapse toggle. Collapsing a group removes its items from the view entirely, which reduces the number of rows virtualization has to realize - collapsing large groups by default (`DefaultGroupState="Collapsed"`, the default) can improve initial render time for grouped data. See [Grouping](grouping.md).
+
 ## Refreshing the view after bulk data changes
 
 When you modify items in your source collection in-place (e.g., changing a property without `INotifyPropertyChanged`, or replacing items in a `List<T>`) the view may not update automatically. Use the refresh methods to force the control to re-evaluate:
@@ -112,4 +116,5 @@ On Uno Platform targets, data binding and layout passes may have slightly differ
 - [Binding data](binding-data.md)
 - [Filtering](filtering.md)
 - [Sorting](sorting.md)
+- [Grouping](grouping.md)
 - [Conditional cell styling](conditional-styling.md)

--- a/docs/docs/sorting.md
+++ b/docs/docs/sorting.md
@@ -150,6 +150,10 @@ tableView.ClearSorting += (s, e) =>
 
 Ctrl+Click a column header to add it as a secondary sort. The sort indicators show numbers when multiple columns are sorted.
 
+## Sorting and grouping
+
+Grouping a column also drives its order, so a grouped column shows a sort indicator too. If the column already had its own sort applied before being grouped, that keeps three-state cycling as usual until it's eventually cleared; from that point on (or immediately, if it had no prior sort) the column toggles ascending/descending only, since a group's order always needs a direction. See [Grouping](grouping.md#sorting-and-grouping-together).
+
 ## Checking sort state
 
 ```csharp
@@ -179,6 +183,7 @@ var descriptions = tableView.SortDescriptions; // the active SortDescription lis
 
 ## Related articles
 
+- [Grouping](grouping.md)
 - [Filtering](filtering.md)
 - [Binding data](binding-data.md)
 - [Defining columns](defining-columns.md)

--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -24,6 +24,8 @@
   items:
   - name: Sorting
     href: sorting.md
+  - name: Grouping
+    href: grouping.md
   - name: Filtering
     href: filtering.md
   - name: Editing

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,7 @@ Explore interactive samples with code snippets in the Samples App on Microsoft S
 | [Auto-generating columns](docs/defining-columns.md) | Automatically generate columns based on the data source properties |
 | [Column types](docs/column-types.md) | Text, Number, CheckBox, ComboBox, ToggleSwitch, Date, Time, Hyperlink, Template |
 | [Sorting](docs/sorting.md) | Built-in column sorting with sort direction indicators |
+| [Grouping](docs/grouping.md) | Multi-level column grouping with expand/collapse (Windows only) |
 | [Filtering](docs/filtering.md) | Excel-like column filter flyout |
 | [Editing](docs/editing.md) | Double-tap a cell to edit; full editing lifecycle events |
 | [Selection](docs/selection.md) | Row, cell, or combined selection modes |

--- a/samples/WinUI.TableView.SampleApp/ExampleModel.cs
+++ b/samples/WinUI.TableView.SampleApp/ExampleModel.cs
@@ -12,11 +12,16 @@ public partial class ExampleModel : ObservableObject
 
     [ObservableProperty]
     [Display(ShortName = "First Name")]
+    [NotifyPropertyChangedFor(nameof(FullName))]
     public partial string? FirstName { get; set; }
 
     [ObservableProperty]
     [Display(ShortName = "Last Name")]
+    [NotifyPropertyChangedFor(nameof(FullName))]
     public partial string? LastName { get; set; }
+
+    [Display(AutoGenerateField = false)]
+    public string FullName => $"{FirstName} {LastName}".Trim();
 
     [ObservableProperty]
     public partial string? Email { get; set; }

--- a/samples/WinUI.TableView.SampleApp/MainWindow.xaml
+++ b/samples/WinUI.TableView.SampleApp/MainWindow.xaml
@@ -111,6 +111,11 @@
                         <NavigationViewItem Content="Custom Sorting" />
                     </NavigationViewItem.MenuItems>
                 </NavigationViewItem>
+                <NavigationViewItem Content="Grouping">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xF168;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
                 <NavigationViewItem Content="Filtering">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE71C;" />

--- a/samples/WinUI.TableView.SampleApp/MainWindow.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/MainWindow.xaml.cs
@@ -70,6 +70,7 @@ public sealed partial class MainWindow : Window
                 "Editing" => typeof(EditingPage),
                 "Sorting" => typeof(SortingPage),
                 "Custom Sorting" => typeof(CustomizeSortingPage),
+                "Grouping" => typeof(GroupingPage),
                 "Data Export" => typeof(ExportPage),
                 "Large Dataset" => typeof(LargeDataPage),
                 "Conditional Cell Styling" => typeof(ConditionalStylingPage),

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml
@@ -100,7 +100,8 @@
                     <InfoBar IsOpen="True"
                              IsClosable="False"
                              Title="State">
-                        <StackPanel Spacing="8">
+                        <StackPanel Spacing="8"
+                                    Padding="0,0,0,12">
                             <TextBlock>
                                 <Run Text="Item count:" />
                                 <Run FontWeight="Bold"

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml
@@ -1,0 +1,120 @@
+<Page x:Class="WinUI.TableView.SampleApp.Pages.GroupingPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:WinUI.TableView.SampleApp"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:tv="using:WinUI.TableView"
+      xmlns:controls="using:WinUI.TableView.SampleApp.Controls"
+      xmlns:ui="using:CommunityToolkit.WinUI"
+      d:DataContext="{d:DesignInstance Type=local:ExampleViewModel}"
+      mc:Ignorable="d">
+
+    <Grid>
+        <controls:SamplePresenter Header="Grouping"
+                                  Description="Group a column via its options button (try Department or Gender), then use the buttons to add, insert, move, and delete items - a way to check those operations keep group headers, counts, and order correct.">
+            <controls:SamplePresenter.Example>
+                <tv:TableView x:Name="tableView"
+                              ItemsSource="{Binding Items}"
+                              SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                              AutoGenerateColumns="False"
+                              SelectionMode="Single"
+                              DataContextChanged="OnDataContextChanged">
+                    <tv:TableView.Columns>
+                        <tv:TableViewNumberColumn Header="Id"
+                                                  Width="70"
+                                                  Binding="{Binding Id}" />
+                        <tv:TableViewTextColumn Header="First Name"
+                                                Width="150"
+                                                Binding="{Binding FirstName}" />
+                        <tv:TableViewTextColumn Header="Last Name"
+                                                Width="150"
+                                                Binding="{Binding LastName}" />
+                        <tv:TableViewTextColumn Header="Department"
+                                                Width="150"
+                                                Binding="{Binding Department}" />
+                        <tv:TableViewTextColumn Header="Gender"
+                                                Width="120"
+                                                Binding="{Binding Gender}" />
+                    </tv:TableView.Columns>
+                </tv:TableView>
+            </controls:SamplePresenter.Example>
+            <controls:SamplePresenter.Options>
+                <StackPanel Spacing="16"
+                            MaxWidth="360">
+                    <ComboBox x:Name="newItemDepartment"
+                              Header="New item's department"
+                              HorizontalAlignment="Stretch"
+                              SelectedIndex="0">
+                        <x:String>Sales</x:String>
+                        <x:String>Engineering</x:String>
+                        <x:String>Support</x:String>
+                        <x:String>Marketing</x:String>
+                    </ComboBox>
+
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="Add / insert"
+                                   Style="{StaticResource CaptionTextBlockStyle}" />
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                            <Button Content="Add at end"
+                                    Click="OnAddClicked" />
+                            <Button Content="Insert at top"
+                                    Click="OnInsertAtTopClicked" />
+                            <Button Content="Insert before selected"
+                                    Click="OnInsertBeforeSelectedClicked" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="Move / delete selected"
+                                   Style="{StaticResource CaptionTextBlockStyle}" />
+                        <StackPanel Orientation="Horizontal"
+                                    Spacing="8">
+                            <Button Content="Move up"
+                                    Click="OnMoveUpClicked" />
+                            <Button Content="Move down"
+                                    Click="OnMoveDownClicked" />
+                            <Button Content="Delete"
+                                    Click="OnDeleteSelectedClicked" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <Button Content="Reset data"
+                            HorizontalAlignment="Stretch"
+                            Click="OnResetClicked" />
+
+                    <ComboBox Header="DefaultGroupState"
+                              HorizontalAlignment="Stretch"
+                              SelectedItem="{Binding DefaultGroupState, Mode=TwoWay, ElementName=tableView}"
+                              ItemsSource="{ui:EnumValues Type=tv:TableViewGroupState}" />
+                    <ToggleSwitch Header="ShowGroupExpandCollapseButton"
+                                  OnContent="True"
+                                  OffContent="False"
+                                  IsOn="{Binding ShowGroupExpandCollapseButton, Mode=TwoWay, ElementName=tableView}" />
+                    <ToggleSwitch Header="AreStickyGroupHeadersEnabled"
+                                  OnContent="True"
+                                  OffContent="False"
+                                  IsOn="{Binding AreStickyGroupHeadersEnabled, Mode=TwoWay, ElementName=tableView}" />
+
+                    <InfoBar IsOpen="True"
+                             IsClosable="False"
+                             Title="State">
+                        <StackPanel Spacing="8">
+                            <TextBlock>
+                                <Run Text="Item count:" />
+                                <Run FontWeight="Bold"
+                                     Text="{Binding Items.Count}" />
+                            </TextBlock>
+                            <TextBlock>
+                                <Run Text="Selected Id:" />
+                                <Run FontWeight="Bold"
+                                     Text="{Binding SelectedItem.Id}" />
+                            </TextBlock>
+                        </StackPanel>
+                    </InfoBar>
+                </StackPanel>
+            </controls:SamplePresenter.Options>
+        </controls:SamplePresenter>
+    </Grid>
+</Page>

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml
@@ -24,12 +24,9 @@
                         <tv:TableViewNumberColumn Header="Id"
                                                   Width="70"
                                                   Binding="{Binding Id}" />
-                        <tv:TableViewTextColumn Header="First Name"
+                        <tv:TableViewTextColumn Header="Full Name"
                                                 Width="150"
-                                                Binding="{Binding FirstName}" />
-                        <tv:TableViewTextColumn Header="Last Name"
-                                                Width="150"
-                                                Binding="{Binding LastName}" />
+                                                Binding="{Binding FullName}" />
                         <tv:TableViewTextColumn Header="Department"
                                                 Width="150"
                                                 Binding="{Binding Department}" />
@@ -83,6 +80,10 @@
                     <Button Content="Reset data"
                             HorizontalAlignment="Stretch"
                             Click="OnResetClicked" />
+
+                    <Button Content="Group by last name"
+                            HorizontalAlignment="Stretch"
+                            Click="OnToggleLastNameGroupClicked" />
 
                     <ComboBox Header="DefaultGroupState"
                               HorizontalAlignment="Stretch"

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml
@@ -12,7 +12,7 @@
 
     <Grid>
         <controls:SamplePresenter Header="Grouping"
-                                  Description="Group a column via its options button (try Department or Gender), then use the buttons to add, insert, move, and delete items - a way to check those operations keep group headers, counts, and order correct.">
+                                  Description="Group a column via its options button (try Department or Gender), then use the buttons to add, insert, move, and delete items - a way to check those operations keep group headers, counts, and order correct. Groups sort by key by default; toggle 'Sort Groups by Count' below (or the same option in a grouped column's own flyout) to show the biggest group first instead.">
             <controls:SamplePresenter.Example>
                 <tv:TableView x:Name="tableView"
                               ItemsSource="{Binding Items}"
@@ -97,6 +97,11 @@
                                   OnContent="True"
                                   OffContent="False"
                                   IsOn="{Binding AreStickyGroupHeadersEnabled, Mode=TwoWay, ElementName=tableView}" />
+                    <ToggleSwitch x:Name="sortGroupsByCount"
+                                  Header="Sort Groups by Count"
+                                  OnContent="True"
+                                  OffContent="False"
+                                  Toggled="OnSortGroupsByCountToggled" />
 
                     <InfoBar IsOpen="True"
                              IsClosable="False"

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
@@ -1,0 +1,128 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace WinUI.TableView.SampleApp.Pages;
+
+public sealed partial class GroupingPage : Page
+{
+    private static readonly string[] Departments = ["Sales", "Engineering", "Support", "Marketing"];
+
+    private int _nextId = 1;
+
+    public GroupingPage()
+    {
+        InitializeComponent();
+    }
+
+    private void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+    {
+        if (DataContext is not ExampleViewModel viewModel) return;
+
+        ReseedData(viewModel);
+    }
+
+    private void OnResetClicked(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not ExampleViewModel viewModel) return;
+
+        ReseedData(viewModel);
+    }
+
+    /// <summary>
+    /// Seeds a small, deliberately grouping-friendly dataset - a handful of items per department,
+    /// so it's easy to see items land in (or shift between) the right group after each operation.
+    /// </summary>
+    private void ReseedData(ExampleViewModel viewModel)
+    {
+        var items = new List<ExampleModel>();
+
+        for (var i = 0; i < 16; i++)
+        {
+            items.Add(new ExampleModel
+            {
+                Id = i + 1,
+                FirstName = DataFaker.FirstName(),
+                LastName = DataFaker.LastName(),
+                Department = Departments[i % Departments.Length],
+                Gender = DataFaker.Gender(),
+            });
+        }
+
+        _nextId = items.Count + 1;
+        viewModel.Items = new(items);
+        viewModel.SelectedItem = null;
+    }
+
+    private ExampleModel CreateNewItem()
+    {
+        var department = newItemDepartment.SelectedItem as string ?? Departments[0];
+
+        return new ExampleModel
+        {
+            Id = _nextId++,
+            FirstName = DataFaker.FirstName(),
+            LastName = DataFaker.LastName(),
+            Department = department,
+            Gender = DataFaker.Gender(),
+        };
+    }
+
+    private void OnAddClicked(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not ExampleViewModel viewModel) return;
+
+        viewModel.Items.Add(CreateNewItem());
+    }
+
+    private void OnInsertAtTopClicked(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not ExampleViewModel viewModel) return;
+
+        viewModel.Items.Insert(0, CreateNewItem());
+    }
+
+    private void OnInsertBeforeSelectedClicked(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not ExampleViewModel viewModel) return;
+
+        var index = viewModel.SelectedItem is { } selected ? viewModel.Items.IndexOf(selected) : -1;
+
+        viewModel.Items.Insert(Math.Max(0, index), CreateNewItem());
+    }
+
+    private void OnMoveUpClicked(object sender, RoutedEventArgs e) => Move(-1);
+
+    private void OnMoveDownClicked(object sender, RoutedEventArgs e) => Move(1);
+
+    /// <summary>
+    /// Moves the selected item by <paramref name="delta"/> positions in the source collection - exercises
+    /// ObservableCollection.Move, which raises NotifyCollectionChangedAction.Move.
+    /// </summary>
+    private void Move(int delta)
+    {
+        if (DataContext is not ExampleViewModel viewModel || viewModel.SelectedItem is not { } selected)
+        {
+            return;
+        }
+
+        var oldIndex = viewModel.Items.IndexOf(selected);
+        var newIndex = oldIndex + delta;
+
+        if (oldIndex < 0 || newIndex < 0 || newIndex >= viewModel.Items.Count)
+        {
+            return;
+        }
+
+        viewModel.Items.Move(oldIndex, newIndex);
+    }
+
+    private void OnDeleteSelectedClicked(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not ExampleViewModel viewModel || viewModel.SelectedItem is not { } selected)
+        {
+            return;
+        }
+
+        viewModel.Items.Remove(selected);
+    }
+}

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
@@ -125,4 +125,20 @@ public sealed partial class GroupingPage : Page
 
         viewModel.Items.Remove(selected);
     }
+
+    private void OnToggleLastNameGroupClicked(object sender, RoutedEventArgs e)
+    {
+        var existingGroupDescription = tableView.GroupDescriptions
+            .OfType<GroupDescription>()
+            .FirstOrDefault(gd => gd.PropertyName is nameof(ExampleModel.LastName));
+
+        if (existingGroupDescription is not null)
+        {
+            tableView.GroupDescriptions.Remove(existingGroupDescription);
+        }
+        else
+        {
+            tableView.GroupDescriptions.Add(new GroupDescription(nameof(ExampleModel.LastName)));
+        }
+    }
 }

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
@@ -36,7 +36,7 @@ public sealed partial class GroupingPage : Page
     {
         var items = new List<ExampleModel>();
 
-        for (var i = 0; i < 16; i++)
+        for (var i = 0; i < 100; i++)
         {
             items.Add(new ExampleModel
             {

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
@@ -1,5 +1,8 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+#if WINDOWS
+using System.Collections.Specialized;
+#endif
 
 namespace WinUI.TableView.SampleApp.Pages;
 
@@ -8,10 +11,31 @@ public sealed partial class GroupingPage : Page
     private static readonly string[] Departments = ["Sales", "Engineering", "Support", "Marketing"];
 
     private int _nextId = 1;
+    private bool _sortGroupsByCount;
 
     public GroupingPage()
     {
         InitializeComponent();
+
+#if WINDOWS
+        // Groups are always created fresh (Group(), or the "Group by last name" button below) with
+        // SortMode defaulting back to Key - without this, toggling "Sort Groups by Count" before any
+        // column is grouped, or grouping a second level after the toggle, would silently stay key-ordered.
+        if (tableView.GroupDescriptions is INotifyCollectionChanged groupDescriptions)
+        {
+            groupDescriptions.CollectionChanged += (_, e) =>
+            {
+                // This fires synchronously from inside Group()'s own Add() call, itself still inside
+                // Group()'s own DeferRefresh() scope - calling RefreshGrouping() (which ignores any
+                // in-progress defer) from here directly would rebuild grouping reentrantly, mid-rebuild.
+                // Deferring to the next dispatcher tick lets Group() fully unwind first.
+                if (e.NewItems is { Count: > 0 })
+                {
+                    DispatcherQueue.TryEnqueue(ApplyGroupSortMode);
+                }
+            };
+        }
+#endif
     }
 
     private void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
@@ -130,8 +154,8 @@ public sealed partial class GroupingPage : Page
     {
 #if WINDOWS
         var existingGroupDescription = tableView.GroupDescriptions
-            .OfType<GroupDescription>()
-            .FirstOrDefault(gd => gd.PropertyName is nameof(ExampleModel.LastName));
+    .OfType<GroupDescription>()
+    .FirstOrDefault(gd => gd.PropertyName is nameof(ExampleModel.LastName));
 
         if (existingGroupDescription is not null)
         {
@@ -140,7 +164,41 @@ public sealed partial class GroupingPage : Page
         else
         {
             tableView.GroupDescriptions.Add(new GroupDescription(nameof(ExampleModel.LastName)));
+        } 
+#endif
+    }
+
+    /// <summary>
+    /// Records the desired mode and applies it to every currently-grouped level - and, via the
+    /// CollectionChanged subscription in the constructor, to any level grouped afterward too.
+    /// </summary>
+    private void OnSortGroupsByCountToggled(object sender, RoutedEventArgs e)
+    {
+        _sortGroupsByCount = sortGroupsByCount.IsOn;
+#if WINDOWS
+        ApplyGroupSortMode();
+#endif
+    }
+
+#if WINDOWS
+    private void ApplyGroupSortMode()
+    {
+        var mode = _sortGroupsByCount ? GroupSortMode.Count : GroupSortMode.Key;
+        var changed = false;
+
+        foreach (var groupDescription in tableView.GroupDescriptions)
+        {
+            if (groupDescription.SortMode == mode) continue;
+
+            groupDescription.SortMode = mode;
+            changed = true;
+        }
+
+        if (changed)
+        {
+            tableView.RefreshGrouping();
         }
 #endif
     }
+#endif
 }

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
@@ -198,7 +198,6 @@ public sealed partial class GroupingPage : Page
         {
             tableView.RefreshGrouping();
         }
-#endif
     }
 #endif
 }

--- a/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
+++ b/samples/WinUI.TableView.SampleApp/Pages/GroupingPage.xaml.cs
@@ -128,6 +128,7 @@ public sealed partial class GroupingPage : Page
 
     private void OnToggleLastNameGroupClicked(object sender, RoutedEventArgs e)
     {
+#if WINDOWS
         var existingGroupDescription = tableView.GroupDescriptions
             .OfType<GroupDescription>()
             .FirstOrDefault(gd => gd.PropertyName is nameof(ExampleModel.LastName));
@@ -140,5 +141,6 @@ public sealed partial class GroupingPage : Page
         {
             tableView.GroupDescriptions.Add(new GroupDescription(nameof(ExampleModel.LastName)));
         }
+#endif
     }
 }

--- a/src/Collections/ObservableVector.cs
+++ b/src/Collections/ObservableVector.cs
@@ -1,0 +1,122 @@
+﻿using System.Collections;
+using Windows.Foundation.Collections;
+using WinUI.TableView.Extensions;
+
+namespace WinUI.TableView.Collections;
+
+/// <summary>
+/// An observable vector implementation for use with ICollectionViewGroup.
+/// </summary>
+internal partial class ObservableVector<T> : IObservableVector<T>
+{
+    private readonly List<T> _innerItems;
+    public event VectorChangedEventHandler<T>? VectorChanged;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservableVector{T}"/> class.
+    /// </summary>
+    public ObservableVector()
+    {
+        _innerItems = [];
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ObservableVector{T}"/> class with the specified items.
+    /// </summary>
+    /// <param name="items">The items to initialize the vector with.</param>
+    public ObservableVector(IEnumerable<T> items)
+    {
+        _innerItems = [.. items];
+    }
+
+    /// <inheritdoc />
+    public T this[int index]
+    {
+        get => _innerItems[index];
+        set
+        {
+            _innerItems[index] = value;
+            VectorChanged?.Invoke(this, new VectorChangedEventArgs(CollectionChange.ItemChanged, index));
+        }
+    }
+
+    /// <inheritdoc />
+    public void Add(T item)
+    {
+        _innerItems.Add(item);
+        VectorChanged?.Invoke(this, new VectorChangedEventArgs(CollectionChange.ItemInserted, _innerItems.Count - 1));
+    }
+
+    /// <inheritdoc />
+    public void Clear()
+    {
+        _innerItems.Clear();
+        VectorChanged?.Invoke(this, new VectorChangedEventArgs(CollectionChange.Reset, 0));
+
+    }
+
+    /// <inheritdoc />
+    public bool Contains(T item)
+    {
+        return _innerItems.Contains(item);
+    }
+
+    /// <inheritdoc />
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        _innerItems.CopyTo(array, arrayIndex);
+    }
+
+    /// <inheritdoc />
+    public int IndexOf(T item)
+    {
+        return _innerItems.IndexOf(item);
+    }
+
+    /// <inheritdoc />
+    public void Insert(int index, T item)
+    {
+        _innerItems.Insert(index, item);
+        VectorChanged?.Invoke(this, new VectorChangedEventArgs(CollectionChange.ItemInserted, index));
+    }
+
+    /// <inheritdoc />
+    public bool Remove(T item)
+    {
+        var index = _innerItems.IndexOf(item);
+        if (index < 0) return false;
+        _innerItems.RemoveAt(index);
+        VectorChanged?.Invoke(this, new VectorChangedEventArgs(CollectionChange.ItemRemoved, index));
+        return true;
+    }
+
+    /// <inheritdoc />
+    public void RemoveAt(int index)
+    {
+        _innerItems.RemoveAt(index);
+        VectorChanged?.Invoke(this, new VectorChangedEventArgs(CollectionChange.ItemRemoved, index));
+    }
+
+    /// <inheritdoc />
+    public IEnumerator<T> GetEnumerator()
+    {
+        return _innerItems.GetEnumerator();
+    }
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public int BinarySearch(T item, IComparer<T>? comparer)
+    {
+        return _innerItems.BinarySearch(item, comparer);
+    }
+
+    /// <inheritdoc />
+    public int Count => _innerItems.Count;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => _innerItems.IsReadOnly();
+}

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -247,6 +247,15 @@ public abstract partial class TableViewColumn : DependencyObject
     }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the column can be grouped.
+    /// </summary>
+    public bool CanGroup
+    {
+        get => (bool)GetValue(CanGroupProperty);
+        set => SetValue(CanGroupProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the column can be resized.
     /// </summary>
     public bool CanResize
@@ -628,6 +637,11 @@ public abstract partial class TableViewColumn : DependencyObject
     /// Identifies the ColumnAutoWidthMode dependency property.
     /// </summary>
     public static readonly DependencyProperty ColumnAutoWidthModeProperty = DependencyProperty.Register(nameof(ColumnAutoWidthMode), typeof(TableViewColumnAutoWidthMode?), typeof(TableViewColumn), new PropertyMetadata(null, OnColumnAutoWidthModeChanged));
+
+    /// <summary>
+    /// Identifies the CanGroup dependency property.
+    /// </summary>
+    public static readonly DependencyProperty CanGroupProperty = DependencyProperty.Register(nameof(CanGroup), typeof(bool), typeof(TableViewColumn), new PropertyMetadata(true));
 
     /// <summary>
     /// Identifies the CanResize dependency property.

--- a/src/EventArgs/TableViewGroupingEventArgs.cs
+++ b/src/EventArgs/TableViewGroupingEventArgs.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Provides data for the event that is raised when a column is being grouped in a TableView.
+/// </summary>
+public partial class TableViewGroupingEventArgs : HandledEventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TableViewGroupingEventArgs"/> class.
+    /// </summary>
+    /// <param name="column">The column that is being grouped.</param>
+    public TableViewGroupingEventArgs(TableViewColumn column)
+    {
+        Column = column;
+    }
+
+    /// <summary>
+    /// Gets the column that is being grouped.
+    /// </summary>
+    public TableViewColumn Column { get; }
+}

--- a/src/ItemsSource/CollectionView.Events.cs
+++ b/src/ItemsSource/CollectionView.Events.cs
@@ -20,6 +20,7 @@ partial class CollectionView
         }
 
         CurrentChanging?.Invoke(this, e);
+        OnPropertyChanging(nameof(CurrentItem));
     }
 
     /// <summary>
@@ -59,6 +60,15 @@ partial class CollectionView
     /// Property changed event invoker
     /// </summary>
     /// <param name="propertyName">name of the property that changed</param>
+    private void OnPropertyChanging([CallerMemberName] string propertyName = null!)
+    {
+        PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
+    }
+
+    /// <summary>
+    /// Property changed event invoker
+    /// </summary>
+    /// <param name="propertyName">name of the property that changed</param>
     private void OnPropertyChanged([CallerMemberName] string propertyName = null!)
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -78,6 +88,11 @@ partial class CollectionView
     /// Occurs when the vector has changed.
     /// </summary>
     public event VectorChangedEventHandler<object>? VectorChanged;
+
+    /// <summary>
+    /// Occurs when a property value is changing.
+    /// </summary>
+    public event PropertyChangingEventHandler? PropertyChanging;
 
     /// <summary>
     /// Occurs when a property value changes.

--- a/src/ItemsSource/CollectionView.Properties.cs
+++ b/src/ItemsSource/CollectionView.Properties.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Windows.Foundation.Collections;
+using WinUI.TableView.Collections;
 using WinUI.TableView.Extensions;
 
 namespace WinUI.TableView;
@@ -20,7 +21,7 @@ partial class CollectionView
 
             DetachCollectionChangedHandlers(field);
             DetachPropertyChangedHandlers(field);
-
+            OnPropertyChanging();
             field = value;
 
             AttachCollectionChangedHandlers(field);
@@ -59,10 +60,49 @@ partial class CollectionView
         set => _view[index] = value;
     }
 
+#if WINDOWS
+    /// <summary>
+    /// Gets the collection of group descriptions.
+    /// </summary>
+    public IList<GroupDescription> GroupDescriptions => _groupDescriptions;
+
+    /// <summary>
+    /// Gets or sets whether a group starts out expanded or collapsed by default, unless it's been explicitly
+    /// toggled away from that. Changing this re-applies it to every group that hasn't been explicitly toggled.
+    /// </summary>
+    public TableViewGroupState DefaultGroupState
+    {
+        get;
+        set
+        {
+            if (field == value) return;
+
+            field = value;
+
+            if (GroupDescriptions.Count > 0)
+            {
+                HandleGroupChanged();
+            }
+        }
+    } = TableViewGroupState.Collapsed;
+
     /// <summary>
     /// Gets the collection groups.
     /// </summary>
+    public IObservableVector<object>? CollectionGroups
+    {
+        get;
+        set
+        {
+            if (field == value) return;
+            OnPropertyChanging();
+            field = value;
+            OnPropertyChanged();
+        }
+    }
+#else
     public IObservableVector<object?>? CollectionGroups { get; } = null;
+#endif
 
     /// <summary>
     /// Gets or sets the current item in the view.

--- a/src/ItemsSource/CollectionView.cs
+++ b/src/ItemsSource/CollectionView.cs
@@ -464,7 +464,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
                 Level = level,
                 GroupPath = groupPath,
                 Description = description,
-                Count = group.Count(),
+                Count = groupedItems.Count,
                 IsExpanded = isExpanded,
                 CollectionView = this,
             };

--- a/src/ItemsSource/CollectionView.cs
+++ b/src/ItemsSource/CollectionView.cs
@@ -441,26 +441,42 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
         var description = GroupDescriptions[level];
         var isLeafLevel = level == GroupDescriptions.Count - 1;
         var comparer = Comparer<object?>.Create(description.Compare);
-        var groups = description.Direction == SortDirection.Ascending
-            ? items.GroupBy(description.GetPropertyValue).OrderBy(g => g.Key, comparer)
-            : items.GroupBy(description.GetPropertyValue).OrderByDescending(g => g.Key, comparer);
+
+        // Materialized up front (key + item list): GroupSortMode.Count needs each group's size to decide
+        // the order, which only exists once every group's items are known - Key mode materializes here too
+        // so the ordering and the loop below don't have to special-case IGrouping vs. a plain list.
+        var materialized = items.GroupBy(description.GetPropertyValue)
+            .Select(g => (g.Key, Items: g.ToList()))
+            .ToList();
+
+        var ordered = description.SortMode switch
+        {
+            // Ties (equal counts) always break ascending by key, regardless of Direction - a deterministic
+            // fallback, not a user-facing direction concept. Unlike key mode, where GroupBy guarantees no
+            // ties, count ties are common (many groups can share a size).
+            GroupSortMode.Count => description.Direction == SortDirection.Ascending
+                ? materialized.OrderBy(g => g.Items.Count).ThenBy(g => g.Key, comparer)
+                : materialized.OrderByDescending(g => g.Items.Count).ThenBy(g => g.Key, comparer),
+            _ => description.Direction == SortDirection.Ascending
+                ? materialized.OrderBy(g => g.Key, comparer)
+                : materialized.OrderByDescending(g => g.Key, comparer)
+        };
 
         var overridesForDescription = _groupExpandedStates.TryGetValue(description, out var existing) ? existing : null;
 
-        foreach (var group in groups)
+        foreach (var (key, groupedItems) in ordered)
         {
-            object[] groupPath = [.. parentPath, group.Key!];
+            object[] groupPath = [.. parentPath, key!];
             var isExpanded = overridesForDescription is not null && overridesForDescription.TryGetValue(groupPath, out var overridden)
                 ? overridden
                 : DefaultGroupState == TableViewGroupState.Expanded;
-            var groupedItems = group.ToList();
             // IsExpanded must be set before CollectionView: its DependencyProperty changed callback calls back
             // into CollectionView.OnGroupExpandedChanged (which triggers a full group rebuild), and setting it
             // here is just restoring already-computed state, not a real toggle - assigning CollectionView first
             // would make that callback fire mid-rebuild and recurse into BuildGroupLevel until the stack overflows.
             var groupInfo = new TableViewGroupInfo
             {
-                Key = group.Key,
+                Key = key,
                 Level = level,
                 GroupPath = groupPath,
                 Description = description,
@@ -487,7 +503,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
 
             if (isExpanded)
             {
-                BuildGroupLevel(group, level + 1, groupPath);
+                BuildGroupLevel(groupedItems, level + 1, groupPath);
             }
         }
     }

--- a/src/ItemsSource/CollectionView.cs
+++ b/src/ItemsSource/CollectionView.cs
@@ -1,13 +1,12 @@
-﻿using Microsoft.UI.Xaml.Data;
-using System;
+﻿using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Data;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Linq;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using WinUI.TableView.Collections;
 using WinUI.TableView.Extensions;
 
 namespace WinUI.TableView;
@@ -15,12 +14,20 @@ namespace WinUI.TableView;
 /// <summary>
 /// A collection view implementation that supports filtering, sorting, and incremental loading.
 /// </summary>
-internal partial class CollectionView : ICollectionView, ISupportIncrementalLoading, INotifyPropertyChanged, IComparer<object?>
+internal partial class CollectionView : ICollectionView, ISupportIncrementalLoading, INotifyPropertyChanging, INotifyPropertyChanged, IComparer<object?>
 {
     private object[] _itemsCopy = []; // In case the source is ICollection, keep a copy of the items to keep track of removed items.
     private readonly List<object?> _view = [];
+    // The full filtered+sorted set, in source order, regardless of grouping. _view is pruned down to just
+    // the items currently visible under grouping (every leaf-level, expanded group's items, flattened in
+    // group order) - the two only ever match when nothing is grouped.
+    private readonly List<object?> _groupingSourceItems = [];
     private readonly ObservableCollection<FilterDescription> _filterDescriptions = [];
     private readonly ObservableCollection<SortDescription> _sortDescriptions = [];
+#if WINDOWS
+    private readonly ObservableCollection<GroupDescription> _groupDescriptions = [];
+    private readonly Dictionary<GroupDescription, Dictionary<object[], bool>> _groupExpandedStates = [];
+#endif
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CollectionView"/> class.
@@ -31,6 +38,9 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     {
         _filterDescriptions.CollectionChanged += OnFilterDescriptionsCollectionChanged;
         _sortDescriptions.CollectionChanged += OnSortDescriptionsCollectionChanged;
+#if WINDOWS
+        _groupDescriptions.CollectionChanged += OnGroupDescriptionsCollectionChanged;
+#endif
 
         AllowLiveShaping = liveShapingEnabled;
         Source = source ?? new List<object>();
@@ -61,6 +71,38 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
         else
             HandleSortChanged();
     }
+
+#if WINDOWS
+    /// <summary>
+    /// Handles changes to the group descriptions collection. Also drops any recorded expanded/collapsed
+    /// overrides for a description once it's removed - it no longer groups anything, and re-adding the same
+    /// column later creates a brand new <see cref="GroupDescription"/> instance that should start fresh.
+    /// </summary>
+    private void OnGroupDescriptionsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        CollectionGroups = GroupDescriptions.Count > 0 ? new ObservableVector<object>() : null;
+
+        if (_deferCounter > 0) return;
+
+        if (e.Action == NotifyCollectionChangedAction.Reset)
+        {
+            _groupExpandedStates.Clear();
+            HandleSourceChanged();
+        }
+        else
+        {
+            if (e.OldItems is not null)
+            {
+                foreach (var removed in e.OldItems.Cast<GroupDescription>())
+                {
+                    _groupExpandedStates.Remove(removed);
+                }
+            }
+
+            HandleGroupChanged();
+        }
+    }
+#endif
 
     /// <summary>
     /// Attaches collection changed handlers to the source collection.
@@ -256,13 +298,13 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
         if (FilterDescriptions.Any(fd => string.IsNullOrEmpty(fd.PropertyName) || fd.PropertyName == e.PropertyName))
         {
             var filterResult = FilterDescriptions.All(x => x.Predicate(item));
-            var viewIndex = _view.IndexOf(item);
+            var sourceIndex = _groupingSourceItems.IndexOf(item);
 
-            if (viewIndex != -1 && !filterResult)
+            if (sourceIndex != -1 && !filterResult)
             {
-                RemoveFromView(viewIndex, item);
+                RemoveFromView(sourceIndex, item);
             }
-            else if (viewIndex == -1 && filterResult)
+            else if (sourceIndex == -1 && filterResult)
             {
                 var index = Source.IndexOf(item);
                 HandleItemAdded(index, item);
@@ -271,33 +313,39 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
 
         if (SortDescriptions.Any(sd => string.IsNullOrEmpty(sd.PropertyName) || sd.PropertyName == e.PropertyName))
         {
-            var oldIndex = _view.IndexOf(item);
+            var oldIndex = _groupingSourceItems.IndexOf(item);
 
-            // Check if item is in view:
+            // Check if item is in the source set:
             if (oldIndex < 0)
             {
                 return;
             }
 
-            _view.RemoveAt(oldIndex);
-            var targetIndex = _view.BinarySearch(item, this);
+            _groupingSourceItems.RemoveAt(oldIndex);
+            var targetIndex = _groupingSourceItems.BinarySearch(item, this);
             if (targetIndex < 0)
             {
                 targetIndex = ~targetIndex;
             }
 
+            _groupingSourceItems.Insert(targetIndex, item);
+
+#if WINDOWS
+            if (GroupDescriptions.Count > 0)
+            {
+                HandleGroupChanged();
+                return;
+            }
+#endif
+
             // Only trigger expensive UI updates if the index really changed:
             if (targetIndex != oldIndex)
             {
+                _view.RemoveAt(oldIndex);
                 OnVectorChanged(new VectorChangedEventArgs(CollectionChange.ItemRemoved, oldIndex, item));
 
                 _view.Insert(targetIndex, item);
-
                 OnVectorChanged(new VectorChangedEventArgs(CollectionChange.ItemInserted, targetIndex, item));
-            }
-            else
-            {
-                _view.Insert(targetIndex, item);
             }
         }
         else if (string.IsNullOrEmpty(e.PropertyName))
@@ -312,7 +360,7 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     private void HandleSourceChanged()
     {
         var currentItem = CurrentItem;
-        _view.Clear();
+        _groupingSourceItems.Clear();
 
         if (Source is not null)
         {
@@ -321,21 +369,189 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
                 foreach (var item in Source)
                 {
                     if (FilterDescriptions.All(x => x.Predicate(item)))
-                        _view.Add(item);
+                        _groupingSourceItems.Add(item);
                 }
             }
             else
             {
-                _view.AddRange(Source.OfType<object>());
+                _groupingSourceItems.AddRange(Source.OfType<object>());
             }
 
             if (SortDescriptions.Count > 0)
-                _view.Sort(this);
+                _groupingSourceItems.Sort(this);
         }
+
+#if WINDOWS
+        if (GroupDescriptions.Count > 0)
+        {
+            CreateGroupCollections();
+        }
+        else
+        {
+            RebuildFlatView();
+        }
+#else
+        RebuildFlatView();
+#endif
 
         OnVectorChanged(new VectorChangedEventArgs(CollectionChange.Reset));
         MoveCurrentTo(currentItem);
     }
+
+    /// <summary>
+    /// Copies <see cref="_groupingSourceItems"/> into <see cref="_view"/> as-is - the ungrouped case, where
+    /// nothing is pruned.
+    /// </summary>
+    private void RebuildFlatView()
+    {
+        _view.Clear();
+        _view.AddRange(_groupingSourceItems);
+    }
+
+#if WINDOWS
+
+    /// <summary>
+    /// Rebuilds <see cref="CollectionGroups"/> - and, alongside it, <see cref="_view"/> pruned down to just
+    /// what's currently visible - from <see cref="_groupingSourceItems"/>, the full filtered+sorted set.
+    /// </summary>
+    private void CreateGroupCollections()
+    {
+        CollectionGroups?.Clear();
+        _view.Clear();
+
+        if (GroupDescriptions.Count == 0)
+        {
+            _view.AddRange(_groupingSourceItems);
+            return;
+        }
+
+        BuildGroupLevel(_groupingSourceItems, level: 0, parentPath: []);
+    }
+
+    /// <summary>
+    /// Groups <paramref name="items"/> by the <see cref="GroupDescription"/> at <paramref name="level"/>,
+    /// adding a flattened <see cref="CollectionViewGroup"/> entry (in depth-first order) for every group at
+    /// every level, and recursing into deeper levels until the last <see cref="GroupDescription"/> is reached.
+    /// A collapsed group still gets its own header entry, but its descendant subgroups are not built at all,
+    /// and none of its items are appended to <see cref="_view"/> - only a leaf-level, expanded group's items
+    /// are, in group order, so <see cref="_view"/> ends up holding exactly what's currently displayed.
+    /// </summary>
+    private void BuildGroupLevel(IEnumerable<object?> items, int level, object[] parentPath)
+    {
+        var description = GroupDescriptions[level];
+        var isLeafLevel = level == GroupDescriptions.Count - 1;
+        var comparer = Comparer<object?>.Create(description.Compare);
+        var groups = description.Direction == SortDirection.Ascending
+            ? items.GroupBy(description.GetPropertyValue).OrderBy(g => g.Key, comparer)
+            : items.GroupBy(description.GetPropertyValue).OrderByDescending(g => g.Key, comparer);
+
+        var overridesForDescription = _groupExpandedStates.TryGetValue(description, out var existing) ? existing : null;
+
+        foreach (var group in groups)
+        {
+            object[] groupPath = [.. parentPath, group.Key!];
+            var isExpanded = overridesForDescription is not null && overridesForDescription.TryGetValue(groupPath, out var overridden)
+                ? overridden
+                : DefaultGroupState == TableViewGroupState.Expanded;
+            var groupedItems = group.ToList();
+            // IsExpanded must be set before CollectionView: its DependencyProperty changed callback calls back
+            // into CollectionView.OnGroupExpandedChanged (which triggers a full group rebuild), and setting it
+            // here is just restoring already-computed state, not a real toggle - assigning CollectionView first
+            // would make that callback fire mid-rebuild and recurse into BuildGroupLevel until the stack overflows.
+            var groupInfo = new TableViewGroupInfo
+            {
+                Key = group.Key,
+                Level = level,
+                GroupPath = groupPath,
+                Description = description,
+                Count = group.Count(),
+                IsExpanded = isExpanded,
+                CollectionView = this,
+            };
+
+            CollectionGroups?.Add(new CollectionViewGroup
+            {
+                Group = groupInfo,
+                GroupItems = new ObservableVector<object?>(isLeafLevel && isExpanded ? groupedItems : [])
+            });
+
+            if (isLeafLevel)
+            {
+                if (isExpanded)
+                {
+                    _view.AddRange(groupedItems);
+                }
+
+                continue;
+            }
+
+            if (isExpanded)
+            {
+                BuildGroupLevel(group, level + 1, groupPath);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Persists a group's expanded/collapsed state (across the fresh <see cref="TableViewGroupInfo"/> instances
+    /// created on every rebuild) and refreshes the grouped view to reflect it. Only recorded when it differs from
+    /// <see cref="DefaultGroupState"/> - toggling a group back to match the current default clears its override.
+    /// Scoped under the group's own <see cref="GroupDescription"/> so it's dropped entirely once that
+    /// description is removed (see <see cref="OnGroupDescriptionsCollectionChanged"/>).
+    /// </summary>
+    internal void OnGroupExpandedChanged(TableViewGroupInfo info)
+    {
+        if (info.Description is not { } description) return;
+
+        if (info.IsExpanded == (DefaultGroupState == TableViewGroupState.Expanded))
+        {
+            if (_groupExpandedStates.TryGetValue(description, out var overrides))
+            {
+                overrides.Remove(info.GroupPath);
+            }
+        }
+        else
+        {
+            if (!_groupExpandedStates.TryGetValue(description, out var overrides))
+            {
+                overrides = new Dictionary<object[], bool>(ObjectArrayComparer.Instance);
+                _groupExpandedStates[description] = overrides;
+            }
+
+            overrides[info.GroupPath] = info.IsExpanded;
+        }
+
+        HandleGroupChanged();
+    }
+
+    sealed class ObjectArrayComparer : IEqualityComparer<object[]>
+    {
+        public static readonly ObjectArrayComparer Instance = new();
+
+        public bool Equals(object[]? x, object[]? y)
+        {
+            return x is not null && y is not null && x.SequenceEqual(y);
+        }
+
+        public int GetHashCode(object[] obj)
+        {
+            return obj.Aggregate(0, (hash, item) => HashCode.Combine(hash, item));
+        }
+    }
+
+    /// <summary>
+    /// Handles changes to the group descriptions or an individual group's expanded state.
+    /// </summary>
+    private void HandleGroupChanged()
+    {
+        var currentItem = CurrentItem;
+
+        CreateGroupCollections();
+
+        OnVectorChanged(new VectorChangedEventArgs(CollectionChange.Reset));
+        MoveCurrentTo(currentItem);
+    }
+#endif
 
     /// <summary>
     /// Handles changes to the filter descriptions.
@@ -344,9 +560,9 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     {
         if (FilterDescriptions.Count > 0)
         {
-            for (var index = 0; index < _view.Count; index++)
+            for (var index = 0; index < _groupingSourceItems.Count; index++)
             {
-                var item = _view.ElementAt(index);
+                var item = _groupingSourceItems.ElementAt(index);
                 if (FilterDescriptions.All(x => x.Predicate(item)))
                 {
                     continue;
@@ -357,20 +573,20 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
             }
         }
 
-        var viewHash = new HashSet<object?>(_view);
-        var viewIndex = 0;
+        var sourceHash = new HashSet<object?>(_groupingSourceItems);
+        var sourceIndex = 0;
         var i = 0;
         foreach (var item in Source)
         {
-            if (viewHash.Contains(item))
+            if (sourceHash.Contains(item))
             {
-                viewIndex++;
+                sourceIndex++;
                 continue;
             }
 
-            if (HandleItemAdded(i, item, viewIndex))
+            if (HandleItemAdded(i, item, sourceIndex))
             {
-                viewIndex++;
+                sourceIndex++;
             }
 
             i++;
@@ -384,11 +600,22 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     {
         if (SortDescriptions.Count > 0)
         {
-            _view.Sort(this);
+            _groupingSourceItems.Sort(this);
+
+#if WINDOWS
+            if (GroupDescriptions.Count > 0)
+            {
+                HandleGroupChanged();
+                return;
+            }
+#endif
+
+            RebuildFlatView();
         }
         else
         {
             HandleSourceChanged();
+            return;
         }
 
         OnVectorChanged(new VectorChangedEventArgs(CollectionChange.Reset));
@@ -397,21 +624,21 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     /// <summary>
     /// Handles the addition of an item to the collection.
     /// </summary>
-    private bool HandleItemAdded(int newStartingIndex, object? newItem, int? viewIndex = null)
+    private bool HandleItemAdded(int newStartingIndex, object? newItem, int? sourceItemsIndex = null)
     {
         if (!FilterDescriptions.All(x => x.Predicate(newItem)))
         {
             return false;
         }
 
-        var newViewIndex = newStartingIndex;
+        var newIndex = newStartingIndex;
 
         if (_sortDescriptions.Any())
         {
-            newViewIndex = _view.BinarySearch(newItem!, this);
-            if (newViewIndex < 0)
+            newIndex = _groupingSourceItems.BinarySearch(newItem!, this);
+            if (newIndex < 0)
             {
-                newViewIndex = ~newViewIndex;
+                newIndex = ~newIndex;
             }
         }
         else if (FilterDescriptions.Any())
@@ -421,16 +648,26 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
                 HandleSourceChanged();
                 return false;
             }
-            newViewIndex = viewIndex ?? _view.Take(newStartingIndex).Count();
+            newIndex = sourceItemsIndex ?? _groupingSourceItems.Take(newStartingIndex).Count();
         }
 
-        _view.Insert(newViewIndex, newItem!);
-        if (newViewIndex <= CurrentPosition)
+        _groupingSourceItems.Insert(newIndex, newItem!);
+
+#if WINDOWS
+        if (GroupDescriptions.Count > 0)
+        {
+            HandleGroupChanged();
+            return true;
+        }
+#endif
+
+        _view.Insert(newIndex, newItem!);
+        if (newIndex <= CurrentPosition)
         {
             CurrentPosition++;
         }
 
-        var e = new VectorChangedEventArgs(CollectionChange.ItemInserted, newViewIndex, newItem);
+        var e = new VectorChangedEventArgs(CollectionChange.ItemInserted, newIndex, newItem);
         OnVectorChanged(e);
 
         return true;
@@ -446,9 +683,9 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
             return;
         }
 
-        if (oldStartingIndex < 0 || oldStartingIndex >= _view.Count || !Equals(_view[oldStartingIndex], oldItem))
+        if (oldStartingIndex < 0 || oldStartingIndex >= _groupingSourceItems.Count || !Equals(_groupingSourceItems[oldStartingIndex], oldItem))
         {
-            oldStartingIndex = _view.IndexOf(oldItem!);
+            oldStartingIndex = _groupingSourceItems.IndexOf(oldItem!);
         }
 
         if (oldStartingIndex < 0)
@@ -460,10 +697,21 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     }
 
     /// <summary>
-    /// Removes an item from the view.
+    /// Removes an item from <see cref="_groupingSourceItems"/> (identified by its index there) and, if it's
+    /// currently visible, from <see cref="_view"/> too.
     /// </summary>
     private void RemoveFromView(int itemIndex, object? item)
     {
+        _groupingSourceItems.RemoveAt(itemIndex);
+
+#if WINDOWS
+        if (GroupDescriptions.Count > 0)
+        {
+            HandleGroupChanged();
+            return;
+        }
+#endif
+
         _view.RemoveAt(itemIndex);
 
         if (itemIndex <= CurrentPosition)
@@ -708,4 +956,14 @@ internal partial class CollectionView : ICollectionView, ISupportIncrementalLoad
     {
         HandleSortChanged();
     }
+
+#if WINDOWS
+    /// <summary>
+    /// Refreshes the grouping applied to the view.
+    /// </summary>
+    public void RefreshGrouping()
+    {
+        HandleGroupChanged();
+    }
+#endif
 }

--- a/src/ItemsSource/CollectionViewGroup.cs
+++ b/src/ItemsSource/CollectionViewGroup.cs
@@ -1,0 +1,28 @@
+#if WINDOWS
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using Windows.Foundation.Collections;
+using WinUI.TableView.Collections;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// A single flattened entry in <see cref="CollectionView.CollectionGroups"/>. For a leaf-level group,
+/// <see cref="GroupItems"/> holds the actual items; for a non-leaf (parent) group it's always empty, since
+/// <see cref="CollectionView"/> flattens the group tree depth-first so a plain <see cref="ICollectionView.CollectionGroups"/>
+/// consumer (like a grouped ListView) can render nested grouping without needing to understand the hierarchy itself.
+/// </summary>
+internal partial class CollectionViewGroup : DependencyObject, ICollectionViewGroup
+{
+    /// <summary>
+    /// Gets the <see cref="TableViewGroupInfo"/> describing this group (its name, nesting level, item count,
+    /// and expanded/collapsed state).
+    /// </summary>
+    public object? Group { get; init; }
+
+    /// <summary>
+    /// Gets the items belonging to this group. Empty for a non-leaf (parent) group or a collapsed group.
+    /// </summary>
+    public IObservableVector<object?>? GroupItems { get; init; }
+}
+#endif

--- a/src/ItemsSource/ColumnGroupDescription.cs
+++ b/src/ItemsSource/ColumnGroupDescription.cs
@@ -1,0 +1,39 @@
+namespace WinUI.TableView;
+
+/// <summary>
+/// A <see cref="GroupDescription"/> created for grouping by a <see cref="TableViewColumn"/> from its header's
+/// "Group" command - grouping by the column's bound property (or <see cref="TableViewColumn.SortMemberPath"/>
+/// when set) if it has one, otherwise by its rendered cell content.
+/// </summary>
+internal class ColumnGroupDescription : GroupDescription
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ColumnGroupDescription"/> class.
+    /// </summary>
+    /// <param name="column">The column being grouped by.</param>
+    /// <param name="propertyName">The property to group by, or <see langword="null"/> to group by the column's rendered cell content.</param>
+    /// <param name="direction">The direction groups are ordered in.</param>
+    public ColumnGroupDescription(TableViewColumn column,
+                                  string? propertyName,
+                                  SortDirection direction = SortDirection.Ascending)
+        : base(propertyName, direction)
+    {
+        Column = column;
+    }
+
+    /// <inheritdoc/>
+    public override object? GetPropertyValue(object? item)
+    {
+        // Use reflection-based property access when SortMemberPath is explicitly provided; otherwise, fall back to column cell content.
+        if (!string.IsNullOrEmpty(Column.SortMemberPath))
+        {
+            return base.GetPropertyValue(item);
+        }
+        return Column.GetCellContent(item);
+    }
+
+    /// <summary>
+    /// Gets the column associated with this group description.
+    /// </summary>
+    public TableViewColumn Column { get; }
+}

--- a/src/ItemsSource/ColumnSortDescription.cs
+++ b/src/ItemsSource/ColumnSortDescription.cs
@@ -13,7 +13,7 @@ internal class ColumnSortDescription : SortDescription
     /// <param name="direction">The direction of the sort.</param>
     public ColumnSortDescription(TableViewColumn column,
                                  string? propertyName,
-                                 SortDirection direction)
+                                 SortDirection direction = SortDirection.Ascending)
         : base(propertyName!, direction, null, null)
     {
         Column = column;

--- a/src/ItemsSource/GroupDescription.cs
+++ b/src/ItemsSource/GroupDescription.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Describes a grouping operation applied to TableView items. Extends <see cref="SortDescription"/> since
+/// grouping and sorting share the same "extract a value, then order/compare by it" shape - a group's own
+/// items, and the groups themselves, are ordered using this description's <see cref="SortDescription.Direction"/>
+/// and <see cref="SortDescription.Comparer"/>.
+/// </summary>
+public class GroupDescription : SortDescription
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GroupDescription"/> class.
+    /// </summary>
+    /// <param name="propertyName">The name of the property to group by.</param>
+    /// <param name="direction">The direction groups are ordered in.</param>
+    /// <param name="comparer">An optional comparer to use for ordering groups.</param>
+    /// <param name="valueDelegate">An optional delegate to extract the value to group by.</param>
+    public GroupDescription(string? propertyName,
+                            SortDirection direction = SortDirection.Ascending,
+                            IComparer? comparer = null,
+                            Func<object?, object?>? valueDelegate = null)
+        : base(propertyName, direction, comparer, valueDelegate)
+    {
+    }
+}

--- a/src/ItemsSource/GroupDescription.cs
+++ b/src/ItemsSource/GroupDescription.cs
@@ -24,4 +24,11 @@ public class GroupDescription : SortDescription
         : base(propertyName, direction, comparer, valueDelegate)
     {
     }
+
+    /// <summary>
+    /// Gets or sets what groups at this level are ordered by - their key value (default) or the number of
+    /// items they contain. <see cref="SortDescription.Direction"/> still controls ascending/descending of
+    /// whichever this is set to.
+    /// </summary>
+    public GroupSortMode SortMode { get; set; } = GroupSortMode.Key;
 }

--- a/src/ItemsSource/GroupSortMode.cs
+++ b/src/ItemsSource/GroupSortMode.cs
@@ -1,0 +1,17 @@
+namespace WinUI.TableView;
+
+/// <summary>
+/// Specifies what a <see cref="GroupDescription"/> orders its groups by.
+/// </summary>
+public enum GroupSortMode
+{
+    /// <summary>
+    /// Groups are ordered by their key value (default).
+    /// </summary>
+    Key = 0,
+
+    /// <summary>
+    /// Groups are ordered by the number of items they contain.
+    /// </summary>
+    Count = 1
+}

--- a/src/ItemsSource/SortDescription.cs
+++ b/src/ItemsSource/SortDescription.cs
@@ -21,7 +21,7 @@ public class SortDescription
     /// <param name="comparer">An optional comparer to use for sorting.</param>
     /// <param name="valueDelegate">An optional delegate to extract the value to sort by.</param>
     public SortDescription(string? propertyName,
-                           SortDirection direction,
+                           SortDirection direction = SortDirection.Ascending,
                            IComparer? comparer = null,
                            Func<object?, object?>? valueDelegate = null)
     {
@@ -71,9 +71,9 @@ public class SortDescription
     public string? PropertyName { get; }
 
     /// <summary>
-    /// Gets the direction of the sort.
+    /// Gets or sets the direction of the sort.
     /// </summary>
-    public SortDirection Direction { get; }
+    public SortDirection Direction { get; set; }
 
     /// <summary>
     /// Gets the comparer to use for sorting.

--- a/src/ItemsSource/TableViewGroupInfo.cs
+++ b/src/ItemsSource/TableViewGroupInfo.cs
@@ -1,0 +1,76 @@
+#if WINDOWS
+using Microsoft.UI.Xaml;
+using WinRT;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Describes a single group header shown by a <see cref="TableViewGroupHeaderRow"/> - its display name, item
+/// count, nesting level, and expanded/collapsed state. This is the object bound as a <see cref="CollectionViewGroup"/>'s
+/// <see cref="CollectionViewGroup.Group"/>.
+/// </summary>
+[GeneratedBindableCustomProperty]
+public partial class TableViewGroupInfo : DependencyObject
+{
+
+    private static void OnIsExpandedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var info = (TableViewGroupInfo)d;
+        info.CollectionView?.OnGroupExpandedChanged(info);
+    }
+
+    /// <summary>
+    /// A stable identifier for this group's position in the group tree (level + key, prefixed by every
+    /// ancestor's own key), used to persist its expanded/collapsed state across rebuilds.
+    /// </summary>
+    internal object[] GroupPath { get; set; } = [];
+
+    /// <summary>
+    /// The <see cref="GroupDescription"/> for this group's level, used to scope its persisted expanded/collapsed
+    /// override to the description instance it belongs to - see <see cref="CollectionView.OnGroupExpandedChanged"/>.
+    /// </summary>
+    internal GroupDescription? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="CollectionView"/> that owns this group, used to notify it when the group's
+    /// expanded/collapsed state changes.
+    /// </summary>
+    internal CollectionView? CollectionView { get; set; }
+
+    /// <summary>
+    /// Gets the group's key, e.g. the value of the column/property being grouped by.
+    /// </summary>
+    public object? Key { get; init; }
+
+    /// <summary>
+    /// Gets the number of items in this group (including all descendant subgroups/items, if any).
+    /// </summary>
+    public int Count { get; init; }
+
+    /// <summary>
+    /// Gets the zero-based nesting level of this group among the active <see cref="GroupDescription"/> entries.
+    /// </summary>
+    internal int Level { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this group's items (and, for a non-leaf group, every descendant
+    /// subgroup/item) are currently shown.
+    /// </summary>
+    public bool IsExpanded
+    {
+        get => (bool)GetValue(IsExpandedProperty);
+        set => SetValue(IsExpandedProperty, value);
+    }
+
+    /// <summary>
+    /// Identifies the <see cref="IsExpanded"/> dependency property.
+    /// </summary>
+    public static readonly DependencyProperty IsExpandedProperty = DependencyProperty.Register(nameof(IsExpanded), typeof(bool), typeof(TableViewGroupInfo), new PropertyMetadata(true, OnIsExpandedChanged));
+
+    /// <inheritdoc/>
+    public override string? ToString()
+    {
+        return $"{Key}";
+    }
+}
+#endif

--- a/src/Strings/de-DE/WinUI.TableView.resw
+++ b/src/Strings/de-DE/WinUI.TableView.resw
@@ -198,4 +198,10 @@
   <data name="UngroupAll" xml:space="preserve">
     <value>Alle Gruppierungen aufheben</value>
   </data>
+  <data name="SortGroupsByCount" xml:space="preserve">
+    <value>Gruppen nach Anzahl sortieren</value>
+  </data>
+  <data name="SortGroupsByValue" xml:space="preserve">
+    <value>Gruppen nach Wert sortieren</value>
+  </data>
 </root>

--- a/src/Strings/de-DE/WinUI.TableView.resw
+++ b/src/Strings/de-DE/WinUI.TableView.resw
@@ -189,4 +189,13 @@
   <data name="Filtered" xml:space="preserve">
     <value>Gefiltert</value>
   </data>
+  <data name="Group" xml:space="preserve">
+    <value>Gruppieren</value>
+  </data>
+  <data name="Ungroup" xml:space="preserve">
+    <value>Gruppierung aufheben</value>
+  </data>
+  <data name="UngroupAll" xml:space="preserve">
+    <value>Alle Gruppierungen aufheben</value>
+  </data>
 </root>

--- a/src/Strings/en-US/WinUI.TableView.resw
+++ b/src/Strings/en-US/WinUI.TableView.resw
@@ -198,4 +198,10 @@
   <data name="UngroupAll" xml:space="preserve">
     <value>Ungroup All</value>
   </data>
+  <data name="SortGroupsByCount" xml:space="preserve">
+    <value>Sort Groups by Count</value>
+  </data>
+  <data name="SortGroupsByValue" xml:space="preserve">
+    <value>Sort Groups by Value</value>
+  </data>
 </root>

--- a/src/Strings/en-US/WinUI.TableView.resw
+++ b/src/Strings/en-US/WinUI.TableView.resw
@@ -189,4 +189,13 @@
   <data name="Filtered" xml:space="preserve">
     <value>Filtered</value>
   </data>
+  <data name="Group" xml:space="preserve">
+    <value>Group</value>
+  </data>
+  <data name="Ungroup" xml:space="preserve">
+    <value>Ungroup</value>
+  </data>
+  <data name="UngroupAll" xml:space="preserve">
+    <value>Ungroup All</value>
+  </data>
 </root>

--- a/src/Strings/es-ES/WinUI.TableView.resw
+++ b/src/Strings/es-ES/WinUI.TableView.resw
@@ -189,4 +189,13 @@
   <data name="Filtered" xml:space="preserve">
     <value>Filtrado</value>
   </data>
+  <data name="Group" xml:space="preserve">
+    <value>Agrupar</value>
+  </data>
+  <data name="Ungroup" xml:space="preserve">
+    <value>Desagrupar</value>
+  </data>
+  <data name="UngroupAll" xml:space="preserve">
+    <value>Desagrupar todo</value>
+  </data>
 </root>

--- a/src/Strings/es-ES/WinUI.TableView.resw
+++ b/src/Strings/es-ES/WinUI.TableView.resw
@@ -198,4 +198,10 @@
   <data name="UngroupAll" xml:space="preserve">
     <value>Desagrupar todo</value>
   </data>
+  <data name="SortGroupsByCount" xml:space="preserve">
+    <value>Ordenar grupos por recuento</value>
+  </data>
+  <data name="SortGroupsByValue" xml:space="preserve">
+    <value>Ordenar grupos por valor</value>
+  </data>
 </root>

--- a/src/Strings/fa-IR/WinUI.TableView.resw
+++ b/src/Strings/fa-IR/WinUI.TableView.resw
@@ -189,4 +189,13 @@
   <data name="Filtered" xml:space="preserve">
     <value>فیلتر شده</value>
   </data>
+  <data name="Group" xml:space="preserve">
+    <value>گروه‌ بندی</value>
+  </data>
+  <data name="Ungroup" xml:space="preserve">
+    <value>لغو گروه‌ بندی</value>
+  </data>
+  <data name="UngroupAll" xml:space="preserve">
+    <value>لغو همه گروه‌ بندی‌ ها</value>
+  </data>
 </root>

--- a/src/Strings/fa-IR/WinUI.TableView.resw
+++ b/src/Strings/fa-IR/WinUI.TableView.resw
@@ -198,4 +198,10 @@
   <data name="UngroupAll" xml:space="preserve">
     <value>لغو همه گروه‌ بندی‌ ها</value>
   </data>
+  <data name="SortGroupsByCount" xml:space="preserve">
+    <value>مرتب‌ سازی گروه‌ ها بر اساس تعداد</value>
+  </data>
+  <data name="SortGroupsByValue" xml:space="preserve">
+    <value>مرتب‌ سازی گروه‌ ها بر اساس مقدار</value>
+  </data>
 </root>

--- a/src/Strings/ja-JP/WinUI.TableView.resw
+++ b/src/Strings/ja-JP/WinUI.TableView.resw
@@ -208,4 +208,10 @@
   <data name="UngroupAll" xml:space="preserve">
     <value>すべてグループ解除</value>
   </data>
+  <data name="SortGroupsByCount" xml:space="preserve">
+    <value>グループを件数で並べ替え</value>
+  </data>
+  <data name="SortGroupsByValue" xml:space="preserve">
+    <value>グループを値で並べ替え</value>
+  </data>
 </root>

--- a/src/Strings/ja-JP/WinUI.TableView.resw
+++ b/src/Strings/ja-JP/WinUI.TableView.resw
@@ -197,4 +197,15 @@
   <data name="Filtered" xml:space="preserve">
     <value>フィルター済み</value>
   </data>
+  <data name="Group" xml:space="preserve">
+    <value>グループ化</value>
+    <comment>Excel 表記準拠</comment>
+  </data>
+  <data name="Ungroup" xml:space="preserve">
+    <value>グループ解除</value>
+    <comment>Excel 表記準拠</comment>
+  </data>
+  <data name="UngroupAll" xml:space="preserve">
+    <value>すべてグループ解除</value>
+  </data>
 </root>

--- a/src/Strings/pt-BR/WinUI.TableView.resw
+++ b/src/Strings/pt-BR/WinUI.TableView.resw
@@ -189,4 +189,13 @@
   <data name="Filtered" xml:space="preserve">
     <value>Filtrado</value>
   </data>
+  <data name="Group" xml:space="preserve">
+    <value>Agrupar</value>
+  </data>
+  <data name="Ungroup" xml:space="preserve">
+    <value>Desagrupar</value>
+  </data>
+  <data name="UngroupAll" xml:space="preserve">
+    <value>Desagrupar tudo</value>
+  </data>
 </root>

--- a/src/Strings/pt-BR/WinUI.TableView.resw
+++ b/src/Strings/pt-BR/WinUI.TableView.resw
@@ -198,4 +198,10 @@
   <data name="UngroupAll" xml:space="preserve">
     <value>Desagrupar tudo</value>
   </data>
+  <data name="SortGroupsByCount" xml:space="preserve">
+    <value>Ordenar grupos por contagem</value>
+  </data>
+  <data name="SortGroupsByValue" xml:space="preserve">
+    <value>Ordenar grupos por valor</value>
+  </data>
 </root>

--- a/src/Strings/ru-RU/WinUI.TableView.resw
+++ b/src/Strings/ru-RU/WinUI.TableView.resw
@@ -198,4 +198,10 @@
   <data name="UngroupAll" xml:space="preserve">
     <value>Разгруппировать всё</value>
   </data>
+  <data name="SortGroupsByCount" xml:space="preserve">
+    <value>Сортировать группы по количеству</value>
+  </data>
+  <data name="SortGroupsByValue" xml:space="preserve">
+    <value>Сортировать группы по значению</value>
+  </data>
 </root>

--- a/src/Strings/ru-RU/WinUI.TableView.resw
+++ b/src/Strings/ru-RU/WinUI.TableView.resw
@@ -189,4 +189,13 @@
   <data name="Filtered" xml:space="preserve">
     <value>Отфильтровано</value>
   </data>
+  <data name="Group" xml:space="preserve">
+    <value>Группировать</value>
+  </data>
+  <data name="Ungroup" xml:space="preserve">
+    <value>Разгруппировать</value>
+  </data>
+  <data name="UngroupAll" xml:space="preserve">
+    <value>Разгруппировать всё</value>
+  </data>
 </root>

--- a/src/Strings/sk-SK/WinUI.TableView.resw
+++ b/src/Strings/sk-SK/WinUI.TableView.resw
@@ -189,4 +189,13 @@
   <data name="Filtered" xml:space="preserve">
     <value>Filtrované</value>
   </data>
+  <data name="Group" xml:space="preserve">
+    <value>Zoskupiť</value>
+  </data>
+  <data name="Ungroup" xml:space="preserve">
+    <value>Zrušiť Zoskupenie</value>
+  </data>
+  <data name="UngroupAll" xml:space="preserve">
+    <value>Zrušiť Všetky Zoskupenia</value>
+  </data>
 </root>

--- a/src/Strings/sk-SK/WinUI.TableView.resw
+++ b/src/Strings/sk-SK/WinUI.TableView.resw
@@ -198,4 +198,10 @@
   <data name="UngroupAll" xml:space="preserve">
     <value>Zrušiť Všetky Zoskupenia</value>
   </data>
+  <data name="SortGroupsByCount" xml:space="preserve">
+    <value>Zoradiť Skupiny Podľa Počtu</value>
+  </data>
+  <data name="SortGroupsByValue" xml:space="preserve">
+    <value>Zoradiť Skupiny Podľa Hodnoty</value>
+  </data>
 </root>

--- a/src/Strings/zh-CN/WinUI.TableView.resw
+++ b/src/Strings/zh-CN/WinUI.TableView.resw
@@ -198,4 +198,10 @@
   <data name="UngroupAll" xml:space="preserve">
     <value>取消所有分组</value>
   </data>
+  <data name="SortGroupsByCount" xml:space="preserve">
+    <value>按数量排序分组</value>
+  </data>
+  <data name="SortGroupsByValue" xml:space="preserve">
+    <value>按值排序分组</value>
+  </data>
 </root>

--- a/src/Strings/zh-CN/WinUI.TableView.resw
+++ b/src/Strings/zh-CN/WinUI.TableView.resw
@@ -189,4 +189,13 @@
   <data name="Filtered" xml:space="preserve">
     <value>已筛选</value>
   </data>
+  <data name="Group" xml:space="preserve">
+    <value>分组</value>
+  </data>
+  <data name="Ungroup" xml:space="preserve">
+    <value>取消分组</value>
+  </data>
+  <data name="UngroupAll" xml:space="preserve">
+    <value>取消所有分组</value>
+  </data>
 </root>

--- a/src/Strings/zh-TW/WinUI.TableView.resw
+++ b/src/Strings/zh-TW/WinUI.TableView.resw
@@ -198,4 +198,10 @@
   <data name="UngroupAll" xml:space="preserve">
     <value>取消所有群組</value>
   </data>
+  <data name="SortGroupsByCount" xml:space="preserve">
+    <value>依數量排序群組</value>
+  </data>
+  <data name="SortGroupsByValue" xml:space="preserve">
+    <value>依值排序群組</value>
+  </data>
 </root>

--- a/src/Strings/zh-TW/WinUI.TableView.resw
+++ b/src/Strings/zh-TW/WinUI.TableView.resw
@@ -189,4 +189,13 @@
   <data name="Filtered" xml:space="preserve">
     <value>已篩選</value>
   </data>
+  <data name="Group" xml:space="preserve">
+    <value>群組</value>
+  </data>
+  <data name="Ungroup" xml:space="preserve">
+    <value>取消群組</value>
+  </data>
+  <data name="UngroupAll" xml:space="preserve">
+    <value>取消所有群組</value>
+  </data>
 </root>

--- a/src/TableView.Events.cs
+++ b/src/TableView.Events.cs
@@ -147,6 +147,22 @@ partial class TableView
         CellContextFlyoutOpening?.Invoke(this, args);
     }
 
+#if WINDOWS
+    /// <summary>
+    /// Occurs when a grouping is being applied to a column in the TableView.
+    /// </summary>
+    public event EventHandler<TableViewGroupingEventArgs>? Grouping;
+
+    /// <summary>
+    /// Called before the <see cref="Grouping"/> event occurs.
+    /// </summary>
+    /// <param name="args">Handleable event args.</param>
+    protected internal virtual void OnGrouping(TableViewGroupingEventArgs args)
+    {
+        Grouping?.Invoke(this, args);
+    }
+#endif
+
     /// <summary>
     /// Occurs when a sorting is being applied to a column in the TableView.
     /// </summary>

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -600,6 +600,11 @@ public partial class TableView
 
 #if WINDOWS
     /// <summary>
+    /// Gets the collection of group descriptions applied to the items.
+    /// </summary>
+    public IList<GroupDescription> GroupDescriptions => _collectionView.GroupDescriptions;
+
+    /// <summary>
     /// Gets a value indicating whether the TableView items are grouped.
     /// </summary>
     public bool IsGrouped => _collectionView.GroupDescriptions.Count > 0;

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -77,6 +77,33 @@ public partial class TableView
     /// </summary>
     public static readonly DependencyProperty CornerButtonModeProperty = DependencyProperty.Register(nameof(CornerButtonMode), typeof(TableViewCornerButtonMode), typeof(TableView), new PropertyMetadata(TableViewCornerButtonMode.Options, OnCornerButtonModeChanged));
 
+#if WINDOWS
+    /// <summary>
+    /// Identifies the CanGroupColumns dependency property.
+    /// </summary>
+    public static readonly DependencyProperty CanGroupColumnsProperty = DependencyProperty.Register(nameof(CanGroupColumns), typeof(bool), typeof(TableView), new PropertyMetadata(true));
+
+    /// <summary>
+    /// Identifies the AreStickyGroupHeadersEnabled dependency property.
+    /// </summary>
+    public static readonly DependencyProperty AreStickyGroupHeadersEnabledProperty = DependencyProperty.Register(nameof(AreStickyGroupHeadersEnabled), typeof(bool), typeof(TableView), new PropertyMetadata(false, OnAreStickyGroupHeadersEnabledChanged));
+
+    /// <summary>
+    /// Identifies the DefaultGroupStyle dependency property.
+    /// </summary>
+    public static readonly DependencyProperty DefaultGroupStyleProperty = DependencyProperty.Register(nameof(DefaultGroupStyle), typeof(GroupStyle), typeof(TableView), new PropertyMetadata(null));
+
+    /// <summary>
+    /// Identifies the DefaultGroupState dependency property.
+    /// </summary>
+    public static readonly DependencyProperty DefaultGroupStateProperty = DependencyProperty.Register(nameof(DefaultGroupState), typeof(TableViewGroupState), typeof(TableView), new PropertyMetadata(TableViewGroupState.Collapsed, OnDefaultGroupStateChanged));
+
+    /// <summary>
+    /// Identifies the ShowGroupExpandCollapseButton dependency property.
+    /// </summary>
+    public static readonly DependencyProperty ShowGroupExpandCollapseButtonProperty = DependencyProperty.Register(nameof(ShowGroupExpandCollapseButton), typeof(bool), typeof(TableView), new PropertyMetadata(true, OnShowGroupExpandCollapseButtonChanged));
+#endif
+
     /// <summary>
     /// Identifies the CanResizeColumns dependency property.
     /// </summary>
@@ -571,6 +598,66 @@ public partial class TableView
         set => SetValue(CornerButtonModeProperty, value);
     }
 
+#if WINDOWS
+    /// <summary>
+    /// Gets a value indicating whether the TableView items are grouped.
+    /// </summary>
+    public bool IsGrouped => _collectionView.GroupDescriptions.Count > 0;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether columns can be grouped. This will override what is set on individual column.
+    /// </summary>
+    public bool CanGroupColumns
+    {
+        get => (bool)GetValue(CanGroupColumnsProperty);
+        set => SetValue(CanGroupColumnsProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a group header stays pinned to the top of the viewport while
+    /// scrolling through its items.
+    /// </summary>
+    public bool AreStickyGroupHeadersEnabled
+    {
+        get => (bool)GetValue(AreStickyGroupHeadersEnabledProperty);
+        set => SetValue(AreStickyGroupHeadersEnabledProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the default <see cref="Microsoft.UI.Xaml.Controls.GroupStyle"/> used when the consumer hasn't
+    /// added one to <see cref="ListViewBase.GroupStyle"/> themselves. Set from the default style; there's normally
+    /// no need to set this directly. It's a plain property (rather than being applied via <c>GroupStyleSelector</c>)
+    /// because <c>GroupStyleSelector</c>, once set, always takes priority over <see cref="ListViewBase.GroupStyle"/>
+    /// regardless of whether the consumer added their own entries, which would make overriding it impossible.
+    /// </summary>
+    public GroupStyle? DefaultGroupStyle
+    {
+        get => (GroupStyle?)GetValue(DefaultGroupStyleProperty);
+        set => SetValue(DefaultGroupStyleProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether a group starts out expanded or collapsed by default, unless it's been explicitly
+    /// toggled away from that.
+    /// </summary>
+    public TableViewGroupState DefaultGroupState
+    {
+        get => (TableViewGroupState)GetValue(DefaultGroupStateProperty);
+        set => SetValue(DefaultGroupStateProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a group header shows its expand/collapse button. When
+    /// <see langword="false"/>, groups can still be toggled programmatically (e.g. <see cref="CollectionView.ToggleGroup"/>)
+    /// or start collapsed/expanded via <see cref="DefaultGroupState"/> - only the button is hidden.
+    /// </summary>
+    public bool ShowGroupExpandCollapseButton
+    {
+        get => (bool)GetValue(ShowGroupExpandCollapseButtonProperty);
+        set => SetValue(ShowGroupExpandCollapseButtonProperty, value);
+    }
+#endif
+
     /// <summary>
     /// Gets or sets a value indicating whether columns can be resized. This will override what is set on individual column.
     /// </summary>
@@ -963,6 +1050,44 @@ public partial class TableView
         }
     }
 
+#if WINDOWS
+    /// <summary>
+    /// Handles changes to the AreStickyGroupHeadersEnabled property.
+    /// </summary>
+    private static void OnAreStickyGroupHeadersEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView)
+        {
+            tableView.ApplyStickyGroupHeadersSetting();
+        }
+    }
+
+    /// <summary>
+    /// Handles changes to the DefaultGroupState property.
+    /// </summary>
+    private static void OnDefaultGroupStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView)
+        {
+            tableView._collectionView.DefaultGroupState = (TableViewGroupState)e.NewValue;
+        }
+    }
+
+    /// <summary>
+    /// Handles changes to the ShowGroupExpandCollapseButton property.
+    /// </summary>
+    private static void OnShowGroupExpandCollapseButtonChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView)
+        {
+            foreach (var groupHeaderRow in tableView._groupHeaderRows)
+            {
+                groupHeaderRow.UpdateExpandCollapseButtonVisibility();
+            }
+        }
+    }
+#endif
+
     /// <summary>
     /// Handles changes to the IsReadOnly property.
     /// </summary>
@@ -1253,7 +1378,10 @@ public partial class TableView
     /// </summary>
     private void OnBaseItemsSourceChanged(DependencyObject sender, DependencyProperty dp)
     {
-        throw new InvalidOperationException("Setting this property directly is not allowed. Use TableView.ItemsSource instead.");
+        if (_shouldThrowBaseProeprtyChangedException)
+        {
+            throw new InvalidOperationException("Setting this property directly is not allowed. Use TableView.ItemsSource instead.");
+        }
     }
 
     /// <summary>
@@ -1261,7 +1389,7 @@ public partial class TableView
     /// </summary>
     private void OnBaseSelectionModeChanged(DependencyObject sender, DependencyProperty dp)
     {
-        if (!_shouldThrowSelectionModeChangedException)
+        if (_shouldThrowBaseProeprtyChangedException)
         {
             throw new InvalidOperationException("Setting this property directly is not allowed. Use TableView.SelectionMode instead.");
         }

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -625,9 +625,9 @@ public partial class TableView
 
     /// <summary>
     /// Gets or sets the default <see cref="Microsoft.UI.Xaml.Controls.GroupStyle"/> used when the consumer hasn't
-    /// added one to <see cref="ListViewBase.GroupStyle"/> themselves. Set from the default style; there's normally
+    /// added one to <c>ListViewBase.GroupStyle</c> themselves. Set from the default style; there's normally
     /// no need to set this directly. It's a plain property (rather than being applied via <c>GroupStyleSelector</c>)
-    /// because <c>GroupStyleSelector</c>, once set, always takes priority over <see cref="ListViewBase.GroupStyle"/>
+    /// because <c>GroupStyleSelector</c>, once set, always takes priority over <c>ListViewBase.GroupStyle</c>
     /// regardless of whether the consumer added their own entries, which would make overriding it impossible.
     /// </summary>
     public GroupStyle? DefaultGroupStyle
@@ -648,8 +648,9 @@ public partial class TableView
 
     /// <summary>
     /// Gets or sets a value indicating whether a group header shows its expand/collapse button. When
-    /// <see langword="false"/>, groups can still be toggled programmatically (e.g. <see cref="CollectionView.ToggleGroup"/>)
-    /// or start collapsed/expanded via <see cref="DefaultGroupState"/> - only the button is hidden.
+    /// <see langword="false"/>, groups can still be toggled programmatically (e.g. by setting
+    /// <see cref="TableViewGroupInfo.IsExpanded"/> directly) or start collapsed/expanded via
+    /// <see cref="DefaultGroupState"/> - only the button is hidden.
     /// </summary>
     public bool ShowGroupExpandCollapseButton
     {

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -1741,6 +1741,14 @@ public partial class TableView : ListView
 
         foreach (var column in Columns.Where(c => c.SortDirection is not null))
         {
+#if WINDOWS
+            // A grouped column's SortDirection mirrors its group's own order, not an independent sort -
+            // sorting a different column shouldn't strip its indicator or desync it from the group.
+            if (_collectionView.GroupDescriptions.Any(x => x is ColumnGroupDescription columnGroup && columnGroup.Column == column))
+            {
+                continue;
+            }
+#endif
             column?.SortDirection = null;
         }
     }

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -1794,6 +1794,9 @@ public partial class TableView : ListView
         _collectionView.SortDescriptions.RemoveWhere(x => x is ColumnSortDescription columnSort && groupedColumns.Contains(columnSort.Column));
     }
 
+    /// <summary>
+    /// Refreshes the grouping applied to the items in the TableView.
+    /// </summary>
     public void RefreshGrouping()
     {
         DeselectAll();

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -1793,6 +1793,12 @@ public partial class TableView : ListView
         // though its SortDirection indicator above was just cleared.
         _collectionView.SortDescriptions.RemoveWhere(x => x is ColumnSortDescription columnSort && groupedColumns.Contains(columnSort.Column));
     }
+
+    public void RefreshGrouping()
+    {
+        DeselectAll();
+        _collectionView.RefreshGrouping();
+    }
 #endif
 
     /// <summary>

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -197,12 +197,8 @@ public partial class TableView : ListView
 
         if (SelectedItems?.Count == 1)
         {
-            //// Items.IndexOf(SelectedItem), not SelectedIndex: once grouped, a grouped ListViewBase's own
-            //// SelectedIndex has been observed resolving against a different (and inconsistent) index space
-            //// than Items - passing that straight into ScrollRowIntoView's Items[index] lookup could hand it
-            //// an entirely unrelated item to scroll to.
-            //var index = Items.IndexOf(SelectedItem);
-            //DispatcherQueue.TryEnqueue(async () => await ScrollRowIntoView(index));
+            var index = Items.IndexOf(SelectedItem);
+            DispatcherQueue.TryEnqueue(async () => await ScrollRowIntoView(index));
         }
     }
 
@@ -1783,12 +1779,19 @@ public partial class TableView : ListView
     /// </summary>
     public void UngroupAll()
     {
-        foreach (var column in _collectionView.GroupDescriptions.OfType<ColumnGroupDescription>().Select(x => x.Column))
+        var groupedColumns = _collectionView.GroupDescriptions.OfType<ColumnGroupDescription>().Select(x => x.Column).ToList();
+
+        foreach (var column in groupedColumns)
         {
             column.SortDirection = null;
         }
 
         _collectionView.GroupDescriptions.Clear();
+
+        // A column can still have an independent ColumnSortDescription mirroring its group's order (see
+        // HasGroupSortCompanion) - without removing it too, the view would stay sorted by that column even
+        // though its SortDirection indicator above was just cleared.
+        _collectionView.SortDescriptions.RemoveWhere(x => x is ColumnSortDescription columnSort && groupedColumns.Contains(columnSort.Column));
     }
 #endif
 
@@ -2142,13 +2145,13 @@ public partial class TableView : ListView
             return;
         }
 
-        //// This runs from CurrentCellSlot's DependencyProperty changed callback, which fires synchronously
-        //// as part of CurrentCellSlot's own SetValue call. Without yielding first, everything below - down
-        //// through ScrollCellIntoView's native ScrollIntoView call - executes re-entrantly on that same
-        //// native SetValue call stack, which crashes the process outright (an unhandled native exception,
-        //// not a catchable .NET one). Yielding lets that SetValue call fully unwind before touching XAML's
-        //// scroll/layout machinery again.
-        //await Task.Yield();
+        // This runs from CurrentCellSlot's DependencyProperty changed callback, which fires synchronously
+        // as part of CurrentCellSlot's own SetValue call. Without yielding first, everything below - down
+        // through ScrollCellIntoView's native ScrollIntoView call - executes re-entrantly on that same
+        // native SetValue call stack, which crashes the process outright (an unhandled native exception,
+        // not a catchable .NET one). Yielding lets that SetValue call fully unwind before touching XAML's
+        // scroll/layout machinery again.
+        await Task.Yield();
 
         if (oldSlot.HasValue)
         {

--- a/src/TableView.cs
+++ b/src/TableView.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
+using Windows.Foundation.Collections;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.System;
@@ -30,7 +31,7 @@ public partial class TableView : ListView
     private TableViewHeaderRow? _headerRow;
     private ScrollViewer? _scrollViewer;
     private RowDefinition? _headerRowDefinition;
-    private bool _shouldThrowSelectionModeChangedException;
+    private bool _shouldThrowBaseProeprtyChangedException = true;
     private bool _ensureColumns = true;
     private bool _isItemsSourceSuspended;
     private readonly List<TableViewRow> _rows = [];
@@ -55,6 +56,10 @@ public partial class TableView : ListView
     private readonly List<TableViewCell> _resizingPreviewCells = [];
     private readonly List<TableViewCell> _resizingDownstreamCells = [];
     private readonly List<(Panel Panel, TranslateTransform Shift)> _resizingScrollableShifts = [];
+    // private bool _isScrollingRowIntoView;
+#if WINDOWS
+    private readonly List<TableViewGroupHeaderRow> _groupHeaderRows = [];
+#endif
 
     /// <summary>
     /// Initializes a new instance of the TableView class.
@@ -77,7 +82,82 @@ public partial class TableView : ListView
         Unloaded += OnUnloaded;
         SelectionChanged += TableView_SelectionChanged;
         _collectionView.ItemPropertyChanged += OnItemPropertyChanged;
+#if WINDOWS
+        _collectionView.VectorChanged += OnCollectionViewVectorChanged;
+        _collectionView.PropertyChanging += OnCollectionViewPropertyChanging;
+        _collectionView.PropertyChanged += OnCollectionViewPropertyChanged;
+        ChoosingGroupHeaderContainer += OnChoosingGroupHeaderContainer;
     }
+
+    /// <summary>
+    /// Handles the PropertyChanging event of the CollectionView.
+    /// </summary>
+    private void OnCollectionViewPropertyChanging(object? sender, PropertyChangingEventArgs e)
+    {
+        if (e.PropertyName == nameof(CollectionView.CollectionGroups))
+        {
+            _collectionView.CollectionGroups?.VectorChanged -= OnCollectionViewGroupDescriptionsChanged;
+        }
+    }
+
+    /// <summary>
+    /// Handles the PropertyChanged event of the CollectionView.
+    /// </summary>
+    private async void OnCollectionViewPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(CollectionView.CollectionGroups))
+        {
+            _collectionView.CollectionGroups?.VectorChanged += OnCollectionViewGroupDescriptionsChanged;
+
+            _shouldThrowBaseProeprtyChangedException = false;
+            base.ItemsSource = null;
+            await Task.Yield();
+            base.ItemsSource = _collectionView;
+            _shouldThrowBaseProeprtyChangedException = true;
+        }
+    }
+
+    /// <summary>
+    /// Handles the VectorChanged event of the CollectionGroups collection in the CollectionView.
+    /// </summary>
+    private void OnCollectionViewGroupDescriptionsChanged(IObservableVector<object> sender, IVectorChangedEventArgs args)
+    {
+        if (args.CollectionChange is CollectionChange.Reset)
+        {
+            DeselectAll();
+        }
+    }
+
+    /// <summary>
+    /// Refreshes every currently realized row's group indent on a Reset - covers a regroup/collapse/expand
+    /// toggle, which changes GroupDescriptions.Count or which rows are visible without necessarily going
+    /// through PrepareContainerForItemOverride for rows that were already realized. Also re-targets
+    /// <see cref="CurrentCellSlot"/> at the same underlying item - toggling any group reshuffles every
+    /// index after it, so the row a previously-set current cell points at can silently become a different
+    /// item once other groups expand or collapse around it.
+    /// </summary>
+    private void OnCollectionViewVectorChanged(IObservableVector<object> sender, IVectorChangedEventArgs args)
+    {
+        if (args.CollectionChange != CollectionChange.Reset) return;
+
+        foreach (var row in _rows)
+        {
+            row.RowPresenter?.SetGroupIndent();
+        }
+    }
+
+    private void OnChoosingGroupHeaderContainer(ListViewBase sender, ChoosingGroupHeaderContainerEventArgs args)
+    {
+        if (args.GroupHeaderContainer is not TableViewGroupHeaderRow)
+        {
+            var groupRow = new TableViewGroupHeaderRow { TableView = this };
+            _groupHeaderRows.Add(groupRow);
+            args.GroupHeaderContainer = groupRow;
+        }
+    }
+#else
+    }
+#endif
 
     /// <summary>
     /// Handles the SelectionChanged event of the TableView control.
@@ -117,7 +197,12 @@ public partial class TableView : ListView
 
         if (SelectedItems?.Count == 1)
         {
-            DispatcherQueue.TryEnqueue(async () => await ScrollRowIntoView(SelectedIndex));
+            //// Items.IndexOf(SelectedItem), not SelectedIndex: once grouped, a grouped ListViewBase's own
+            //// SelectedIndex has been observed resolving against a different (and inconsistent) index space
+            //// than Items - passing that straight into ScrollRowIntoView's Items[index] lookup could hand it
+            //// an entirely unrelated item to scroll to.
+            //var index = Items.IndexOf(SelectedItem);
+            //DispatcherQueue.TryEnqueue(async () => await ScrollRowIntoView(index));
         }
     }
 
@@ -173,6 +258,7 @@ public partial class TableView : ListView
                 }
 
                 row.RowPresenter?.ApplyDetailsPaneState(item);
+                row.RowPresenter?.SetGroupIndent();
 
                 if (CurrentCellSlot.HasValue)
                 {
@@ -433,7 +519,7 @@ public partial class TableView : ListView
             || originalSource?.FindAscendant<TableViewCell>() is not null   // Skip if the pointer is over a TableViewCell.
             || originalSource?.FindAscendant<TableViewRow>() is not null)   // Skip if the pointer is over a TableViewRow.
         {
-            return; 
+            return;
         }
 
         e.Handled = OnAnyPointerPressed(this, e);
@@ -931,10 +1017,8 @@ public partial class TableView : ListView
 
             var row = (LastSelectionUnit is TableViewSelectionUnit.Row ? CurrentRowIndex : CurrentCellSlot?.Row) ?? -1;
             var column = CurrentCellSlot?.Column ?? -1;
-
-            var numRows = CollectionView.Count;
             var nextRow = e.Key == VirtualKey.PageDown
-                ? Math.Min(numRows - 1, row + pageSize)
+                ? Math.Min(Items.Count - 1, row + pageSize)
                 : Math.Max(0, row - pageSize);
 
             var newSlot = new TableViewCellSlot(nextRow, column);
@@ -1021,10 +1105,34 @@ public partial class TableView : ListView
             while (ItemsPanelRoot is null) await Task.Yield();
 
             EnsureAutoColumns();
+#if WINDOWS
+            ApplyStickyGroupHeadersSetting();
+        }
+
+        // GroupStyle is a get-only collection, so it can only be populated (never Setter-assigned); this default
+        // only applies when the consumer hasn't already added their own entry.
+        if (GroupStyle.Count == 0 && DefaultGroupStyle is { } defaultGroupStyle)
+        {
+            GroupStyle.Add(defaultGroupStyle);
+#endif
         }
 
         SetHeadersVisibility();
     }
+
+#if WINDOWS
+    /// <summary>
+    /// Applies <see cref="AreStickyGroupHeadersEnabled"/> to the underlying <see cref="ItemsStackPanel"/>, if the
+    /// current <see cref="ItemsPanelRoot"/> is one.
+    /// </summary>
+    private void ApplyStickyGroupHeadersSetting()
+    {
+        if (ItemsPanelRoot is ItemsStackPanel panel)
+        {
+            panel.AreStickyGroupHeadersEnabled = AreStickyGroupHeadersEnabled;
+        }
+    }
+#endif
 
     /// <summary>
     /// Handles the ViewChanged event of the ScrollViewer control, updating the position of each row when the view changes.
@@ -1070,6 +1178,9 @@ public partial class TableView : ListView
 
         ResumeItemsSource();
         EnsureAutoColumns();
+#if WINDOWS
+        ApplyStickyGroupHeadersSetting();
+#endif
     }
 
     /// <summary>
@@ -1658,6 +1769,21 @@ public partial class TableView : ListView
         FilterHandler.ClearFilter(null);
     }
 
+#if WINDOWS
+    /// <summary>
+    /// Removes all grouping applied to the items.
+    /// </summary>
+    public void UngroupAll()
+    {
+        foreach (var column in _collectionView.GroupDescriptions.OfType<ColumnGroupDescription>().Select(x => x.Column))
+        {
+            column.SortDirection = null;
+        }
+
+        _collectionView.GroupDescriptions.Clear();
+    }
+#endif
+
     /// <summary>
     /// Refreshes all applied filters.
     /// </summary>
@@ -1691,7 +1817,11 @@ public partial class TableView : ListView
                     break;
                 case ListViewSelectionMode.Multiple:
                 case ListViewSelectionMode.Extended:
-                    SelectRange(new ItemIndexRange(0, (uint)Items.Count));
+                    if (Items.Count > 0)
+                    {
+                        SelectRange(new ItemIndexRange(0, (uint)Items.Count));
+                    }
+
                     break;
             }
         }
@@ -1763,10 +1893,12 @@ public partial class TableView : ListView
     /// </summary>
     private void DeselectAllCells()
     {
-        if (SelectedCellRanges.Count is 0) return;
+        if (SelectedCellRanges.Count > 0)
+        {
+            SelectedCellRanges.Clear();
+            OnCellSelectionChanged();
+        }
 
-        SelectedCellRanges.Clear();
-        OnCellSelectionChanged();
         CurrentCellSlot = null;
     }
 
@@ -2001,6 +2133,14 @@ public partial class TableView : ListView
         {
             return;
         }
+
+        //// This runs from CurrentCellSlot's DependencyProperty changed callback, which fires synchronously
+        //// as part of CurrentCellSlot's own SetValue call. Without yielding first, everything below - down
+        //// through ScrollCellIntoView's native ScrollIntoView call - executes re-entrantly on that same
+        //// native SetValue call stack, which crashes the process outright (an unhandled native exception,
+        //// not a catchable .NET one). Yielding lets that SetValue call fully unwind before touching XAML's
+        //// scroll/layout machinery again.
+        //await Task.Yield();
 
         if (oldSlot.HasValue)
         {
@@ -2601,7 +2741,7 @@ public partial class TableView : ListView
     /// </summary>
     private void UpdateBaseSelectionMode()
     {
-        _shouldThrowSelectionModeChangedException = true;
+        _shouldThrowBaseProeprtyChangedException = false;
         base.SelectionMode = SelectionUnit is TableViewSelectionUnit.Cell ? ListViewSelectionMode.None : SelectionMode;
 
         UpdateHorizontalScrollBarMargin();
@@ -2614,7 +2754,7 @@ public partial class TableView : ListView
 
         }
 
-        _shouldThrowSelectionModeChangedException = false;
+        _shouldThrowBaseProeprtyChangedException = true;
     }
 
     /// <summary>
@@ -2628,6 +2768,13 @@ public partial class TableView : ListView
         {
             row.RowPresenter?.EnsureGridLines();
         }
+
+#if WINDOWS
+        foreach (var groupHeaderRow in _groupHeaderRows)
+        {
+            groupHeaderRow.EnsureGridLines();
+        }
+#endif
     }
 
     /// <summary>

--- a/src/TableViewColumnHeader.OptionComamnds.cs
+++ b/src/TableViewColumnHeader.OptionComamnds.cs
@@ -8,7 +8,7 @@ partial class TableViewColumnHeader
 {
     private bool _commandsInitialized;
 #if WINDOWS
-    private readonly StandardUICommand _groupCommand = new() { Label = "Group" }; 
+    private readonly StandardUICommand _groupCommand = new() { Label = TableViewLocalizedStrings.Group };
 #endif
     private readonly StandardUICommand _sortAscendingCommand = new() { Label = TableViewLocalizedStrings.SortAscending };
     private readonly StandardUICommand _sortDescendingCommand = new() { Label = TableViewLocalizedStrings.SortDescending };
@@ -51,7 +51,7 @@ partial class TableViewColumnHeader
         _groupCommand.CanExecuteRequested += (_, e) =>
         {
             e.CanExecute = CanGroup;
-            _groupCommand.Label = IsGrouped ? "Ungroup" : "Group";
+            _groupCommand.Label = IsGrouped ? TableViewLocalizedStrings.Ungroup : TableViewLocalizedStrings.Group;
         };
 #endif
 

--- a/src/TableViewColumnHeader.OptionComamnds.cs
+++ b/src/TableViewColumnHeader.OptionComamnds.cs
@@ -57,13 +57,7 @@ partial class TableViewColumnHeader
             _groupCommand.Label = IsGrouped ? TableViewLocalizedStrings.Ungroup : TableViewLocalizedStrings.Group;
         };
 
-        _sortGroupsByCountCommand.ExecuteRequested += delegate
-        {
-            if (_tableView?.CollectionView is CollectionView { } collectionView)
-            {
-                ToggleGroupSortMode(collectionView);
-            }
-        };
+        _sortGroupsByCountCommand.ExecuteRequested += delegate { ToggleGroupSortMode(); };
         _sortGroupsByCountCommand.CanExecuteRequested += (_, e) =>
         {
             e.CanExecute = IsGrouped;
@@ -80,19 +74,12 @@ partial class TableViewColumnHeader
         _sortDescendingCommand.CanExecuteRequested += (_, e) => e.CanExecute = CanSort && Column?.SortDirection != SD.Descending;
 
         _clearSortingCommand.ExecuteRequested += delegate { ClearSortingWithEvent(); };
-        _clearSortingCommand.CanExecuteRequested += (_, e) =>
-        {
-            // A grouped column with no independent sort left over is driven entirely by its group -
-            // "clear sorting" isn't offered for it; ungroup instead. Only three-state (asc -> desc ->
-            // clear) sorting is disabled, not the asc/desc toggle itself (handled by DoSort/SortGroupDescription).
-            // While a leftover ColumnSortDescription from before grouping is still mirroring the group's
-            // order, clearing it is allowed and hands ordering fully over to the group description.
-            var canClear = Column?.SortDirection is not null;
+        _clearSortingCommand.CanExecuteRequested += (_, e) => e.CanExecute = Column?.SortDirection is not null &&
 #if WINDOWS
-            canClear = canClear && (!IsGrouped || HasGroupSortCompanion);
+        !IsGrouped;
+#else
+        true;
 #endif
-            e.CanExecute = canClear;
-        };
 
         _clearFilterCommand.ExecuteRequested += delegate { ClearFilter(); };
         _clearFilterCommand.CanExecuteRequested += (_, e) => e.CanExecute = Column?.IsFiltered is true;

--- a/src/TableViewColumnHeader.OptionComamnds.cs
+++ b/src/TableViewColumnHeader.OptionComamnds.cs
@@ -7,10 +7,13 @@ namespace WinUI.TableView;
 partial class TableViewColumnHeader
 {
     private bool _commandsInitialized;
+#if WINDOWS
+    private readonly StandardUICommand _groupCommand = new() { Label = "Group" }; 
+#endif
     private readonly StandardUICommand _sortAscendingCommand = new() { Label = TableViewLocalizedStrings.SortAscending };
     private readonly StandardUICommand _sortDescendingCommand = new() { Label = TableViewLocalizedStrings.SortDescending };
     private readonly StandardUICommand _clearSortingCommand = new() { Label = TableViewLocalizedStrings.ClearSorting };
-    private readonly StandardUICommand _clearFilterCommand = new() { Label = TableViewLocalizedStrings.ClearFilter };    
+    private readonly StandardUICommand _clearFilterCommand = new() { Label = TableViewLocalizedStrings.ClearFilter };
 
     /// <summary>
     /// Sets commands to option menu items.
@@ -19,6 +22,10 @@ partial class TableViewColumnHeader
     {
         InitializeCommands();
 
+#if WINDOWS
+        if (GetTemplateChild("GroupMenuItem") is MenuFlyoutItem groupMenuItem)
+            groupMenuItem.Command = _groupCommand; 
+#endif
         if (GetTemplateChild("SortAscendingMenuItem") is MenuFlyoutItem sortAscendingMenuItem)
             sortAscendingMenuItem.Command = _sortAscendingCommand;
         if (GetTemplateChild("SortDescendingMenuItem") is MenuFlyoutItem sortDescendingMenuItem)
@@ -39,6 +46,15 @@ partial class TableViewColumnHeader
             return;
         }
 
+#if WINDOWS
+        _groupCommand.ExecuteRequested += delegate { Group(); };
+        _groupCommand.CanExecuteRequested += (_, e) =>
+        {
+            e.CanExecute = CanGroup;
+            _groupCommand.Label = IsGrouped ? "Ungroup" : "Group";
+        };
+#endif
+
         _sortAscendingCommand.ExecuteRequested += delegate { DoSort(SD.Ascending); };
         _sortAscendingCommand.CanExecuteRequested += (_, e) => e.CanExecute = CanSort && Column?.SortDirection != SD.Ascending;
 
@@ -46,11 +62,23 @@ partial class TableViewColumnHeader
         _sortDescendingCommand.CanExecuteRequested += (_, e) => e.CanExecute = CanSort && Column?.SortDirection != SD.Descending;
 
         _clearSortingCommand.ExecuteRequested += delegate { ClearSortingWithEvent(); };
-        _clearSortingCommand.CanExecuteRequested += (_, e) => e.CanExecute = Column?.SortDirection is not null;
+        _clearSortingCommand.CanExecuteRequested += (_, e) =>
+        {
+            // A grouped column with no independent sort left over is driven entirely by its group -
+            // "clear sorting" isn't offered for it; ungroup instead. Only three-state (asc -> desc ->
+            // clear) sorting is disabled, not the asc/desc toggle itself (handled by DoSort/SortGroupDescription).
+            // While a leftover ColumnSortDescription from before grouping is still mirroring the group's
+            // order, clearing it is allowed and hands ordering fully over to the group description.
+            var canClear = Column?.SortDirection is not null;
+#if WINDOWS
+            canClear = canClear && (!IsGrouped || HasGroupSortCompanion);
+#endif
+            e.CanExecute = canClear;
+        };
 
         _clearFilterCommand.ExecuteRequested += delegate { ClearFilter(); };
         _clearFilterCommand.CanExecuteRequested += (_, e) => e.CanExecute = Column?.IsFiltered is true;
-        
+
         _commandsInitialized = true;
     }
 }

--- a/src/TableViewColumnHeader.OptionComamnds.cs
+++ b/src/TableViewColumnHeader.OptionComamnds.cs
@@ -9,6 +9,7 @@ partial class TableViewColumnHeader
     private bool _commandsInitialized;
 #if WINDOWS
     private readonly StandardUICommand _groupCommand = new() { Label = TableViewLocalizedStrings.Group };
+    private readonly StandardUICommand _sortGroupsByCountCommand = new() { Label = TableViewLocalizedStrings.SortGroupsByCount };
 #endif
     private readonly StandardUICommand _sortAscendingCommand = new() { Label = TableViewLocalizedStrings.SortAscending };
     private readonly StandardUICommand _sortDescendingCommand = new() { Label = TableViewLocalizedStrings.SortDescending };
@@ -24,7 +25,9 @@ partial class TableViewColumnHeader
 
 #if WINDOWS
         if (GetTemplateChild("GroupMenuItem") is MenuFlyoutItem groupMenuItem)
-            groupMenuItem.Command = _groupCommand; 
+            groupMenuItem.Command = _groupCommand;
+        if (GetTemplateChild("SortGroupsByCountMenuItem") is MenuFlyoutItem sortGroupsByCountMenuItem)
+            sortGroupsByCountMenuItem.Command = _sortGroupsByCountCommand;
 #endif
         if (GetTemplateChild("SortAscendingMenuItem") is MenuFlyoutItem sortAscendingMenuItem)
             sortAscendingMenuItem.Command = _sortAscendingCommand;
@@ -52,6 +55,21 @@ partial class TableViewColumnHeader
         {
             e.CanExecute = CanGroup;
             _groupCommand.Label = IsGrouped ? TableViewLocalizedStrings.Ungroup : TableViewLocalizedStrings.Group;
+        };
+
+        _sortGroupsByCountCommand.ExecuteRequested += delegate
+        {
+            if (_tableView?.CollectionView is CollectionView { } collectionView)
+            {
+                ToggleGroupSortMode(collectionView);
+            }
+        };
+        _sortGroupsByCountCommand.CanExecuteRequested += (_, e) =>
+        {
+            e.CanExecute = IsGrouped;
+            _sortGroupsByCountCommand.Label = IsGroupSortedByCount
+                ? TableViewLocalizedStrings.SortGroupsByValue
+                : TableViewLocalizedStrings.SortGroupsByCount;
         };
 #endif
 

--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -96,39 +96,168 @@ public partial class TableViewColumnHeader : ContentControl
         }
     }
 
+#if WINDOWS
+    /// <summary>
+    /// Gets a value indicating whether the column is currently grouped.
+    /// </summary>
+    private bool IsGrouped =>
+        Column is not null &&
+        _tableView?.CollectionView is CollectionView { } collectionView &&
+        collectionView.GroupDescriptions.Any(x => x is ColumnGroupDescription columnGroup && columnGroup.Column == Column);
+
+    /// <summary>
+    /// Gets a value indicating whether this grouped column still has an independent <see cref="ColumnSortDescription"/>
+    /// left over from before it was grouped - i.e. its order is still being mirrored from that description
+    /// rather than owned outright by its <see cref="ColumnGroupDescription"/>. See <see cref="SortGroupDescription"/>
+    /// and <see cref="HandOffToGroupDescription"/>.
+    /// </summary>
+    private bool HasGroupSortCompanion =>
+        Column is not null &&
+        _tableView?.CollectionView is CollectionView { } collectionView &&
+        collectionView.SortDescriptions.Any(x => x is ColumnSortDescription columnSort && columnSort.Column == Column);
+
+    /// <summary>
+    /// Groups the column, or removes its grouping if it's already grouped.
+    /// </summary>
+    private void Group()
+    {
+        if (!CanGroup || Column is null || _tableView is not { CollectionView: CollectionView { } collectionView })
+        {
+            return;
+        }
+
+        if (IsGrouped)
+        {
+            using var ungroupDefer = collectionView.DeferRefresh();
+            collectionView.GroupDescriptions.RemoveWhere(x => x is ColumnGroupDescription columnGroup && columnGroup.Column == Column);
+            collectionView.SortDescriptions.RemoveWhere(x => x is ColumnSortDescription columnSort && columnSort.Column == Column);
+            Column.SortDirection = null;
+            return;
+        }
+
+        var eventArgs = new TableViewGroupingEventArgs(Column);
+        _tableView.OnGrouping(eventArgs);
+
+        if (eventArgs.Handled) return;
+
+        var boundColumn = Column as TableViewBoundColumn;
+
+        // Prefer explicit SortMemberPath if provided, otherwise use bound column's property path
+        var sortPath = Column.SortMemberPath ?? boundColumn?.PropertyPath;
+
+        using var defer = collectionView.DeferRefresh();
+
+        // If the column already had its own sort applied, keep that ColumnSortDescription in place and
+        // seed the group with its direction, rather than discarding it and resetting to Ascending - see
+        // SortGroupDescription/HandOffToGroupDescription for how the two are kept in sync afterwards.
+        var direction = Column.SortDirection ?? SortDirection.Ascending;
+
+        var groupDescription = new ColumnGroupDescription(Column, sortPath, direction);
+        collectionView.GroupDescriptions.Add(groupDescription);
+        Column.SortDirection = direction;
+    }
+
+    /// <summary>
+    /// Changes the direction driving a grouped column's order. If the column still has an independent
+    /// <see cref="ColumnSortDescription"/> left over from before it was grouped (<see cref="HasGroupSortCompanion"/>),
+    /// that description is updated too, keeping it mirrored; otherwise only the <see cref="ColumnGroupDescription"/>
+    /// itself changes. Either way, the group's order always needs a direction, so this is the only way to
+    /// change it while grouped - there's no cycling to a cleared/unsorted state.
+    /// </summary>
+    private void SortGroupDescription(SD direction, CollectionView collectionView)
+    {
+        var groupDescription = collectionView.GroupDescriptions
+            .OfType<ColumnGroupDescription>()
+            .FirstOrDefault(x => x.Column == Column);
+
+        if (groupDescription is null || groupDescription.Direction == direction) return;
+
+        var sortDescription = collectionView.SortDescriptions
+            .OfType<ColumnSortDescription>()
+            .FirstOrDefault(x => x.Column == Column);
+
+        if (sortDescription is not null)
+        {
+            sortDescription.Direction = direction;
+        }
+
+        groupDescription.Direction = direction;
+        Column!.SortDirection = direction;
+        collectionView.RefreshGrouping();
+    }
+
+    /// <summary>
+    /// Removes a grouped column's leftover <see cref="ColumnSortDescription"/> from before it was grouped,
+    /// once it's cycled to cleared (or "Clear Sorting" is invoked) - handing its order over fully to the
+    /// <see cref="ColumnGroupDescription"/> that's been mirroring it (see <see cref="SortGroupDescription"/>).
+    /// Its current direction carries over unchanged, since the group still needs one.
+    /// </summary>
+    private void HandOffToGroupDescription(CollectionView collectionView)
+    {
+        collectionView.SortDescriptions.RemoveWhere(x => x is ColumnSortDescription columnSort && columnSort.Column == Column);
+
+        var groupDescription = collectionView.GroupDescriptions
+            .OfType<ColumnGroupDescription>()
+            .FirstOrDefault(x => x.Column == Column);
+
+        if (groupDescription is not null)
+        {
+            Column!.SortDirection = groupDescription.Direction;
+        }
+    }
+#endif
+
     /// <summary>
     /// Sorts the column in the specified direction.
     /// </summary>
     private void DoSort(SD? direction, bool singleSorting = true)
     {
-        if (CanSort && Column is not null && _tableView is { CollectionView: CollectionView { } collectionView })
+        if (!CanSort || Column is null || _tableView is not { CollectionView: CollectionView { } collectionView })
         {
-            var eventArgs = new TableViewSortingEventArgs(Column);
-            _tableView.OnSorting(eventArgs);
+            return;
+        }
 
-            if (eventArgs.Handled) return;
+        var eventArgs = new TableViewSortingEventArgs(Column);
+        _tableView.OnSorting(eventArgs);
 
-            using var defer = collectionView.DeferRefresh();
-            if (singleSorting)
+        if (eventArgs.Handled) return;
+
+#if WINDOWS
+        if (IsGrouped)
+        {
+            if (direction is not null)
             {
-                _tableView.ClearAllSortingWithEvent();
+                SortGroupDescription(direction.Value, collectionView);
             }
             else
             {
-                ClearSortingWithEvent();
+                HandOffToGroupDescription(collectionView);
             }
 
-            if (direction is not null)
-            {
-                var boundColumn = Column as TableViewBoundColumn;
-                Column.SortDirection = direction;
+            return;
+        }
+#endif
 
-                // Prefer explicit SortMemberPath if provided, otherwise use bound column's property path
-                var sortPath = Column.SortMemberPath ?? boundColumn?.PropertyPath;
+        using var defer = collectionView.DeferRefresh();
+        if (singleSorting)
+        {
+            _tableView.ClearAllSortingWithEvent();
+        }
+        else
+        {
+            ClearSortingWithEvent();
+        }
 
-                _tableView.SortDescriptions.Add(
-                    new ColumnSortDescription(Column!, sortPath, direction.Value));
-            }
+        if (direction is not null)
+        {
+            var boundColumn = Column as TableViewBoundColumn;
+            Column.SortDirection = direction;
+
+            // Prefer explicit SortMemberPath if provided, otherwise use bound column's property path
+            var sortPath = Column.SortMemberPath ?? boundColumn?.PropertyPath;
+
+            _tableView.SortDescriptions.Add(
+                new ColumnSortDescription(Column!, sortPath, direction.Value));
         }
     }
 
@@ -149,6 +278,15 @@ public partial class TableViewColumnHeader : ContentControl
         {
             using var defer = collectionView.DeferRefresh();
             _tableView.DeselectAll();
+
+#if WINDOWS
+            if (IsGrouped)
+            {
+                HandOffToGroupDescription(collectionView);
+                return;
+            }
+#endif
+
             Column.SortDirection = null;
             collectionView.SortDescriptions.RemoveWhere(x => x is ColumnSortDescription columnSort && columnSort.Column == Column);
         }
@@ -225,8 +363,24 @@ public partial class TableViewColumnHeader : ContentControl
         base.OnTapped(e);
     }
 
+    /// <summary>
+    /// Computes the next sort direction for a tap/invoke on this header. A grouped column with no
+    /// independent <see cref="ColumnSortDescription"/> of its own (<see cref="HasGroupSortCompanion"/>)
+    /// cycles between just <see cref="SD.Ascending"/> and <see cref="SD.Descending"/> - its order is owned
+    /// entirely by its group and always needs a direction, so it never lands on the cleared/unsorted state
+    /// a three-state cycle's third click does. A grouped column that still has a leftover independent sort
+    /// from before it was grouped keeps three-state cycling until that description is cleared (see
+    /// <see cref="HandOffToGroupDescription"/>), at which point it falls into the two-state case above.
+    /// </summary>
     private SD? GetNextSortDirection()
     {
+#if WINDOWS
+        if (IsGrouped && !HasGroupSortCompanion)
+        {
+            return Column?.SortDirection == SD.Ascending ? SD.Descending : SD.Ascending;
+        }
+#endif
+
         return Column?.SortDirection switch
         {
             SD.Ascending => SD.Descending,
@@ -623,6 +777,13 @@ public partial class TableViewColumnHeader : ContentControl
     /// Gets or sets the column associated with the header.
     /// </summary>
     public TableViewColumn? Column { get; internal set; }
+
+#if WINDOWS
+    /// <summary>
+    /// Gets a value indicating whether the column can be grouped.
+    /// </summary>
+    private bool CanGroup => _tableView?.CanGroupColumns == true && Column?.CanGroup == true;
+#endif
 
     /// <summary>
     /// Gets a value indicating whether the column can be resized.

--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -106,17 +106,6 @@ public partial class TableViewColumnHeader : ContentControl
         collectionView.GroupDescriptions.Any(x => x is ColumnGroupDescription columnGroup && columnGroup.Column == Column);
 
     /// <summary>
-    /// Gets a value indicating whether this grouped column still has an independent <see cref="ColumnSortDescription"/>
-    /// left over from before it was grouped - i.e. its order is still being mirrored from that description
-    /// rather than owned outright by its <see cref="ColumnGroupDescription"/>. See <see cref="SortGroupDescription"/>
-    /// and <see cref="HandOffToGroupDescription"/>.
-    /// </summary>
-    private bool HasGroupSortCompanion =>
-        Column is not null &&
-        _tableView?.CollectionView is CollectionView { } collectionView &&
-        collectionView.SortDescriptions.Any(x => x is ColumnSortDescription columnSort && columnSort.Column == Column);
-
-    /// <summary>
     /// Groups the column, or removes its grouping if it's already grouped.
     /// </summary>
     private void Group()
@@ -130,8 +119,11 @@ public partial class TableViewColumnHeader : ContentControl
         {
             using var ungroupDefer = collectionView.DeferRefresh();
             collectionView.GroupDescriptions.RemoveWhere(x => x is ColumnGroupDescription columnGroup && columnGroup.Column == Column);
-            collectionView.SortDescriptions.RemoveWhere(x => x is ColumnSortDescription columnSort && columnSort.Column == Column);
-            Column.SortDirection = null;
+            collectionView.SortDescriptions.RemoveWhere(x => x is ColumnGroupDescription columnSort && columnSort.Column == Column);
+
+            var sortDescription = collectionView.SortDescriptions.FirstOrDefault(x => x is ColumnSortDescription columnSort && columnSort.Column == Column);
+            Column.SortDirection = sortDescription?.Direction;
+
             return;
         }
 
@@ -147,62 +139,15 @@ public partial class TableViewColumnHeader : ContentControl
 
         using var defer = collectionView.DeferRefresh();
 
-        // If the column already had its own sort applied, keep that ColumnSortDescription in place and
-        // seed the group with its direction, rather than discarding it and resetting to Ascending - see
-        // SortGroupDescription/HandOffToGroupDescription for how the two are kept in sync afterwards.
-        var direction = Column.SortDirection ?? SortDirection.Ascending;
+        var direction = Column.SortDirection ?? SD.Ascending;
 
         var groupDescription = new ColumnGroupDescription(Column, sortPath, direction);
         collectionView.GroupDescriptions.Add(groupDescription);
-        Column.SortDirection = direction;
-    }
 
-    /// <summary>
-    /// Changes the direction driving a grouped column's order. If the column still has an independent
-    /// <see cref="ColumnSortDescription"/> left over from before it was grouped (<see cref="HasGroupSortCompanion"/>),
-    /// that description is updated too, keeping it mirrored; otherwise only the <see cref="ColumnGroupDescription"/>
-    /// itself changes. Either way, the group's order always needs a direction, so this is the only way to
-    /// change it while grouped - there's no cycling to a cleared/unsorted state.
-    /// </summary>
-    private void SortGroupDescription(SD direction, CollectionView collectionView)
-    {
-        var groupDescription = collectionView.GroupDescriptions
-            .OfType<ColumnGroupDescription>()
-            .FirstOrDefault(x => x.Column == Column);
-
-        if (groupDescription is null || groupDescription.Direction == direction) return;
-
-        var sortDescription = collectionView.SortDescriptions
-            .OfType<ColumnSortDescription>()
-            .FirstOrDefault(x => x.Column == Column);
-
-        if (sortDescription is not null)
+        if (Column.SortDirection is null)
         {
-            sortDescription.Direction = direction;
-        }
-
-        groupDescription.Direction = direction;
-        Column!.SortDirection = direction;
-        collectionView.RefreshGrouping();
-    }
-
-    /// <summary>
-    /// Removes a grouped column's leftover <see cref="ColumnSortDescription"/> from before it was grouped,
-    /// once it's cycled to cleared (or "Clear Sorting" is invoked) - handing its order over fully to the
-    /// <see cref="ColumnGroupDescription"/> that's been mirroring it (see <see cref="SortGroupDescription"/>).
-    /// Its current direction carries over unchanged, since the group still needs one.
-    /// </summary>
-    private void HandOffToGroupDescription(CollectionView collectionView)
-    {
-        collectionView.SortDescriptions.RemoveWhere(x => x is ColumnSortDescription columnSort && columnSort.Column == Column);
-
-        var groupDescription = collectionView.GroupDescriptions
-            .OfType<ColumnGroupDescription>()
-            .FirstOrDefault(x => x.Column == Column);
-
-        if (groupDescription is not null)
-        {
-            Column!.SortDirection = groupDescription.Direction;
+            collectionView.SortDescriptions.Add(groupDescription);
+            Column.SortDirection = direction;
         }
     }
 
@@ -210,20 +155,17 @@ public partial class TableViewColumnHeader : ContentControl
     /// Gets a value indicating whether this grouped column currently orders its groups by item count
     /// rather than by key.
     /// </summary>
-    private bool IsGroupSortedByCount =>
-        Column is not null &&
-        _tableView?.CollectionView is CollectionView { } collectionView &&
-        collectionView.GroupDescriptions.OfType<ColumnGroupDescription>()
-            .FirstOrDefault(x => x.Column == Column) is { SortMode: GroupSortMode.Count };
+    private bool IsGroupSortedByCount => 
+        _tableView?.GroupDescriptions.OfType<ColumnGroupDescription>()
+                                     .FirstOrDefault(x => x.Column == Column) is { SortMode: GroupSortMode.Count };
 
     /// <summary>
     /// Toggles a grouped column's <see cref="GroupDescription.SortMode"/> between key and item-count order.
     /// </summary>
-    private void ToggleGroupSortMode(CollectionView collectionView)
+    private void ToggleGroupSortMode()
     {
-        var groupDescription = collectionView.GroupDescriptions
-            .OfType<ColumnGroupDescription>()
-            .FirstOrDefault(x => x.Column == Column);
+        var groupDescription = _tableView?.GroupDescriptions.OfType<ColumnGroupDescription>()
+                                                            .FirstOrDefault(x => x.Column == Column);
 
         if (groupDescription is null) return;
 
@@ -231,7 +173,7 @@ public partial class TableViewColumnHeader : ContentControl
             ? GroupSortMode.Key
             : GroupSortMode.Count;
 
-        collectionView.RefreshGrouping();
+        _tableView?.RefreshGrouping();
     }
 #endif
 
@@ -250,42 +192,38 @@ public partial class TableViewColumnHeader : ContentControl
 
         if (eventArgs.Handled) return;
 
-#if WINDOWS
-        if (IsGrouped)
-        {
-            if (direction is not null)
-            {
-                SortGroupDescription(direction.Value, collectionView);
-            }
-            else
-            {
-                HandOffToGroupDescription(collectionView);
-            }
-
-            return;
-        }
-#endif
-
         using var defer = collectionView.DeferRefresh();
+        var sortDescription = collectionView.SortDescriptions
+            .FirstOrDefault(x => (x is ColumnSortDescription columnSort && columnSort.Column == Column) ||
+                                          (x is ColumnGroupDescription columnGroup && columnGroup.Column == Column));
+
         if (singleSorting)
         {
             _tableView.ClearAllSortingWithEvent();
         }
-        else
-        {
-            ClearSortingWithEvent();
-        }
 
         if (direction is not null)
         {
+
+#if WINDOWS
+            if (sortDescription is ColumnSortDescription && IsGrouped)
+            {
+                var groupDescription = collectionView.GroupDescriptions
+                    .FirstOrDefault(x => x is ColumnGroupDescription columnGroup && columnGroup.Column == Column);
+
+                groupDescription?.Direction = direction.Value;
+            }
+#endif
+
             var boundColumn = Column as TableViewBoundColumn;
             Column.SortDirection = direction;
 
             // Prefer explicit SortMemberPath if provided, otherwise use bound column's property path
             var sortPath = Column.SortMemberPath ?? boundColumn?.PropertyPath;
+            sortDescription ??= new ColumnSortDescription(Column, sortPath);
+            sortDescription.Direction = direction.Value;
 
-            _tableView.SortDescriptions.Add(
-                new ColumnSortDescription(Column!, sortPath, direction.Value));
+            _tableView.SortDescriptions.Add(sortDescription);
         }
     }
 
@@ -306,14 +244,6 @@ public partial class TableViewColumnHeader : ContentControl
         {
             using var defer = collectionView.DeferRefresh();
             _tableView.DeselectAll();
-
-#if WINDOWS
-            if (IsGrouped)
-            {
-                HandOffToGroupDescription(collectionView);
-                return;
-            }
-#endif
 
             Column.SortDirection = null;
             collectionView.SortDescriptions.RemoveWhere(x => x is ColumnSortDescription columnSort && columnSort.Column == Column);
@@ -403,7 +333,7 @@ public partial class TableViewColumnHeader : ContentControl
     private SD? GetNextSortDirection()
     {
 #if WINDOWS
-        if (IsGrouped && !HasGroupSortCompanion)
+        if (IsGrouped)
         {
             return Column?.SortDirection == SD.Ascending ? SD.Descending : SD.Ascending;
         }

--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -201,10 +201,13 @@ public partial class TableViewColumnHeader : ContentControl
         {
             _tableView.ClearAllSortingWithEvent();
         }
+        else
+        {
+            ClearSortingWithEvent();
+        }
 
         if (direction is not null)
         {
-
 #if WINDOWS
             if (sortDescription is ColumnSortDescription && IsGrouped)
             {
@@ -223,7 +226,7 @@ public partial class TableViewColumnHeader : ContentControl
             sortDescription ??= new ColumnSortDescription(Column, sortPath);
             sortDescription.Direction = direction.Value;
 
-            _tableView.SortDescriptions.Add(sortDescription);
+            collectionView.SortDescriptions.Add(sortDescription);
         }
     }
 

--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -205,6 +205,34 @@ public partial class TableViewColumnHeader : ContentControl
             Column!.SortDirection = groupDescription.Direction;
         }
     }
+
+    /// <summary>
+    /// Gets a value indicating whether this grouped column currently orders its groups by item count
+    /// rather than by key.
+    /// </summary>
+    private bool IsGroupSortedByCount =>
+        Column is not null &&
+        _tableView?.CollectionView is CollectionView { } collectionView &&
+        collectionView.GroupDescriptions.OfType<ColumnGroupDescription>()
+            .FirstOrDefault(x => x.Column == Column) is { SortMode: GroupSortMode.Count };
+
+    /// <summary>
+    /// Toggles a grouped column's <see cref="GroupDescription.SortMode"/> between key and item-count order.
+    /// </summary>
+    private void ToggleGroupSortMode(CollectionView collectionView)
+    {
+        var groupDescription = collectionView.GroupDescriptions
+            .OfType<ColumnGroupDescription>()
+            .FirstOrDefault(x => x.Column == Column);
+
+        if (groupDescription is null) return;
+
+        groupDescription.SortMode = groupDescription.SortMode == GroupSortMode.Count
+            ? GroupSortMode.Key
+            : GroupSortMode.Count;
+
+        collectionView.RefreshGrouping();
+    }
 #endif
 
     /// <summary>

--- a/src/TableViewGroupHeaderRow.cs
+++ b/src/TableViewGroupHeaderRow.cs
@@ -1,0 +1,132 @@
+#if WINDOWS
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Shapes;
+using Windows.Foundation;
+
+namespace WinUI.TableView;
+
+/// <summary>
+/// Represents a group header row in a TableView control, used to display group information and provide expand/collapse functionality.
+/// </summary>
+public partial class TableViewGroupHeaderRow : ListViewHeaderItem
+{
+    /// <summary>
+    /// The per-level indent step (in pixels). Shared with <see cref="TableViewRow"/> so rows line up with the
+    /// deepest group header they belong to.
+    /// </summary>
+    internal const double GroupIndentSize = 24d;
+
+    private Button? _expandCollapseButton;
+    private Border? _indentPlaceholder;
+    private Rectangle? _h_gridLine;
+
+    /// <summary>
+    /// Initializes a new instance of the TableViewGroupHeaderRow class.
+    /// </summary>
+    public TableViewGroupHeaderRow()
+    {
+        DefaultStyleKey = typeof(TableViewGroupHeaderRow);
+
+        Loaded += OnLoaded;
+    }
+
+    /// <summary>
+    /// Gets or sets the owning <see cref="TableView"/>, used to keep this row's grid line and other
+    /// TableView-driven appearance in sync.
+    /// </summary>
+    internal TableView? TableView { get; set; }
+
+    /// <inheritdoc/>
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+
+        _expandCollapseButton = GetTemplateChild("ExpandCollapseButton") as Button;
+        _expandCollapseButton?.Click -= OnExpandCollapseButtonClick;
+        _expandCollapseButton?.Click += OnExpandCollapseButtonClick;
+        _indentPlaceholder = GetTemplateChild("IndentPlaceholder") as Border;
+        _h_gridLine = GetTemplateChild("HorizontalGridLine") as Rectangle;
+
+        EnsureGridLines();
+        UpdateExpandCollapseButtonVisibility();
+
+        if (Content is TableViewGroupInfo groupInfo)
+        {
+            UpdateExpandCollapseVisualState(groupInfo.IsExpanded);
+        }
+    }
+
+    /// <summary>
+    /// Registers this row with its owning <see cref="TableView"/> so it can be refreshed (e.g. grid line
+    /// appearance) whenever a relevant TableView property changes.
+    /// </summary>
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        EnsureGridLines();
+        UpdateExpandCollapseButtonVisibility();
+    }
+
+    /// <summary>
+    /// Applies <see cref="TableView.HorizontalGridLinesStroke"/> and
+    /// <see cref="TableView.HorizontalGridLinesStrokeThickness"/> to the divider below this row,
+    /// matching every other horizontal grid line in the control.
+    /// </summary>
+    internal void EnsureGridLines()
+    {
+        if (_h_gridLine is null || TableView is null) return;
+
+        _h_gridLine.Fill = TableView.HorizontalGridLinesStroke;
+        _h_gridLine.Height = TableView.HorizontalGridLinesStrokeThickness;
+    }
+
+    /// <summary>
+    /// Shows or hides the expand/collapse button per <see cref="TableView.ShowGroupExpandCollapseButton"/>.
+    /// The button's layout slot - and with it, this row's level-based indent, applied via the button's own
+    /// Margin - is kept either way; only its visual/interactivity is toggled, so hiding it doesn't flatten
+    /// every level's indentation back to zero.
+    /// </summary>
+    internal void UpdateExpandCollapseButtonVisibility()
+    {
+        if (_expandCollapseButton is null) return;
+
+        var showButton = TableView?.ShowGroupExpandCollapseButton != false;
+        _expandCollapseButton.Opacity = showButton ? 1 : 0;
+        _expandCollapseButton.IsHitTestVisible = showButton;
+    }
+
+    /// <summary>
+    /// Handles the Click event of the expand/collapse button, toggling the IsExpanded property of the associated TableViewGroupInfo.
+    /// </summary>
+    private void OnExpandCollapseButtonClick(object sender, RoutedEventArgs e)
+    {
+        if (Content is TableViewGroupInfo groupInfo)
+        {
+            groupInfo.IsExpanded = !groupInfo.IsExpanded;
+            UpdateExpandCollapseVisualState(groupInfo.IsExpanded);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnContentChanged(object oldContent, object newContent)
+    {
+        base.OnContentChanged(oldContent, newContent);
+
+        if (Content is TableViewGroupInfo groupInfo)
+        {
+            _indentPlaceholder?.Width = groupInfo.Level * GroupIndentSize;
+            UpdateExpandCollapseVisualState(groupInfo.IsExpanded);
+            UpdateExpandCollapseButtonVisibility();
+        }
+    }
+
+    /// <summary>
+    /// Updates the visual state of the group header row based on whether it is expanded or collapsed.
+    /// </summary>
+    private void UpdateExpandCollapseVisualState(bool isExpanded)
+    {
+        VisualStates.GoToState(this, true, isExpanded ? VisualStates.StateExpanded : VisualStates.StateCollapsed);
+    }
+}
+#endif

--- a/src/TableViewGroupState.cs
+++ b/src/TableViewGroupState.cs
@@ -1,0 +1,17 @@
+namespace WinUI.TableView;
+
+/// <summary>
+/// Specifies whether a newly created group starts out expanded or collapsed.
+/// </summary>
+public enum TableViewGroupState
+{
+    /// <summary>
+    /// Groups start out expanded.
+    /// </summary>
+    Expanded,
+
+    /// <summary>
+    /// Groups start out collapsed.
+    /// </summary>
+    Collapsed
+}

--- a/src/TableViewHeaderRow.OptionComamnds.cs
+++ b/src/TableViewHeaderRow.OptionComamnds.cs
@@ -17,6 +17,9 @@ partial class TableViewHeaderRow
     private readonly StandardUICommand _copyWithHeadersCommand = new() { Label = TableViewLocalizedStrings.CopyWithHeaders };
     private readonly StandardUICommand _clearSortingCommand = new() { Label = TableViewLocalizedStrings.ClearSorting };
     private readonly StandardUICommand _clearFilterCommand = new() { Label = TableViewLocalizedStrings.ClearFilter };
+#if WINDOWS
+    private readonly StandardUICommand _ungroupAllCommand = new() { Label = "Ungroup All" };
+#endif
     private readonly StandardUICommand _exportAllToCSVCommand = new() { Label = TableViewLocalizedStrings.ExportAll };
     private readonly StandardUICommand _exportSelectedToCSVCommand = new() { Label = TableViewLocalizedStrings.ExportSelected };
 
@@ -52,6 +55,10 @@ partial class TableViewHeaderRow
             clearSortingMenuItem.Command = _clearSortingCommand;
         if (GetTemplateChild("ClearFilterMenuItem") is MenuFlyoutItem clearFilterMenuItem)
             clearFilterMenuItem.Command = _clearFilterCommand;
+#if WINDOWS
+        if (GetTemplateChild("UngroupAllMenuItem") is MenuFlyoutItem ungroupAllMenuItem)
+            ungroupAllMenuItem.Command = _ungroupAllCommand;
+#endif
         if (GetTemplateChild("ExportAllMenuItem") is MenuFlyoutItem exportAllMenuItem)
         {
             _exportAllMenuItem = exportAllMenuItem;
@@ -99,6 +106,11 @@ partial class TableViewHeaderRow
 
         _clearFilterCommand.ExecuteRequested += delegate { TableView?.FilterHandler.ClearFilter(default); };
         _clearFilterCommand.CanExecuteRequested += CanExecuteClearFilterCommand;
+
+#if WINDOWS
+        _ungroupAllCommand.ExecuteRequested += delegate { TableView?.UngroupAll(); };
+        _ungroupAllCommand.CanExecuteRequested += CanExecuteUngroupAllCommand;
+#endif
 
         _exportAllToCSVCommand.ExecuteRequested += delegate { TableView?.ExportAllToCSV(); };
 
@@ -155,6 +167,13 @@ partial class TableViewHeaderRow
     {
         e.CanExecute = TableView?.IsEditing is false && TableView.IsFiltered;
     }
+
+#if WINDOWS
+    private void CanExecuteUngroupAllCommand(XamlUICommand sender, CanExecuteRequestedEventArgs e)
+    {
+        e.CanExecute = TableView?.IsEditing is false && TableView.IsGrouped;
+    }
+#endif
 
     private void CanExecuteExportSelectedToCSVCommand(XamlUICommand sender, CanExecuteRequestedEventArgs e)
     {

--- a/src/TableViewHeaderRow.OptionComamnds.cs
+++ b/src/TableViewHeaderRow.OptionComamnds.cs
@@ -18,7 +18,7 @@ partial class TableViewHeaderRow
     private readonly StandardUICommand _clearSortingCommand = new() { Label = TableViewLocalizedStrings.ClearSorting };
     private readonly StandardUICommand _clearFilterCommand = new() { Label = TableViewLocalizedStrings.ClearFilter };
 #if WINDOWS
-    private readonly StandardUICommand _ungroupAllCommand = new() { Label = "Ungroup All" };
+    private readonly StandardUICommand _ungroupAllCommand = new() { Label = TableViewLocalizedStrings.UngroupAll };
 #endif
     private readonly StandardUICommand _exportAllToCSVCommand = new() { Label = TableViewLocalizedStrings.ExportAll };
     private readonly StandardUICommand _exportSelectedToCSVCommand = new() { Label = TableViewLocalizedStrings.ExportSelected };

--- a/src/TableViewHeaderRow.cs
+++ b/src/TableViewHeaderRow.cs
@@ -33,6 +33,7 @@ public partial class TableViewHeaderRow : Control
     private Button? _optionsButton;
     private Button? _selectAllButton;
     private CheckBox? _selectAllCheckBox;
+    private bool _isSyncingSelectAllCheckBox;
     private Rectangle? _v_gridLine;
     private Rectangle? _h_gridLine;
     private StackPanel? _frozenHeadersPanel;
@@ -375,6 +376,13 @@ public partial class TableViewHeaderRow : Control
     {
         if (TableView is not null && _selectAllCheckBox is not null)
         {
+            // Setting IsChecked below can itself raise Checked/Unchecked (WinUI doesn't distinguish a
+            // programmatic set from a user click) - those handlers call back into TableView.SelectAll()/
+            // DeselectAll(), which re-enters this same method via the resulting SelectionChanged, and so on
+            // forever until the stack overflows. _isSyncingSelectAllCheckBox marks this update as our own
+            // so OnSelectAllCheckBoxChecked/Unchecked can ignore it instead of re-triggering selection.
+            _isSyncingSelectAllCheckBox = true;
+
             if (TableView.Items.Count == 0)
             {
                 _selectAllCheckBox.IsChecked = null;
@@ -395,6 +403,8 @@ public partial class TableViewHeaderRow : Control
                 _selectAllCheckBox.IsChecked = false;
                 _selectAllCheckBox.IsEnabled = true;
             }
+
+            _isSyncingSelectAllCheckBox = false;
         }
     }
 
@@ -475,6 +485,11 @@ public partial class TableViewHeaderRow : Control
     /// </summary>
     private void OnSelectAllCheckBoxChecked(object sender, RoutedEventArgs e)
     {
+        // Ignore our own programmatic update from OnTableViewSelectionChanged - only react to a real
+        // user click, otherwise this and DeselectAll() below recurse into each other via SelectionChanged
+        // until the stack overflows.
+        if (_isSyncingSelectAllCheckBox) return;
+
         TableView?.SelectAll();
     }
 
@@ -483,6 +498,8 @@ public partial class TableViewHeaderRow : Control
     /// </summary>
     private void OnSelectAllCheckBoxUnchecked(object sender, RoutedEventArgs e)
     {
+        if (_isSyncingSelectAllCheckBox) return;
+
         TableView?.DeselectAll();
     }
 

--- a/src/TableViewLocalizedStrings.cs
+++ b/src/TableViewLocalizedStrings.cs
@@ -42,6 +42,9 @@ internal partial class TableViewLocalizedStrings
         SortDescending = GetValue(nameof(SortDescending));
         TimePickerPlaceholder = GetValue(nameof(TimePickerPlaceholder));
         Filtered = GetValue(nameof(Filtered));
+        Group = GetValue(nameof(Group));
+        Ungroup = GetValue(nameof(Ungroup));
+        UngroupAll = GetValue(nameof(UngroupAll));
     }
 
     private static string GetValue(string name)
@@ -91,4 +94,7 @@ internal partial class TableViewLocalizedStrings
     public static string SortDescending { get; set; }
     public static string TimePickerPlaceholder { get; set; }
     public static string Filtered { get; set; }
+    public static string Group { get; set; }
+    public static string Ungroup { get; set; }
+    public static string UngroupAll { get; set; }
 }

--- a/src/TableViewLocalizedStrings.cs
+++ b/src/TableViewLocalizedStrings.cs
@@ -45,6 +45,8 @@ internal partial class TableViewLocalizedStrings
         Group = GetValue(nameof(Group));
         Ungroup = GetValue(nameof(Ungroup));
         UngroupAll = GetValue(nameof(UngroupAll));
+        SortGroupsByCount = GetValue(nameof(SortGroupsByCount));
+        SortGroupsByValue = GetValue(nameof(SortGroupsByValue));
     }
 
     private static string GetValue(string name)
@@ -97,4 +99,6 @@ internal partial class TableViewLocalizedStrings
     public static string Group { get; set; }
     public static string Ungroup { get; set; }
     public static string UngroupAll { get; set; }
+    public static string SortGroupsByCount { get; set; }
+    public static string SortGroupsByValue { get; set; }
 }

--- a/src/TableViewRowPresenter.cs
+++ b/src/TableViewRowPresenter.cs
@@ -32,6 +32,7 @@ public partial class TableViewRowPresenter : Control
     private Panel? _detailsPanel;
     private ContentPresenter? _detailsPresenter;
     private ToggleButton? _detailsToggleButton;
+    private Border? _indentPlaceholder;
     private ListViewItemPresenter? _itemPresenter;
     private long? _detailsPanelVisibilityCallbackToken;
 
@@ -67,6 +68,7 @@ public partial class TableViewRowPresenter : Control
         _detailsPanel = GetTemplateChild("DetailsPanel") as Panel;
         _detailsPresenter = GetTemplateChild("DetailsPresenter") as ContentPresenter;
         _detailsToggleButton = GetTemplateChild("DetailsToggleButton") as ToggleButton;
+        _indentPlaceholder = GetTemplateChild("IndentPlaceholder") as Border;
 
         _itemPresenter = this.FindAscendant<ListViewItemPresenter>();
         TableViewRow = this.FindAscendant<TableViewRow>();
@@ -91,6 +93,20 @@ public partial class TableViewRowPresenter : Control
         SetRowHeaderWidth();
         SetRowDetailsVisibility();
         SetRowDetailsTemplate();
+        SetGroupIndent();
+    }
+
+    /// <summary>
+    /// Indents this row's cells for the active grouping depth by setting a left margin on
+    /// <see cref="_frozenCellsPanel"/> - <see cref="_scrollableCellsPanel"/> follows automatically since
+    /// <see cref="ArrangeOverride"/> positions it relative to the frozen panel's actual (post-margin) offset.
+    /// The row header, in its own column, is unaffected. Called once per row preparation (not from
+    /// ArrangeOverride, which runs on every scroll tick - mutating a child's Margin there would
+    /// re-invalidate measure every pass and risks a "Layout cycle detected" crash).
+    /// </summary>
+    internal void SetGroupIndent()
+    {
+        _indentPlaceholder?.Width = GetGroupIndent();
     }
 
     /// <summary>
@@ -182,6 +198,21 @@ public partial class TableViewRowPresenter : Control
         }
 
         return finalSize;
+    }
+
+    /// <summary>
+    /// The extra <see cref="TableView.CellsHorizontalOffset"/> added for the active grouping depth, so cells (and,
+    /// via that shared offset, the column headers) shift right under nested group headers. A single grouping
+    /// level isn't indented - only levels after the first add <see cref="TableViewGroupHeaderRow.GroupIndentSize"/>.
+    /// </summary>
+    private double GetGroupIndent()
+    {
+#if WINDOWS
+        var groupLevels = (TableView?.CollectionView as CollectionView)?.GroupDescriptions.Count ?? 0;
+        return Math.Max(0, groupLevels - 1) * TableViewGroupHeaderRow.GroupIndentSize;
+#else
+        return 0d;
+#endif
     }
 
     /// <summary>

--- a/src/Themes/Generic.xaml
+++ b/src/Themes/Generic.xaml
@@ -1,13 +1,15 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:WinUI.TableView"
-                    xmlns:controls="using:WinUI.TableView.Controls">
+                    xmlns:controls="using:WinUI.TableView.Controls"
+                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableView.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewCell.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewRowPresenter.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewColumnHeader.xaml" />
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewGroupHeaderRow.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewHeaderRow.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewRow.xaml" />
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewRowHeader.xaml" />
@@ -40,5 +42,8 @@
 
     <Style TargetType="controls:TableViewTimePicker"
            BasedOn="{StaticResource DefaultTableViewTimePickerStyle}" />
+
+    <win:Style TargetType="local:TableViewGroupHeaderRow"
+           BasedOn="{StaticResource DefaultTableViewGroupHeaderRowStyle}" />
 
 </ResourceDictionary>

--- a/src/Themes/Resources.xaml
+++ b/src/Themes/Resources.xaml
@@ -77,6 +77,12 @@
             <SolidColorBrush x:Key="TableViewDragRectangleFill" Color="{StaticResource SystemAccentColor}" Opacity="0.2" />
             <StaticResource x:Key="TableViewDragRectangleStroke" ResourceKey="AccentFillColorDefaultBrush" />
             <CornerRadius x:Key="TableViewDragRectangleCornerRadius">0</CornerRadius>
+            <StaticResource x:Key="TableViewGroupHeaderRowBackground" ResourceKey="CardBackgroundFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewGroupHeaderRowForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <x:Double x:Key="TableViewGroupHeaderRowMinHeight">36</x:Double>
+            <Thickness x:Key="TableViewGroupHeaderRowExpanderMargin">4,0,4,0</Thickness>
+            <Thickness x:Key="TableViewGroupHeaderRowContentMargin">8,0,16,0</Thickness>
+            <x:Double x:Key="TableViewGroupHeaderRowFontSize">18</x:Double>
         </ResourceDictionary>
         
         <ResourceDictionary x:Key="Dark">
@@ -149,6 +155,12 @@
             <SolidColorBrush x:Key="TableViewDragRectangleFill" Color="{StaticResource SystemAccentColor}" Opacity="0.2" />
             <StaticResource x:Key="TableViewDragRectangleStroke" ResourceKey="AccentFillColorDefaultBrush" />
             <CornerRadius x:Key="TableViewDragRectangleCornerRadius">0</CornerRadius>
+            <StaticResource x:Key="TableViewGroupHeaderRowBackground" ResourceKey="CardBackgroundFillColorSecondaryBrush" />
+            <StaticResource x:Key="TableViewGroupHeaderRowForeground" ResourceKey="TextFillColorPrimaryBrush" />
+            <x:Double x:Key="TableViewGroupHeaderRowMinHeight">36</x:Double>
+            <Thickness x:Key="TableViewGroupHeaderRowExpanderMargin">4,0,0,0</Thickness>
+            <Thickness x:Key="TableViewGroupHeaderRowContentMargin">8,0,16,0</Thickness>
+            <x:Double x:Key="TableViewGroupHeaderRowFontSize">18</x:Double>
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
@@ -221,6 +233,12 @@
             <SolidColorBrush x:Key="TableViewDragRectangleFill" Color="{ThemeResource SystemColorHighlightColor}" Opacity="0.3" />
             <SolidColorBrush x:Key="TableViewDragRectangleStroke" Color="{ThemeResource SystemColorHighlightColor}" />
             <CornerRadius x:Key="TableViewDragRectangleCornerRadius">0</CornerRadius>
+            <SolidColorBrush x:Key="TableViewGroupHeaderRowBackground" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="TableViewGroupHeaderRowForeground" Color="{ThemeResource SystemColorWindowTextColor}" />
+            <x:Double x:Key="TableViewGroupHeaderRowMinHeight">36</x:Double>
+            <Thickness x:Key="TableViewGroupHeaderRowExpanderMargin">4,0,0,0</Thickness>
+            <Thickness x:Key="TableViewGroupHeaderRowContentMargin">8,0,16,0</Thickness>
+            <x:Double x:Key="TableViewGroupHeaderRowFontSize">18</x:Double>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 

--- a/src/Themes/TableView.xaml
+++ b/src/Themes/TableView.xaml
@@ -9,6 +9,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/TableViewGroupHeaderRow.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="DefaultTableViewStyle"
@@ -61,6 +62,8 @@
                 Value="{ThemeResource TableViewHorizontalGridLineStrokeThickness}" />
         <Setter Property="VerticalGridLinesStrokeThickness"
                 Value="{ThemeResource TableViewVerticalGridLineStrokeThickness}" />
+        <win:Setter Property="DefaultGroupStyle"
+                    Value="{StaticResource DefaultTableViewGroupStyle}" />
         <win:Setter Property="ItemContainerTransitions">
             <win:Setter.Value>
                 <TransitionCollection>

--- a/src/Themes/TableViewColumnHeader.xaml
+++ b/src/Themes/TableViewColumnHeader.xaml
@@ -139,7 +139,7 @@
                                                         <FontIcon Glyph="&#xF168;" />
                                                     </win:MenuFlyoutItem.Icon>
                                                 </win:MenuFlyoutItem>
-                                                <MenuFlyoutSeparator />
+                                                <win:MenuFlyoutSeparator />
                                                 <MenuFlyoutItem x:Name="SortAscendingMenuItem">
                                                     <MenuFlyoutItem.Icon>
                                                         <FontIcon Glyph="&#xf0ad;" />

--- a/src/Themes/TableViewColumnHeader.xaml
+++ b/src/Themes/TableViewColumnHeader.xaml
@@ -1,7 +1,8 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:WinUI.TableView"
-                    xmlns:controls="using:WinUI.TableView.Controls">
+                    xmlns:controls="using:WinUI.TableView.Controls"
+                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
@@ -133,6 +134,12 @@
                                         <local:TableViewFilterMenuFlyout x:Name="OptionsFlyout"
                                                                          Placement="Bottom">
                                             <local:TableViewFilterMenuFlyout.Items>
+                                                <win:MenuFlyoutItem x:Name="GroupMenuItem">
+                                                    <win:MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xF168;" />
+                                                    </win:MenuFlyoutItem.Icon>
+                                                </win:MenuFlyoutItem>
+                                                <MenuFlyoutSeparator />
                                                 <MenuFlyoutItem x:Name="SortAscendingMenuItem">
                                                     <MenuFlyoutItem.Icon>
                                                         <FontIcon Glyph="&#xf0ad;" />

--- a/src/Themes/TableViewColumnHeader.xaml
+++ b/src/Themes/TableViewColumnHeader.xaml
@@ -139,6 +139,11 @@
                                                         <FontIcon Glyph="&#xF168;" />
                                                     </win:MenuFlyoutItem.Icon>
                                                 </win:MenuFlyoutItem>
+                                                <win:MenuFlyoutItem x:Name="SortGroupsByCountMenuItem">
+                                                    <win:MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE9D9;" />
+                                                    </win:MenuFlyoutItem.Icon>
+                                                </win:MenuFlyoutItem>
                                                 <win:MenuFlyoutSeparator />
                                                 <MenuFlyoutItem x:Name="SortAscendingMenuItem">
                                                     <MenuFlyoutItem.Icon>

--- a/src/Themes/TableViewGroupHeaderRow.xaml
+++ b/src/Themes/TableViewGroupHeaderRow.xaml
@@ -1,0 +1,106 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:local="using:WinUI.TableView"
+                    xmlns:helpers="using:WinUI.TableView.Helpers"
+                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <win:DataTemplate x:Key="DefaultTableViewGroupHeaderTemplate">
+        <Grid>
+            <TextBlock Text="{Binding Key}" />
+            <TextBlock HorizontalAlignment="Right"
+                       Text="{Binding Count}" />
+        </Grid>
+    </win:DataTemplate>
+
+    <win:GroupStyle x:Key="DefaultTableViewGroupStyle"
+                HeaderTemplate="{StaticResource DefaultTableViewGroupHeaderTemplate}" />
+
+    <win:Style x:Key="DefaultTableViewGroupHeaderRowStyle"
+           TargetType="local:TableViewGroupHeaderRow">
+        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+        <Setter Property="FontSize" Value="{ThemeResource TableViewGroupHeaderRowFontSize}" />
+        <Setter Property="Background" Value="{ThemeResource TableViewGroupHeaderRowBackground}" />
+        <Setter Property="Foreground" Value="{ThemeResource TableViewGroupHeaderRowForeground}" />
+        <Setter Property="Margin" Value="0,0,0,0" />
+        <Setter Property="Padding" Value="{ThemeResource TableViewGroupHeaderRowContentMargin}" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="MinHeight" Value="{ThemeResource TableViewGroupHeaderRowMinHeight}" />
+        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="local:TableViewGroupHeaderRow">
+                    <Grid Background="{TemplateBinding Background}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}"
+                          CornerRadius="{TemplateBinding CornerRadius}">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="ExpandCollapseStates">
+                                <VisualState x:Name="Expanded" />
+                                <VisualState x:Name="Collapsed">
+                                    <VisualState.Setters>
+                                        <Setter Target="ExpandCollapseIconRotation.Angle"
+                                                Value="-90" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <Border x:Name="IndentPlaceholder"
+                                IsHitTestVisible="False" />
+                        
+                        <Button x:Name="ExpandCollapseButton"
+                                Grid.Column="1"
+                                Background="Transparent"
+                                BorderThickness="0"
+                                Padding="4"
+                                Margin="{ThemeResource TableViewGroupHeaderRowExpanderMargin}"
+                                MinWidth="24"
+                                MinHeight="24"
+                                VerticalAlignment="Center">
+                            <FontIcon x:Name="ExpandCollapseIcon"
+                                      FontSize="12"
+                                      Glyph="&#xE70D;"
+                                      RenderTransformOrigin="0.5,0.5">
+                                <FontIcon.RenderTransform>
+                                    <RotateTransform x:Name="ExpandCollapseIconRotation" />
+                                </FontIcon.RenderTransform>
+                            </FontIcon>
+                        </Button>
+
+                        <ContentPresenter x:Name="ContentPresenter"
+                                          Grid.Column="2"
+                                          Margin="{TemplateBinding Padding}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          ContentTransitions="{TemplateBinding ContentTransitions}"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+
+                        <Rectangle x:Name="HorizontalGridLine"
+                                   Grid.Row="1"
+                                   Grid.ColumnSpan="3"
+                                   HorizontalAlignment="Stretch" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </win:Style>
+
+</ResourceDictionary>

--- a/src/Themes/TableViewHeaderRow.xaml
+++ b/src/Themes/TableViewHeaderRow.xaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="using:WinUI.TableView">
+                    xmlns:local="using:WinUI.TableView"
+                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="ms-appx:///WinUI.TableView/Themes/Resources.xaml" />
@@ -159,6 +160,7 @@
                                         <MenuFlyoutSeparator />
                                         <MenuFlyoutItem x:Name="ClearSortingMenuItem" />
                                         <MenuFlyoutItem x:Name="ClearFilterMenuItem" />
+                                        <win:MenuFlyoutItem x:Name="UngroupAllMenuItem" />
                                         <MenuFlyoutSeparator Visibility="{Binding Visibility, ElementName=ExportAllMenuItem}" />
                                         <MenuFlyoutItem x:Name="ExportAllMenuItem">
                                             <MenuFlyoutItem.Icon>

--- a/src/Themes/TableViewRowPresenter.xaml
+++ b/src/Themes/TableViewRowPresenter.xaml
@@ -92,10 +92,15 @@
                                               Style="{StaticResource DetailsExpanderToggleButtonStyle}" />
                             </Grid>
 
+                            <Border x:Name="IndentPlaceholder"
+                                    Grid.Column="1"
+                                    IsHitTestVisible="False" />
+
                             <Rectangle x:Name="VerticalGridLine"
                                        Width="1"
                                        Grid.RowSpan="2"
                                        Grid.Column="1"
+                                       HorizontalAlignment="Right"
                                        VerticalAlignment="Stretch"
                                        IsHitTestVisible="False" />
 

--- a/tests/CollectionViewTests.cs
+++ b/tests/CollectionViewTests.cs
@@ -753,6 +753,121 @@ public class CollectionViewTests
         Assert.AreEqual(2, ((TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups![0]).Group!).Key);
     }
 
+    [UITestMethod]
+    public void Group_Sort_Mode_Count_Orders_Groups_By_Size_Not_Key()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 1 },
+            new() { Id = 3, Name = "C", Value = 1 },
+            new() { Id = 4, Name = "D", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        var groupDescription = GroupByValue();
+        groupDescription.SortMode = GroupSortMode.Count;
+        view.GroupDescriptions.Add(groupDescription);
+
+        // Value=1 has 3 items, Value=2 has 1 - ascending-by-key (the default mode) would put Value=1
+        // first; ascending-by-count puts the SMALLER group first instead, so Value=2 comes first here.
+        var first = (TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups![0]).Group!;
+        Assert.AreEqual(2, first.Key);
+        Assert.AreEqual(1, first.Count);
+
+        var second = (TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups[1]).Group!;
+        Assert.AreEqual(1, second.Key);
+        Assert.AreEqual(3, second.Count);
+    }
+
+    [UITestMethod]
+    public void Changing_A_Group_Descriptions_Sort_Mode_Reorders_Groups()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 1 },
+            new() { Id = 3, Name = "C", Value = 1 },
+            new() { Id = 4, Name = "D", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        var groupDescription = GroupByValue();
+        view.GroupDescriptions.Add(groupDescription);
+
+        // Default: Key mode, ascending - Value=1 (the smaller key) first, same as today.
+        Assert.AreEqual(1, ((TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups![0]).Group!).Key);
+
+        groupDescription.SortMode = GroupSortMode.Count;
+        view.RefreshGrouping();
+
+        // Switching to Count mode (still Ascending) puts the smaller GROUP first instead - Value=2 (1 item).
+        Assert.AreEqual(2, ((TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups![0]).Group!).Key);
+
+        groupDescription.Direction = SortDirection.Descending;
+        view.RefreshGrouping();
+
+        // The two toggles compose: Count mode + Descending puts the BIGGER group first - Value=1 (3 items).
+        Assert.AreEqual(1, ((TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups![0]).Group!).Key);
+    }
+
+    [UITestMethod]
+    public void Group_Sort_Mode_Count_Breaks_Ties_By_Key()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            // Value=2's item is encountered first, but ties should break ascending by key (Value=1
+            // first), not by source encounter order.
+            new() { Id = 1, Name = "A", Value = 2 },
+            new() { Id = 2, Name = "B", Value = 1 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        var groupDescription = GroupByValue();
+        groupDescription.SortMode = GroupSortMode.Count;
+        view.GroupDescriptions.Add(groupDescription);
+
+        // Both groups have exactly 1 item - a tie. The tie-break is always ascending by key, so Value=1
+        // comes first despite Value=2 appearing first in the source.
+        Assert.AreEqual(1, ((TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups![0]).Group!).Key);
+        Assert.AreEqual(2, ((TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups[1]).Group!).Key);
+    }
+
+    [UITestMethod]
+    public void Multi_Level_Group_Sort_Mode_Applies_Independently_Per_Level()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "Z", Value = 1 },
+            new() { Id = 2, Name = "M", Value = 2 },
+            new() { Id = 3, Name = "A", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+
+        var outerGroupDescription = GroupByValue();
+        outerGroupDescription.SortMode = GroupSortMode.Count;
+        outerGroupDescription.Direction = SortDirection.Descending; // biggest outer group first
+        view.GroupDescriptions.Add(outerGroupDescription);
+        view.GroupDescriptions.Add(GroupByName()); // inner level: default Key mode, ascending
+
+        // Outer: Value=2 has 2 items, Value=1 has 1 - Count+Descending puts Value=2 (bigger) first,
+        // the opposite of the default key-ascending order.
+        var outerFirst = (TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups![0]).Group!;
+        Assert.AreEqual(2, outerFirst.Key);
+
+        // Inner (still Key mode) keeps ordering alphabetically within that outer group: "A" before "M".
+        var innerFirst = (TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups[1]).Group!;
+        Assert.AreEqual("A", innerFirst.Key);
+
+        var innerSecond = (TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups[2]).Group!;
+        Assert.AreEqual("M", innerSecond.Key);
+
+        // Outer: Value=1 (1 item) comes last.
+        var outerSecond = (TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups[3]).Group!;
+        Assert.AreEqual(1, outerSecond.Key);
+    }
+
     /// <summary>
     /// Flips a group's expanded/collapsed state, the same DependencyProperty the header row's expand/collapse
     /// button toggles - a stand-in for the removed CollectionView.ToggleGroup convenience method.

--- a/tests/CollectionViewTests.cs
+++ b/tests/CollectionViewTests.cs
@@ -308,6 +308,471 @@ public class CollectionViewTests
         Assert.AreEqual(0, view.Count);
     }
 
+    [UITestMethod]
+    public void Single_Group_Description_Groups_Items()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+            new() { Id = 3, Name = "C", Value = 1 },
+            new() { Id = 4, Name = "D", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+
+        Assert.AreEqual(2, view.CollectionGroups!.Count);
+
+        var group1 = (CollectionViewGroup)view.CollectionGroups[0];
+        var group2 = (CollectionViewGroup)view.CollectionGroups[1];
+        Assert.AreEqual(1, ((TableViewGroupInfo)group1.Group!).Key);
+        Assert.AreEqual(2, ((TableViewGroupInfo)group2.Group!).Key);
+        CollectionAssert.AreEqual(new[] { "A", "C" }, group1.GroupItems!.Select(i => ((TestItem)i!).Name).ToArray());
+        CollectionAssert.AreEqual(new[] { "B", "D" }, group2.GroupItems!.Select(i => ((TestItem)i!).Name).ToArray());
+
+        // The flat view is pruned/reordered to match what's currently visible - with everything expanded,
+        // that's every item, flattened in group order (Value=1's A, C, then Value=2's B, D), not source order.
+        CollectionAssert.AreEqual(new[] { "A", "C", "B", "D" }, view.Select(i => ((TestItem)i).Name).ToArray());
+    }
+
+    [UITestMethod]
+    public void Multi_Level_Group_Descriptions_Create_Nested_Flattened_Groups()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+            new() { Id = 3, Name = "C", Value = 1 },
+            new() { Id = 4, Name = "D", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+        view.GroupDescriptions.Add(GroupByName());
+
+        // Depth-first flattened order: Value-1 (parent, empty), Name-A (leaf), Name-C (leaf),
+        // Value-2 (parent, empty), Name-B (leaf), Name-D (leaf).
+        Assert.AreEqual(6, view.CollectionGroups!.Count);
+
+        var parent1 = (CollectionViewGroup)view.CollectionGroups[0];
+        Assert.AreEqual(1, ((TableViewGroupInfo)parent1.Group!).Key);
+        Assert.AreEqual(0, parent1.GroupItems!.Count);
+
+        var leafA = (CollectionViewGroup)view.CollectionGroups[1];
+        Assert.AreEqual("A", ((TableViewGroupInfo)leafA.Group!).Key);
+        CollectionAssert.AreEqual(new[] { "A" }, leafA.GroupItems!.Select(i => ((TestItem)i!).Name).ToArray());
+
+        var leafC = (CollectionViewGroup)view.CollectionGroups[2];
+        Assert.AreEqual("C", ((TableViewGroupInfo)leafC.Group!).Key);
+
+        var parent2 = (CollectionViewGroup)view.CollectionGroups[3];
+        Assert.AreEqual(2, ((TableViewGroupInfo)parent2.Group!).Key);
+        Assert.AreEqual(0, parent2.GroupItems!.Count);
+
+        var leafB = (CollectionViewGroup)view.CollectionGroups[4];
+        Assert.AreEqual("B", ((TableViewGroupInfo)leafB.Group!).Key);
+
+        var leafD = (CollectionViewGroup)view.CollectionGroups[5];
+        Assert.AreEqual("D", ((TableViewGroupInfo)leafD.Group!).Key);
+
+        // With everything expanded, the flat view holds every item flattened in depth-first group order.
+        CollectionAssert.AreEqual(new[] { "A", "C", "B", "D" }, view.Select(i => ((TestItem)i).Name).ToArray());
+    }
+
+    [UITestMethod]
+    public void Group_Descriptions_Direct_Add_Without_Deferral_Updates_Groups()
+    {
+        var src = CreateItems(4); // Values: 4,3,2,1
+        var view = new CollectionView(src);
+
+        // Adding directly (no DeferRefresh) must still rebuild CollectionGroups.
+        view.GroupDescriptions.Add(GroupByValue());
+
+        Assert.AreEqual(4, view.CollectionGroups!.Count);
+    }
+
+    [UITestMethod]
+    public void Default_Group_State_Collapsed_Starts_Groups_Collapsed()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Collapsed;
+        view.GroupDescriptions.Add(GroupByValue());
+
+        Assert.AreEqual(2, view.CollectionGroups!.Count);
+        var group1 = (CollectionViewGroup)view.CollectionGroups[0];
+        Assert.IsFalse(((TableViewGroupInfo)group1.Group!).IsExpanded);
+        Assert.AreEqual(0, group1.GroupItems!.Count); // Collapsed - no items surfaced through this group.
+        Assert.AreEqual(0, view.Count); // Both groups collapsed - nothing is currently visible.
+    }
+
+    [UITestMethod]
+    public void Changing_Default_Group_State_Reapplies_To_Non_Overridden_Groups()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.GroupDescriptions.Add(GroupByValue()); // CollectionView's own default is Collapsed.
+
+        Assert.IsTrue(view.CollectionGroups!.Cast<CollectionViewGroup>().All(g => g.GroupItems!.Count == 0));
+
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+
+        Assert.IsTrue(view.CollectionGroups!.Cast<CollectionViewGroup>().All(g => g.GroupItems!.Count == 1));
+        Assert.AreEqual(2, view.Count); // Both groups are now expanded, so both items are visible.
+    }
+
+    [UITestMethod]
+    public void Explicitly_Toggled_Group_Ignores_Later_Default_State_Changes()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.GroupDescriptions.Add(GroupByValue()); // Both groups start collapsed.
+
+        ToggleGroup((CollectionViewGroup)view.CollectionGroups![0]); // Explicitly expand just this one.
+        Assert.AreEqual(1, ((CollectionViewGroup)view.CollectionGroups![0]).GroupItems!.Count);
+        Assert.AreEqual(0, ((CollectionViewGroup)view.CollectionGroups![1]).GroupItems!.Count);
+
+        view.DefaultGroupState = TableViewGroupState.Expanded; // Both groups now show.
+        Assert.AreEqual(1, ((CollectionViewGroup)view.CollectionGroups![0]).GroupItems!.Count);
+        Assert.AreEqual(1, ((CollectionViewGroup)view.CollectionGroups![1]).GroupItems!.Count);
+
+        view.DefaultGroupState = TableViewGroupState.Collapsed; // The explicitly-expanded group stays expanded.
+        Assert.AreEqual(1, ((CollectionViewGroup)view.CollectionGroups![0]).GroupItems!.Count);
+        Assert.AreEqual(0, ((CollectionViewGroup)view.CollectionGroups![1]).GroupItems!.Count);
+    }
+
+    [UITestMethod]
+    public void Ungrouping_And_Regrouping_Does_Not_Resurrect_Prior_Expanded_State()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+        };
+        var view = new CollectionView(src); // Default group state is Collapsed.
+        var firstGrouping = GroupByValue();
+        view.GroupDescriptions.Add(firstGrouping);
+
+        ToggleGroup((CollectionViewGroup)view.CollectionGroups![0]); // Explicitly expand just this one.
+        Assert.AreEqual(1, ((CollectionViewGroup)view.CollectionGroups![0]).GroupItems!.Count);
+
+        view.GroupDescriptions.Remove(firstGrouping); // Ungroup.
+
+        // Re-group: a brand new GroupDescription instance, exactly like the ColumnGroupDescription
+        // TableViewColumnHeader.Group() creates when a column is grouped again after being ungrouped.
+        view.GroupDescriptions.Add(GroupByValue());
+
+        // The prior expand override must not resurrect under the new GroupDescription instance - both
+        // groups should start at the (still Collapsed) default again, not "remember" the old expand state.
+        Assert.IsTrue(view.CollectionGroups!.Cast<CollectionViewGroup>().All(g => g.GroupItems!.Count == 0));
+    }
+
+    [UITestMethod]
+    public void Collapsing_A_Leaf_Group_Hides_Its_Items()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+            new() { Id = 3, Name = "C", Value = 1 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+
+        ToggleGroup((CollectionViewGroup)view.CollectionGroups![0]);
+
+        // ToggleGroup rebuilds CollectionGroups, so re-fetch rather than reuse the pre-toggle instance.
+        var group1 = (CollectionViewGroup)view.CollectionGroups![0];
+        Assert.AreEqual(0, group1.GroupItems!.Count); // Collapsed - no items surfaced through this group.
+        Assert.AreEqual(1, view.Count); // Only the still-expanded Value=2 group's item ("B") is visible.
+
+        ToggleGroup((CollectionViewGroup)view.CollectionGroups![0]);
+        group1 = (CollectionViewGroup)view.CollectionGroups![0];
+        Assert.AreEqual(2, group1.GroupItems!.Count); // Re-expanded - both Value=1 items surfaced again.
+        Assert.AreEqual(3, view.Count); // Both groups now expanded - everything is visible again.
+    }
+
+    [UITestMethod]
+    public void Collapsing_A_Parent_Group_Hides_Descendant_Subgroups_And_Items()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+            new() { Id = 3, Name = "C", Value = 1 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+        view.GroupDescriptions.Add(GroupByName());
+
+        // Flattened order: Value-1 (parent), Name-A (leaf), Name-C (leaf), Value-2 (parent), Name-B (leaf).
+        Assert.AreEqual(5, view.CollectionGroups!.Count);
+
+        var parent1 = (CollectionViewGroup)view.CollectionGroups[0];
+        ToggleGroup(parent1);
+
+        // Collapsing the parent removes its subgroup headers entirely, not just their items.
+        Assert.AreEqual(3, view.CollectionGroups!.Count);
+        Assert.AreEqual(1, view.Count); // Only Value=2's "B" remains visible - Value=1's subtree is hidden.
+
+        var remainingLeaf = (CollectionViewGroup)view.CollectionGroups[2];
+        Assert.AreEqual("B", ((TableViewGroupInfo)remainingLeaf.Group!).Key);
+        CollectionAssert.AreEqual(new[] { "B" }, remainingLeaf.GroupItems!.Select(i => ((TestItem)i!).Name).ToArray());
+    }
+
+    [UITestMethod]
+    public void Collapsed_State_Survives_A_Rebuild_Triggered_By_Something_Else()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+
+        var group1 = (CollectionViewGroup)view.CollectionGroups![0];
+        ToggleGroup(group1);
+        group1 = (CollectionViewGroup)view.CollectionGroups![0];
+        Assert.AreEqual(0, group1.GroupItems!.Count);
+
+        // Adding a single item goes through HandleItemAdded (not HandleSourceChanged), which rebuilds
+        // CollectionGroups via HandleGroupChanged and so constructs brand new TableViewGroupInfo
+        // instances - the collapsed state must still stick.
+        src.Add(new TestItem { Id = 3, Name = "E", Value = 1 });
+
+        // Still collapsed - the new Value=1 item stays hidden too, even under a brand new
+        // TableViewGroupInfo instance for the (still collapsed) Value=1 group.
+        group1 = (CollectionViewGroup)view.CollectionGroups![0];
+        Assert.AreEqual(0, group1.GroupItems!.Count);
+        Assert.AreEqual(1, view.Count); // Only Value=2's "B" is visible - Value=1's group (A, E) stays collapsed.
+    }
+
+    [UITestMethod]
+    public void Adding_An_Item_Places_It_In_Its_Existing_Group()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+
+        src.Add(new TestItem { Id = 3, Name = "C", Value = 1 }); // Joins the existing Value=1 group.
+
+        Assert.AreEqual(2, view.CollectionGroups!.Count); // Still just two groups - no new one created.
+        var group1 = (CollectionViewGroup)view.CollectionGroups[0];
+        CollectionAssert.AreEqual(new[] { "A", "C" }, group1.GroupItems!.Select(i => ((TestItem)i!).Name).ToArray());
+        Assert.AreEqual(2, ((TableViewGroupInfo)group1.Group!).Count);
+        Assert.AreEqual(3, view.Count);
+    }
+
+    [UITestMethod]
+    public void Adding_An_Item_With_A_New_Key_Creates_A_New_Group()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+
+        Assert.AreEqual(1, view.CollectionGroups!.Count);
+
+        src.Add(new TestItem { Id = 2, Name = "B", Value = 2 }); // A brand new Value=2 group.
+
+        Assert.AreEqual(2, view.CollectionGroups!.Count);
+        var newGroup = (CollectionViewGroup)view.CollectionGroups[1];
+        Assert.AreEqual(2, ((TableViewGroupInfo)newGroup.Group!).Key);
+        CollectionAssert.AreEqual(new[] { "B" }, newGroup.GroupItems!.Select(i => ((TestItem)i!).Name).ToArray());
+        Assert.AreEqual(2, view.Count);
+    }
+
+    [UITestMethod]
+    public void Removing_An_Item_Updates_Its_Group()
+    {
+        var a = new TestItem { Id = 1, Name = "A", Value = 1 };
+        var c = new TestItem { Id = 3, Name = "C", Value = 1 };
+        var src = new ObservableCollection<TestItem>
+        {
+            a,
+            new() { Id = 2, Name = "B", Value = 2 },
+            c,
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+
+        src.Remove(a);
+
+        Assert.AreEqual(2, view.CollectionGroups!.Count); // Value=1 group still exists - C remains.
+        var group1 = (CollectionViewGroup)view.CollectionGroups[0];
+        CollectionAssert.AreEqual(new[] { "C" }, group1.GroupItems!.Select(i => ((TestItem)i!).Name).ToArray());
+        Assert.AreEqual(1, ((TableViewGroupInfo)group1.Group!).Count);
+        Assert.AreEqual(2, view.Count);
+    }
+
+    [UITestMethod]
+    public void Removing_The_Last_Item_In_A_Group_Removes_The_Group_Header()
+    {
+        var a = new TestItem { Id = 1, Name = "A", Value = 1 };
+        var src = new ObservableCollection<TestItem>
+        {
+            a,
+            new() { Id = 2, Name = "B", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+
+        Assert.AreEqual(2, view.CollectionGroups!.Count);
+
+        src.Remove(a); // The only Value=1 item - its group should disappear entirely, not just empty out.
+
+        Assert.AreEqual(1, view.CollectionGroups!.Count);
+        Assert.AreEqual(2, ((TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups[0]).Group!).Key);
+        Assert.AreEqual(1, view.Count);
+    }
+
+    [UITestMethod]
+    public void Removing_An_Item_Hidden_In_A_Collapsed_Group_Updates_The_Group()
+    {
+        var a = new TestItem { Id = 1, Name = "A", Value = 1 };
+        var c = new TestItem { Id = 3, Name = "C", Value = 1 };
+        var src = new ObservableCollection<TestItem> { a, c };
+        var view = new CollectionView(src); // Groups start collapsed per CollectionView's own default.
+        view.GroupDescriptions.Add(GroupByValue());
+
+        var group1 = (CollectionViewGroup)view.CollectionGroups![0];
+        Assert.AreEqual(0, group1.GroupItems!.Count); // Collapsed - nothing surfaced through the group yet.
+        Assert.AreEqual(0, view.Count); // The only group is collapsed - nothing is currently visible.
+
+        src.Remove(a); // Removing an item that's currently hidden inside the collapsed group.
+
+        group1 = (CollectionViewGroup)view.CollectionGroups![0];
+        ToggleGroup(group1); // Expand to check what's actually left inside.
+
+        var expandedGroup = (CollectionViewGroup)view.CollectionGroups![0];
+        CollectionAssert.AreEqual(new[] { "C" }, expandedGroup.GroupItems!.Select(i => ((TestItem)i!).Name).ToArray());
+        Assert.AreEqual(1, view.Count);
+    }
+
+    [UITestMethod]
+    public void Adding_An_Item_Places_It_In_The_Correct_Nested_Group()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+        view.GroupDescriptions.Add(GroupByName());
+
+        // Flattened: Value-1 (parent), Name-A (leaf), Value-2 (parent), Name-B (leaf).
+        Assert.AreEqual(4, view.CollectionGroups!.Count);
+
+        src.Add(new TestItem { Id = 3, Name = "A", Value = 1 }); // Joins the existing Value=1/Name=A leaf group.
+
+        Assert.AreEqual(4, view.CollectionGroups!.Count); // No new group - same Value/Name combo.
+        var leafA = (CollectionViewGroup)view.CollectionGroups[1];
+        Assert.AreEqual("A", ((TableViewGroupInfo)leafA.Group!).Key);
+        Assert.AreEqual(2, leafA.GroupItems!.Count);
+        Assert.AreEqual(3, view.Count);
+
+        src.Add(new TestItem { Id = 4, Name = "D", Value = 1 }); // A brand new Value=1/Name=D leaf group.
+
+        Assert.AreEqual(5, view.CollectionGroups!.Count);
+        Assert.AreEqual(4, view.Count);
+    }
+
+    [UITestMethod]
+    public void CollectionView_Add_And_Remove_Respect_Grouping()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        view.GroupDescriptions.Add(GroupByValue());
+
+        view.Add(new TestItem { Id = 2, Name = "B", Value = 2 }); // Via CollectionView.Add, not the source directly.
+
+        Assert.AreEqual(2, view.CollectionGroups!.Count);
+        Assert.AreEqual(2, view.Count);
+
+        view.RemoveAt(0); // Removes whatever is first in the (grouped/reordered) view - item "A".
+
+        Assert.AreEqual(1, view.CollectionGroups!.Count);
+        Assert.AreEqual(1, view.Count);
+    }
+
+    [UITestMethod]
+    public void Changing_A_Group_Descriptions_Direction_Reorders_Groups()
+    {
+        var src = new ObservableCollection<TestItem>
+        {
+            new() { Id = 1, Name = "A", Value = 1 },
+            new() { Id = 2, Name = "B", Value = 2 },
+        };
+        var view = new CollectionView(src);
+        view.DefaultGroupState = TableViewGroupState.Expanded;
+        var groupDescription = GroupByValue();
+        view.GroupDescriptions.Add(groupDescription);
+
+        // Ascending by default.
+        Assert.AreEqual(1, ((TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups![0]).Group!).Key);
+
+        groupDescription.Direction = SortDirection.Descending;
+        view.RefreshGrouping();
+
+        // Mutating the same GroupDescription's Direction and refreshing reorders groups in place -
+        // this is exactly what TableViewColumnHeader.SortGroupDescription does when toggling a grouped
+        // column's sort direction, instead of adding a redundant SortDescription.
+        Assert.AreEqual(2, ((TableViewGroupInfo)((CollectionViewGroup)view.CollectionGroups![0]).Group!).Key);
+    }
+
+    /// <summary>
+    /// Flips a group's expanded/collapsed state, the same DependencyProperty the header row's expand/collapse
+    /// button toggles - a stand-in for the removed CollectionView.ToggleGroup convenience method.
+    /// </summary>
+    private static void ToggleGroup(CollectionViewGroup group)
+    {
+        var info = (TableViewGroupInfo)group.Group!;
+        info.IsExpanded = !info.IsExpanded;
+    }
+
+    private static GroupDescription GroupByValue()
+    {
+        return new GroupDescription(null, valueDelegate: item => ((TestItem)item!).Value);
+    }
+
+    private static GroupDescription GroupByName()
+    {
+        return new GroupDescription(null, valueDelegate: item => ((TestItem)item!).Name);
+    }
+
     private static ObservableCollection<TestItem> CreateItems(int count)
     {
         var list = new ObservableCollection<TestItem>();

--- a/tests/TableViewGroupingSelectionTests.cs
+++ b/tests/TableViewGroupingSelectionTests.cs
@@ -1,0 +1,271 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WinUI.TableView.Tests;
+
+/// <summary>
+/// Covers row selection, cell selection, and <see cref="TableView.ScrollRowIntoView(int)"/>, both ungrouped
+/// and grouped. <see cref="TableView.Items"/> is pruned by grouping - a collapsed group's items are removed
+/// from it entirely and later items shift down to fill the gap (see <see cref="CollectionViewTests"/> for the
+/// equivalent <see cref="CollectionView"/>-level coverage) - so every index used here is already in the one
+/// space <see cref="TableView.SelectRange"/>, <see cref="TableView.SelectCellRange"/>, and
+/// <see cref="TableView.ContainerFromIndex(int)"/> expect; there's no separate "visible" index space to
+/// reconcile.
+/// </summary>
+[TestClass]
+public class TableViewGroupingSelectionTests
+{
+    [UITestMethod]
+    public async Task RowSelection_Ungrouped_SelectsExpectedItems()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+
+        tableView.SelectRange(new ItemIndexRange(1, 2)); // Rows 1-2.
+
+        Assert.AreEqual(2, tableView.SelectedItems.Count);
+        CollectionAssert.AreEquivalent(new object[] { tableView.Items[1]!, tableView.Items[2]! }, tableView.SelectedItems.ToArray());
+    }
+
+    [UITestMethod]
+    public async Task RowSelection_Grouped_SelectsExpectedItems()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+        await GroupByCategoryAsync(tableView);
+
+        // Nothing is collapsed, so Items still lines up with source order - rows 2-3 are "B"'s items.
+        tableView.SelectRange(new ItemIndexRange(2, 2));
+
+        Assert.AreEqual(2, tableView.SelectedItems.Count);
+        Assert.IsTrue(tableView.SelectedItems.Cast<SelectionTestItem>().All(i => i.Category == "B"));
+    }
+
+    [UITestMethod]
+    public async Task CollapsingAGroup_RemovesItsItemsFromItems_AndShiftsLaterIndicesDown()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+        var collectionView = await GroupByCategoryAsync(tableView);
+
+        Assert.AreEqual(6, tableView.Items.Count);
+
+        SetGroupExpanded(collectionView, "A", isExpanded: false); // Hides rows 0-1.
+
+        Assert.AreEqual(4, tableView.Items.Count);
+        Assert.IsFalse(tableView.Items.Cast<SelectionTestItem>().Any(i => i.Category == "A"));
+        // "B"'s first item, previously at index 2, is now at index 0 - Items has no gaps.
+        Assert.AreEqual("B", ((SelectionTestItem)tableView.Items[0]!).Category);
+    }
+
+    [UITestMethod]
+    public async Task CurrentCellSlot_Grouped_IsCleared_WhenItsOwnGroupCollapses()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+        var collectionView = await GroupByCategoryAsync(tableView);
+
+        tableView.CurrentCellSlot = new TableViewCellSlot(2, 1); // "B"'s first item.
+
+        SetGroupExpanded(collectionView, "B", isExpanded: false); // Hides the item the current cell points at.
+
+        Assert.IsNull(tableView.CurrentCellSlot);
+    }
+
+    [UITestMethod]
+    public async Task CellSelection_Ungrouped_SelectsExpectedCells()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+
+        tableView.SelectCellRange(TableViewCellSlotRange.FromSlots(new TableViewCellSlot(1, 0), new TableViewCellSlot(2, 1)));
+        await Task.Yield(); // Allow selection to propagate.
+
+        Assert.AreEqual(4, tableView.SelectedCells.Count);
+        Assert.IsTrue(tableView.SelectedCells.Contains(new TableViewCellSlot(1, 0)));
+        Assert.IsTrue(tableView.SelectedCells.Contains(new TableViewCellSlot(2, 1)));
+    }
+
+    [UITestMethod]
+    public async Task CellSelection_Grouped_SelectsExpectedCells()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+        await GroupByCategoryAsync(tableView);
+
+        tableView.SelectCellRange(TableViewCellSlotRange.FromSlots(new TableViewCellSlot(2, 0), new TableViewCellSlot(3, 1)));
+        await Task.Yield();
+
+        Assert.AreEqual(4, tableView.SelectedCells.Count);
+        Assert.IsTrue(tableView.SelectedCells.Contains(new TableViewCellSlot(2, 0)));
+        Assert.IsTrue(tableView.SelectedCells.Contains(new TableViewCellSlot(3, 1)));
+    }
+
+    [UITestMethod]
+    public async Task ScrollRowIntoView_Ungrouped_ReturnsTheRealizedRow()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+
+        var row = await tableView.ScrollRowIntoView(3);
+
+        Assert.IsNotNull(row);
+        Assert.AreSame(tableView.Items[3], row!.Content);
+    }
+
+    [UITestMethod]
+    public async Task ScrollRowIntoView_Grouped_ReturnsTheRealizedRow()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+        await GroupByCategoryAsync(tableView);
+
+        var row = await tableView.ScrollRowIntoView(3);
+
+        Assert.IsNotNull(row);
+        Assert.AreSame(tableView.Items[3], row!.Content);
+    }
+
+    [UITestMethod]
+    public async Task ScrollRowIntoView_Grouped_AfterACollapse_ReturnsTheShiftedRow()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+        var collectionView = await GroupByCategoryAsync(tableView);
+
+        SetGroupExpanded(collectionView, "A", isExpanded: false); // "B" shifts down to index 0.
+
+        var row = await tableView.ScrollRowIntoView(0);
+
+        Assert.IsNotNull(row);
+        Assert.AreSame(tableView.Items[0], row!.Content);
+        Assert.AreEqual("B", ((SelectionTestItem)row.Content!).Category);
+    }
+
+    [UITestMethod]
+    public async Task ScrollRowIntoView_NegativeIndex_ReturnsNull()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+
+        var row = await tableView.ScrollRowIntoView(-1);
+
+        Assert.IsNull(row);
+    }
+
+    [UITestMethod]
+    public async Task ScrollRowIntoView_OverlappingCalls_DoNotCrash()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+        await GroupByCategoryAsync(tableView);
+
+        // Two calls started without awaiting the first in between (e.g. two SelectionChanged events firing
+        // in quick succession) used to crash the whole process - an unhandled native exception, not a
+        // catchable one - rather than merely misbehave.
+        var first = tableView.ScrollRowIntoView(2);
+        var second = tableView.ScrollRowIntoView(4);
+
+        await Task.WhenAll(first, second);
+
+        Assert.IsTrue(true, "Did not crash.");
+    }
+
+    [UITestMethod]
+    public async Task GetCellFromSlot_Grouped_ReturnsTheCorrectCellAfterACollapse()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+        var collectionView = await GroupByCategoryAsync(tableView);
+
+        SetGroupExpanded(collectionView, "A", isExpanded: false); // "B" shifts down to index 0.
+
+        await tableView.ScrollRowIntoView(0);
+        var cell = tableView.GetCellFromSlot(new TableViewCellSlot(0, 0));
+
+        Assert.IsNotNull(cell);
+        Assert.AreSame(tableView.Items[0], cell!.Row?.Content);
+        Assert.AreEqual("B", ((SelectionTestItem)cell.Row!.Content!).Category);
+    }
+
+    [UITestMethod]
+    public async Task RowIndex_MatchesItsPositionInItems_AfterACollapseShiftsIt()
+    {
+        var tableView = await CreateTableViewAsync(CreateItems());
+        var collectionView = await GroupByCategoryAsync(tableView);
+
+        SetGroupExpanded(collectionView, "A", isExpanded: false); // "B" shifts down to index 0.
+
+        var row = await tableView.ScrollRowIntoView(0);
+
+        Assert.IsNotNull(row);
+        Assert.AreEqual(0, row!.Index);
+        Assert.AreSame(tableView.Items[0], row.Content);
+    }
+
+    private static async Task<TableView> CreateTableViewAsync(SelectionTestItem[] items, ListViewSelectionMode selectionMode = ListViewSelectionMode.Extended)
+    {
+        var tableView = new TableView { SelectionMode = selectionMode };
+
+        tableView.Columns.Add(new TableViewTextColumn
+        {
+            Header = "Category",
+            Binding = new Binding { Path = new PropertyPath(nameof(SelectionTestItem.Category)) }
+        });
+        tableView.Columns.Add(new TableViewTextColumn
+        {
+            Header = "Value",
+            Binding = new Binding { Path = new PropertyPath(nameof(SelectionTestItem.Value)) }
+        });
+
+        tableView.ItemsSource = items;
+
+        await UnitTestApp.Current.MainWindow.LoadTestContentAsync(tableView);
+
+        return tableView;
+    }
+
+    /// <summary>
+    /// 3 categories ("A", "B", "C"), 2 items each, laid out contiguously (rows 0-1 = A, 2-3 = B, 4-5 = C).
+    /// </summary>
+    private static SelectionTestItem[] CreateItems()
+    {
+        var categories = new[] { "A", "B", "C" };
+
+        return Enumerable.Range(0, 6)
+            .Select(i => new SelectionTestItem { Id = i, Category = categories[i / 2], Value = i })
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Adding a <see cref="GroupDescription"/> to an already-loaded <see cref="TableView"/> makes it
+    /// asynchronously unbind and rebind the base <c>ItemsSource</c>, so callers must await this before
+    /// reading <see cref="TableView.Items"/> - otherwise it's transiently empty.
+    /// </summary>
+    private static async Task<CollectionView> GroupByCategoryAsync(TableView tableView, TableViewGroupState defaultGroupState = TableViewGroupState.Expanded)
+    {
+        var collectionView = (CollectionView)tableView.CollectionView;
+        collectionView.DefaultGroupState = defaultGroupState;
+        collectionView.GroupDescriptions.Add(new GroupDescription(nameof(SelectionTestItem.Category)));
+
+        await Task.Yield();
+
+        return collectionView;
+    }
+
+    private static void SetGroupExpanded(CollectionView collectionView, object key, bool isExpanded)
+    {
+        foreach (var groupObject in collectionView.CollectionGroups!)
+        {
+            var group = (CollectionViewGroup)groupObject;
+            var info = (TableViewGroupInfo)group.Group!;
+            if (Equals(info.Key, key))
+            {
+                info.IsExpanded = isExpanded;
+                return;
+            }
+        }
+
+        Assert.Fail($"No group found for key '{key}'.");
+    }
+
+    private sealed class SelectionTestItem
+    {
+        public int Id { get; set; }
+        public string Category { get; set; } = string.Empty;
+        public int Value { get; set; }
+    }
+}

--- a/tests/TableViewGroupingSortTests.cs
+++ b/tests/TableViewGroupingSortTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WinUI.TableView.Tests;
+
+/// <summary>
+/// Covers the interaction between grouping and sorting a different, unrelated column. A grouped column's
+/// <see cref="TableViewColumn.SortDirection"/> mirrors its group's own order rather than an independent
+/// sort, so <see cref="TableView.ClearAllSorting"/> - invoked whenever a plain header click single-sorts a
+/// different column - must not clear it or desync it from the group.
+/// </summary>
+[TestClass]
+public class TableViewGroupingSortTests
+{
+    [UITestMethod]
+    public async Task ClearAllSorting_DoesNotClear_AGroupedColumnsSortDirection()
+    {
+        var (tableView, categoryColumn, _) = await CreateTableViewAsync();
+        var collectionView = (CollectionView)tableView.CollectionView;
+
+        // Mirrors what TableViewColumnHeader.Group() does: add a ColumnGroupDescription for the column and
+        // give it a SortDirection, since a grouped column's order and its SortDirection indicator are unified.
+        collectionView.GroupDescriptions.Add(new ColumnGroupDescription(categoryColumn, nameof(SortTestItem.Category), SortDirection.Ascending));
+        categoryColumn.SortDirection = SortDirection.Ascending;
+
+        await Task.Yield();
+
+        // What a plain click on a different column's header does: single-sort semantics clear sorting
+        // everywhere else first.
+        tableView.ClearAllSorting();
+
+        Assert.AreEqual(SortDirection.Ascending, categoryColumn.SortDirection);
+        Assert.IsTrue(collectionView.GroupDescriptions.OfType<ColumnGroupDescription>().Any(x => x.Column == categoryColumn));
+    }
+
+    [UITestMethod]
+    public async Task ClearAllSorting_Clears_AnUngroupedColumnsSortDirection()
+    {
+        var (tableView, categoryColumn, _) = await CreateTableViewAsync();
+
+        categoryColumn.SortDirection = SortDirection.Ascending;
+
+        tableView.ClearAllSorting();
+
+        Assert.IsNull(categoryColumn.SortDirection);
+    }
+
+    private static async Task<(TableView TableView, TableViewTextColumn CategoryColumn, TableViewTextColumn ValueColumn)> CreateTableViewAsync()
+    {
+        var items = Enumerable.Range(0, 4)
+            .Select(i => new SortTestItem { Category = i % 2 == 0 ? "A" : "B", Value = i })
+            .ToArray();
+
+        var tableView = new TableView();
+        var categoryColumn = new TableViewTextColumn { Header = "Category", Binding = new Binding { Path = new PropertyPath(nameof(SortTestItem.Category)) } };
+        var valueColumn = new TableViewTextColumn { Header = "Value", Binding = new Binding { Path = new PropertyPath(nameof(SortTestItem.Value)) } };
+        tableView.Columns.Add(categoryColumn);
+        tableView.Columns.Add(valueColumn);
+        tableView.ItemsSource = items;
+
+        await UnitTestApp.Current.MainWindow.LoadTestContentAsync(tableView);
+
+        return (tableView, categoryColumn, valueColumn);
+    }
+
+    private sealed class SortTestItem
+    {
+        public string Category { get; set; } = string.Empty;
+        public int Value { get; set; }
+    }
+}


### PR DESCRIPTION
## Description

Adds Excel-like multi-level column grouping to `TableView` on Windows targets. Rows can be grouped by one or more column values via each column header's options flyout (or programmatically via `GroupDescriptions`), with per-group expand/collapse, group headers showing key + item count, indentation for nested levels, and full integration with existing column sorting.

Highlights:
- `GroupDescriptions` / `CollectionGroups` on `CollectionView`, with `ColumnGroupDescription` driving header-based grouping
- `TableViewGroupHeaderRow` renders group headers with expand/collapse and per-level indentation
- New `TableView` APIs: `CanGroupColumns`, `DefaultGroupState`, `DefaultGroupStyle`, `ShowGroupExpandCollapseButton`, `AreStickyGroupHeadersEnabled`, `IsGrouped`, `UngroupAll()`, and a `Grouping` event
- Per-column `CanGroup`, plus a "Group"/"Ungroup" option in each column header's options flyout
- Grouping and sorting are unified for a grouped column — grouping drives order and shows a sort indicator; see the docs for the three-state → two-state cycling behavior once a column is grouped
- New "Grouping" sample page in the sample app
- New tests: `CollectionView` grouping behavior (single/multi-level, state transitions and persistence, ordering) and `TableView` selection / row/cell access in grouped scenarios
- New `docs/docs/grouping.md` article, plus updates across README, overview, sorting, performance, accessibility, AOT-compatibility, migration guides (WCT/WPF), feature comparison, and the Uno-platform doc to reflect the new feature

## Related Issue

Closes #69 <!-- please double-check this is the right issue number, I couldn't reach the GitHub API to confirm -->

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation update
- [x] 🧪 Test

## Checklist

- [x] This PR is **not** from my `main` branch
- [x] Tested with **WinUI** target <!-- check if you've verified this yourself -->
- [ ] Tested with **Uno Platform** target <!-- not applicable — grouping is Windows-only -->
- [x] Unit / integration tests added or updated
- [x] Documentation updated to reflect changes
- [x] Code follows the project's coding conventions

## Screenshots / Recordings

https://github.com/user-attachments/assets/d61724a9-1da0-4bb4-8e0d-7bdb4fdeb0d0

## Additional Notes

Grouping is Windows-only for now. Non-Windows Uno Platform targets compile out the grouping code paths entirely rather than exposing a degraded/no-op experience in the UI beyond the flyout option being hidden.