### PR TITLE
Add option to show sortable columns hint icon

### DIFF
--- a/docs/docs/sorting.md
+++ b/docs/docs/sorting.md
@@ -32,6 +32,16 @@ Disable sorting for a specific column:
 <tv:TableViewNumberColumn Header="Price" Binding="{Binding Price}" CanSort="False" />
 ```
 
+## Showing a hint icon for sortable columns
+
+By default, an unsorted column shows no indicator, even if it's sortable — there's no way to tell a column supports sorting until you click it. Set [`ShowSortableColumnIcon`](xref:WinUI.TableView.TableView.ShowSortableColumnIcon) to `True` to show a subtle icon on sortable columns that aren't currently sorted, hinting that clicking the header will sort them:
+
+```xml
+<tv:TableView ShowSortableColumnIcon="True" />
+```
+
+The hint icon only appears where sorting is actually possible — it respects both `CanSortColumns` and the column's own `CanSort`. It disappears once the column is sorted, replaced by the usual ascending/descending indicator. `ShowSortableColumnIcon` is `False` by default, so existing apps see no visual change unless they opt in.
+
 ## Sorting by a different property (SortMemberPath)
 
 By default, clicking a column header sorts by the column's bound property path. Use [`SortMemberPath`](xref:WinUI.TableView.TableViewColumn.SortMemberPath) to sort by a **different** property than the one displayed in the cell.
@@ -167,6 +177,7 @@ var descriptions = tableView.SortDescriptions; // the active SortDescription lis
 |---|---|
 | [`CanSortColumns`](xref:WinUI.TableView.TableView.CanSortColumns) | Enables or disables sorting for all columns |
 | [`CanSort`](xref:WinUI.TableView.TableViewColumn.CanSort) | Per-column sort toggle |
+| [`ShowSortableColumnIcon`](xref:WinUI.TableView.TableView.ShowSortableColumnIcon) | Shows a hint icon on sortable, unsorted columns. `False` by default |
 | [`SortMemberPath`](xref:WinUI.TableView.TableViewColumn.SortMemberPath) | Property path used for sorting, overriding the display binding |
 | [`SortDirection`](xref:WinUI.TableView.TableViewColumn.SortDirection) | Current sort direction (`Ascending`, `Descending`, or `null`) |
 | [`SortDescriptions`](xref:WinUI.TableView.TableView.SortDescriptions) | Collection of active sort descriptions |

--- a/samples/WinUI.TableView.SampleApp/ExampleModelColumnsHelper.cs
+++ b/samples/WinUI.TableView.SampleApp/ExampleModelColumnsHelper.cs
@@ -29,8 +29,7 @@ public static class ExampleModelColumnsHelper
                     Binding = boundColumn.Binding,
                     Header = boundColumn.Header,
                     Width = new GridLength(120),
-                    ItemsSource = viewModel.Genders,
-                    CanSort = false
+                    ItemsSource = viewModel.Genders
                 };
                 break;
             case nameof(ExampleModel.Dob):
@@ -48,8 +47,7 @@ public static class ExampleModelColumnsHelper
                     Binding = boundColumn.Binding,
                     Header = boundColumn.Header,
                     Width = new GridLength(200),
-                    ItemsSource = viewModel.Departments,
-                    CanSort = false
+                    ItemsSource = viewModel.Departments
                 };
                 break;
             case nameof(ExampleModel.Designation):

--- a/samples/WinUI.TableView.SampleApp/ExampleModelColumnsHelper.cs
+++ b/samples/WinUI.TableView.SampleApp/ExampleModelColumnsHelper.cs
@@ -29,7 +29,8 @@ public static class ExampleModelColumnsHelper
                     Binding = boundColumn.Binding,
                     Header = boundColumn.Header,
                     Width = new GridLength(120),
-                    ItemsSource = viewModel.Genders
+                    ItemsSource = viewModel.Genders,
+                    CanSort = false
                 };
                 break;
             case nameof(ExampleModel.Dob):
@@ -47,7 +48,8 @@ public static class ExampleModelColumnsHelper
                     Binding = boundColumn.Binding,
                     Header = boundColumn.Header,
                     Width = new GridLength(200),
-                    ItemsSource = viewModel.Departments
+                    ItemsSource = viewModel.Departments,
+                    CanSort = false
                 };
                 break;
             case nameof(ExampleModel.Designation):

--- a/samples/WinUI.TableView.SampleApp/Pages/SortingPage.xaml
+++ b/samples/WinUI.TableView.SampleApp/Pages/SortingPage.xaml
@@ -14,7 +14,9 @@
                                   Description="Showcasing built in column sorting feature.">
             <controls:SamplePresenter.Example>
                 <tv:TableView ItemsSource="{Binding Items}"
-                              CanSortColumns="{Binding IsOn, ElementName=canSort, Mode=TwoWay}" />
+                              CanSortColumns="{Binding IsOn, ElementName=canSort, Mode=TwoWay}"
+                              ShowSortableColumnIcon="{Binding IsOn, ElementName=showSortableColumnIcon, Mode=TwoWay}"
+                              AutoGeneratingColumn="{x:Bind local:ExampleModelColumnsHelper.OnAutoGeneratingColumns}"/>
             </controls:SamplePresenter.Example>
             <controls:SamplePresenter.Options>
                 <StackPanel VerticalAlignment="Top">
@@ -23,17 +25,25 @@
                                   Header="Can Sort Columns"
                                   OnContent="True"
                                   OffContent="False" />
+                    <ToggleSwitch x:Name="showSortableColumnIcon"
+                                  IsOn="False"
+                                  Header="Show Sortable Column Icon"
+                                  OnContent="True"
+                                  OffContent="False" />
                 </StackPanel>
             </controls:SamplePresenter.Options>
             <controls:SamplePresenter.Xaml>
                 <x:String xml:space="preserve">
 &lt;tv:TableView ItemsSource="{Binding Items}"
-    CanSortColumns="$(CanSortColumns)">
+    CanSortColumns="$(CanSortColumns)"
+    ShowSortableColumnIcon="$(ShowSortableColumnIcon)">
                 </x:String>
             </controls:SamplePresenter.Xaml>
             <controls:SamplePresenter.Substitutions>
                 <controls:CodeSubstitution Key="CanSortColumns"
                                            Value="{x:Bind canSort.IsOn, Mode=OneWay}" />
+                <controls:CodeSubstitution Key="ShowSortableColumnIcon"
+                                           Value="{x:Bind showSortableColumnIcon.IsOn, Mode=OneWay}" />
             </controls:SamplePresenter.Substitutions>
         </controls:SamplePresenter>
     </Grid>

--- a/src/Columns/TableViewColumn.cs
+++ b/src/Columns/TableViewColumn.cs
@@ -574,6 +574,17 @@ public abstract partial class TableViewColumn : DependencyObject
     }
 
     /// <summary>
+    /// Handles changes to the CanSort property.
+    /// </summary>
+    private static void OnCanSortChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableViewColumn column && column.HeaderControl is not null)
+        {
+            column.HeaderControl.OnSortDirectionChanged();
+        }
+    }
+
+    /// <summary>
     /// Handles changes to the HeaderStyle property.
     /// </summary>
     private static void OnHeaderStyleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -666,7 +677,7 @@ public abstract partial class TableViewColumn : DependencyObject
     /// <summary>
     /// Identifies the CanSort dependency property.
     /// </summary>
-    public static readonly DependencyProperty CanSortProperty = DependencyProperty.Register(nameof(CanSort), typeof(bool), typeof(TableViewColumn), new PropertyMetadata(true));
+    public static readonly DependencyProperty CanSortProperty = DependencyProperty.Register(nameof(CanSort), typeof(bool), typeof(TableViewColumn), new PropertyMetadata(true, OnCanSortChanged));
 
     /// <summary>
     /// Identifies the CanFilter dependency property.

--- a/src/TableView.Properties.cs
+++ b/src/TableView.Properties.cs
@@ -112,12 +112,17 @@ public partial class TableView
     /// <summary>
     /// Identifies the CanSortColumns dependency property.
     /// </summary>
-    public static readonly DependencyProperty CanSortColumnsProperty = DependencyProperty.Register(nameof(CanSortColumns), typeof(bool), typeof(TableView), new PropertyMetadata(true));
+    public static readonly DependencyProperty CanSortColumnsProperty = DependencyProperty.Register(nameof(CanSortColumns), typeof(bool), typeof(TableView), new PropertyMetadata(true, OnCanSortColumnsChanged));
 
     /// <summary>
     /// Identifies the CanFilterColumns dependency property.
     /// </summary>
     public static readonly DependencyProperty CanFilterColumnsProperty = DependencyProperty.Register(nameof(CanFilterColumns), typeof(bool), typeof(TableView), new PropertyMetadata(true, OnCanFilterColumnsChanged));
+
+    /// <summary>
+    /// Identifies the ShowSortableColumnIcon dependency property.
+    /// </summary>
+    public static readonly DependencyProperty ShowSortableColumnIconProperty = DependencyProperty.Register(nameof(ShowSortableColumnIcon), typeof(bool), typeof(TableView), new PropertyMetadata(false, OnShowSortableColumnIconChanged));
 
     /// <summary>
     /// Identifies the MinColumnWidth dependency property.
@@ -692,6 +697,15 @@ public partial class TableView
     }
 
     /// <summary>
+    /// Gets or sets a value indicating whether a subtle icon is shown on sortable columns that are not currently sorted.
+    /// </summary>
+    public bool ShowSortableColumnIcon
+    {
+        get => (bool)GetValue(ShowSortableColumnIconProperty);
+        set => SetValue(ShowSortableColumnIconProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets the minimum width of columns. This can be overridden by the individual column.
     /// </summary>
     public double MinColumnWidth
@@ -1148,6 +1162,34 @@ public partial class TableView
             foreach (var header in tableView._headerRow.Headers)
             {
                 header.SetFilterButtonVisibility();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Handles changes to the CanSortColumns property.
+    /// </summary>
+    private static void OnCanSortColumnsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView && tableView._headerRow is not null)
+        {
+            foreach (var header in tableView._headerRow.Headers)
+            {
+                header.OnSortDirectionChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Handles changes to the ShowSortableColumnIcon property.
+    /// </summary>
+    private static void OnShowSortableColumnIconChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TableView tableView && tableView._headerRow is not null)
+        {
+            foreach (var header in tableView._headerRow.Headers)
+            {
+                header.OnSortDirectionChanged();
             }
         }
     }

--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -382,6 +382,7 @@ public partial class TableViewColumnHeader : ContentControl
         SetOptionCommands();
         SetFilterButtonVisibility();
         EnsureGridLines();
+        OnSortDirectionChanged();
     }
 
     /// <summary>

--- a/src/TableViewColumnHeader.cs
+++ b/src/TableViewColumnHeader.cs
@@ -28,6 +28,7 @@ namespace WinUI.TableView;
 [TemplateVisualState(Name = VisualStates.StateUnsorted, GroupName = VisualStates.GroupSort)]
 [TemplateVisualState(Name = VisualStates.StateSortAscending, GroupName = VisualStates.GroupSort)]
 [TemplateVisualState(Name = VisualStates.StateSortDescending, GroupName = VisualStates.GroupSort)]
+[TemplateVisualState(Name = VisualStates.StateSortable, GroupName = VisualStates.GroupSort)]
 [TemplateVisualState(Name = VisualStates.StateFiltered, GroupName = VisualStates.GroupFilter)]
 [TemplateVisualState(Name = VisualStates.StateUnfiltered, GroupName = VisualStates.GroupFilter)]
 public partial class TableViewColumnHeader : ContentControl
@@ -403,6 +404,10 @@ public partial class TableViewColumnHeader : ContentControl
         else if (Column?.SortDirection == SD.Descending)
         {
             VisualStates.GoToState(this, false, VisualStates.StateSortDescending);
+        }
+        else if (CanSort && _tableView?.ShowSortableColumnIcon is true)
+        {
+            VisualStates.GoToState(this, false, VisualStates.StateSortable);
         }
         else
         {

--- a/src/Themes/Resources.xaml
+++ b/src/Themes/Resources.xaml
@@ -10,6 +10,7 @@
         <ResourceDictionary x:Key="Light">
             <x:String x:Key="SortIconAscending">&#xf0ad;</x:String>
             <x:String x:Key="SortIconDescending">&#xf0ae;</x:String>
+            <x:String x:Key="SortIconUnsorted">&#xe8cb;</x:String>
             <x:String x:Key="FilterIcon">&#xe71c;</x:String>
             <x:String x:Key="OptionsButtonIcon">&#xe712;</x:String>
             <x:String x:Key="SelectAllButtonIcon">&#xE936;</x:String>
@@ -88,6 +89,7 @@
         <ResourceDictionary x:Key="Dark">
             <x:String x:Key="SortIconAscending">&#xf0ad;</x:String>
             <x:String x:Key="SortIconDescending">&#xf0ae;</x:String>
+            <x:String x:Key="SortIconUnsorted">&#xe8cb;</x:String>
             <x:String x:Key="FilterIcon">&#xe71c;</x:String>
             <x:String x:Key="OptionsButtonIcon">&#xe712;</x:String>
             <x:String x:Key="SelectAllButtonIcon">&#xE936;</x:String>
@@ -166,6 +168,7 @@
         <ResourceDictionary x:Key="HighContrast">
             <x:String x:Key="SortIconAscending">&#xf0ad;</x:String>
             <x:String x:Key="SortIconDescending">&#xf0ae;</x:String>
+            <x:String x:Key="SortIconUnsorted">&#xe8cb;</x:String>
             <x:String x:Key="FilterIcon">&#xe71c;</x:String>
             <x:String x:Key="OptionsButtonIcon">&#xe712;</x:String>
             <x:String x:Key="SelectAllButtonIcon">&#xE936;</x:String>

--- a/src/Themes/TableViewColumnHeader.xaml
+++ b/src/Themes/TableViewColumnHeader.xaml
@@ -55,6 +55,16 @@
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="SortStates">
                                 <VisualState x:Name="Unsorted" />
+                                <VisualState x:Name="Sortable">
+                                    <VisualState.Setters>
+                                        <Setter Target="SortIcon.Visibility"
+                                                Value="Visible" />
+                                        <Setter Target="SortIcon.Glyph"
+                                                Value="{ThemeResource SortIconUnsorted}" />
+                                        <Setter Target="SortIcon.Opacity"
+                                                Value="0.5" />
+                                    </VisualState.Setters>
+                                </VisualState>
                                 <VisualState x:Name="SortAscending">
                                     <VisualState.Setters>
                                         <Setter Target="SortIcon.Visibility"

--- a/src/VisualStates.cs
+++ b/src/VisualStates.cs
@@ -161,6 +161,11 @@ internal static class VisualStates
     public const string StateSortDescending = "SortDescending";
 
     /// <summary>
+    /// Sortable (unsorted, but sortable) state
+    /// </summary>
+    public const string StateSortable = "Sortable";
+
+    /// <summary>
     /// Sort state group
     /// </summary>
     public const string GroupSort = "SortStates";

--- a/tests/TableViewSortableColumnIconTests.cs
+++ b/tests/TableViewSortableColumnIconTests.cs
@@ -1,0 +1,160 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System.Threading.Tasks;
+using WinUI.TableView.Extensions;
+
+namespace WinUI.TableView.Tests;
+
+/// <summary>
+/// Covers <see cref="TableView.ShowSortableColumnIcon"/> - the opt-in hint icon that marks a sortable
+/// column which has no active sort direction (issue #114). The feature defaults to off, must never show
+/// on a column that isn't actually sortable, and must react live to CanSort/CanSortColumns changes.
+/// </summary>
+[TestClass]
+public class TableViewSortableColumnIconTests
+{
+    [UITestMethod]
+    public void ShowSortableColumnIcon_DefaultsToFalse()
+    {
+        var tableView = new TableView();
+
+        Assert.IsFalse(tableView.ShowSortableColumnIcon);
+    }
+
+    [UITestMethod]
+    public void ShowSortableColumnIcon_CanBeSetToTrue()
+    {
+        var tableView = new TableView { ShowSortableColumnIcon = true };
+
+        Assert.IsTrue(tableView.ShowSortableColumnIcon);
+    }
+
+    [UITestMethod]
+    public async Task UnsortedSortableColumn_HidesHintIcon_WhenFeatureIsOff()
+    {
+        var (_, column) = await CreateTableViewAsync();
+
+        var sortIcon = GetSortIcon(column);
+
+        Assert.AreEqual(Visibility.Collapsed, sortIcon.Visibility);
+    }
+
+    [UITestMethod]
+    public async Task UnsortedSortableColumn_ShowsHintIcon_WhenFeatureIsOn()
+    {
+        var (tableView, column) = await CreateTableViewAsync();
+
+        tableView.ShowSortableColumnIcon = true;
+
+        var sortIcon = GetSortIcon(column);
+
+        Assert.AreEqual(Visibility.Visible, sortIcon.Visibility);
+        Assert.AreEqual("\ue8cb", sortIcon.Glyph);
+        Assert.AreEqual(0.5, sortIcon.Opacity);
+    }
+
+    [UITestMethod]
+    public async Task UnsortedNonSortableColumn_HidesHintIcon_EvenWhenFeatureIsOn()
+    {
+        var (tableView, column) = await CreateTableViewAsync();
+
+        column.CanSort = false;
+        tableView.ShowSortableColumnIcon = true;
+
+        var sortIcon = GetSortIcon(column);
+
+        Assert.AreEqual(Visibility.Collapsed, sortIcon.Visibility);
+    }
+
+    [UITestMethod]
+    public async Task SortedColumn_ShowsDirectionIcon_NotHintIcon_WhenFeatureIsOn()
+    {
+        var (tableView, column) = await CreateTableViewAsync();
+
+        tableView.ShowSortableColumnIcon = true;
+        column.SortDirection = SortDirection.Ascending;
+
+        var sortIcon = GetSortIcon(column);
+
+        Assert.AreEqual(Visibility.Visible, sortIcon.Visibility);
+        Assert.AreEqual(1d, sortIcon.Opacity, "Ascending/Descending icon should be full opacity, not the 0.5 hint opacity");
+    }
+
+    [UITestMethod]
+    public async Task TogglingCanSort_AtRuntime_UpdatesHintIconImmediately()
+    {
+        var (tableView, column) = await CreateTableViewAsync();
+        tableView.ShowSortableColumnIcon = true;
+        var sortIcon = GetSortIcon(column);
+        Assert.AreEqual(Visibility.Visible, sortIcon.Visibility, "Precondition: hint icon starts visible");
+
+        column.CanSort = false;
+
+        Assert.AreEqual(Visibility.Collapsed, sortIcon.Visibility);
+
+        column.CanSort = true;
+
+        Assert.AreEqual(Visibility.Visible, sortIcon.Visibility);
+    }
+
+    [UITestMethod]
+    public async Task TogglingCanSortColumns_AtRuntime_UpdatesHintIconImmediately()
+    {
+        var (tableView, column) = await CreateTableViewAsync();
+        tableView.ShowSortableColumnIcon = true;
+        var sortIcon = GetSortIcon(column);
+        Assert.AreEqual(Visibility.Visible, sortIcon.Visibility, "Precondition: hint icon starts visible");
+
+        tableView.CanSortColumns = false;
+
+        Assert.AreEqual(Visibility.Collapsed, sortIcon.Visibility);
+    }
+
+    [UITestMethod]
+    public async Task TogglingShowSortableColumnIcon_AtRuntime_UpdatesExistingHeader()
+    {
+        var (tableView, column) = await CreateTableViewAsync();
+        var sortIcon = GetSortIcon(column);
+        Assert.AreEqual(Visibility.Collapsed, sortIcon.Visibility, "Precondition: hint icon starts hidden by default");
+
+        tableView.ShowSortableColumnIcon = true;
+
+        Assert.AreEqual(Visibility.Visible, sortIcon.Visibility);
+    }
+
+    private static FontIcon GetSortIcon(TableViewColumn column)
+    {
+        var header = column.HeaderControl!;
+        var sortIcon = header.FindDescendant<FontIcon>(f => f.Name == "SortIcon");
+
+        Assert.IsNotNull(sortIcon, "Expected to find the header template's SortIcon FontIcon");
+
+        return sortIcon!;
+    }
+
+    private static async Task<(TableView TableView, TableViewTextColumn Column)> CreateTableViewAsync()
+    {
+        var items = new[]
+        {
+            new SortableIconTestItem { Name = "Alpha" },
+            new SortableIconTestItem { Name = "Beta" },
+        };
+
+        var tableView = new TableView();
+        var column = new TableViewTextColumn { Header = "Name", Binding = new Binding { Path = new PropertyPath(nameof(SortableIconTestItem.Name)) } };
+        tableView.Columns.Add(column);
+        tableView.ItemsSource = items;
+
+        await UnitTestApp.Current.MainWindow.LoadTestContentAsync(tableView);
+
+        return (tableView, column);
+    }
+
+    private sealed class SortableIconTestItem
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/tests/TableViewSortableColumnIconTests.cs
+++ b/tests/TableViewSortableColumnIconTests.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using System;
 using System.Threading.Tasks;
 using WinUI.TableView.Extensions;
 
@@ -125,6 +126,32 @@ public class TableViewSortableColumnIconTests
         Assert.AreEqual(Visibility.Visible, sortIcon.Visibility);
     }
 
+    [UITestMethod]
+    public async Task ShowSortableColumnIcon_SetBeforeLoad_StillAppliesOnFirstApplyTemplate()
+    {
+        var (_, column) = await CreateTableViewAsync((tableView, _) => tableView.ShowSortableColumnIcon = true);
+
+        var sortIcon = GetSortIcon(column);
+
+        Assert.AreEqual(Visibility.Visible, sortIcon.Visibility,
+            "ShowSortableColumnIcon set before the TableView loads must still be reflected once the header's template is applied");
+    }
+
+    [UITestMethod]
+    public async Task CanSortColumnsFalse_SetBeforeLoad_KeepsHintIconCollapsed()
+    {
+        var (_, column) = await CreateTableViewAsync((tableView, _) =>
+        {
+            tableView.ShowSortableColumnIcon = true;
+            tableView.CanSortColumns = false;
+        });
+
+        var sortIcon = GetSortIcon(column);
+
+        Assert.AreEqual(Visibility.Collapsed, sortIcon.Visibility,
+            "CanSortColumns=False set before the TableView loads must still be reflected once the header's template is applied");
+    }
+
     private static FontIcon GetSortIcon(TableViewColumn column)
     {
         var header = column.HeaderControl!;
@@ -135,7 +162,7 @@ public class TableViewSortableColumnIconTests
         return sortIcon!;
     }
 
-    private static async Task<(TableView TableView, TableViewTextColumn Column)> CreateTableViewAsync()
+    private static async Task<(TableView TableView, TableViewTextColumn Column)> CreateTableViewAsync(Action<TableView, TableViewTextColumn>? configure = null)
     {
         var items = new[]
         {
@@ -147,6 +174,8 @@ public class TableViewSortableColumnIconTests
         var column = new TableViewTextColumn { Header = "Name", Binding = new Binding { Path = new PropertyPath(nameof(SortableIconTestItem.Name)) } };
         tableView.Columns.Add(column);
         tableView.ItemsSource = items;
+
+        configure?.Invoke(tableView, column);
 
         await UnitTestApp.Current.MainWindow.LoadTestContentAsync(tableView);
 


### PR DESCRIPTION
## Description

Adds an opt-in `TableView.ShowSortableColumnIcon` property that shows a subtle hint icon on sortable columns that have no active sort direction, so users can tell at a glance which columns support sorting without having to click them first. The property defaults to `false`, so no existing app changes visually unless it opts in.

- New `TableView.ShowSortableColumnIcon` (bool, default `false`).
- New `Sortable` visual state on `TableViewColumnHeader`'s `SortStates` group — shows the header's sort icon at 50% opacity with a new glyph when a column is sortable but currently unsorted.
- Respects both `TableView.CanSortColumns` and the column's own `CanSort` — never shows on a non-sortable column.
- Added change-callbacks for `CanSort` and `CanSortColumns` (previously missing, unlike the equivalent `CanFilter`/`CanFilterColumns` callbacks), so the header now also reacts live if those change at runtime.
- Sample: new "Show Sortable Column Icon" toggle on the Sorting page.
- Docs: new "Showing a hint icon for sortable columns" section in `sorting.md`, plus an entry in the options table.

## Related Issue

Closes #114

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation update
- [x] 🧪 Test

## Checklist

- [x] This PR is **not** from my `main` branch
- [x] Tested with **WinUI** target
- [x] Tested with **Uno Platform** target
- [x] Unit / integration tests added or updated
- [x] Documentation updated to reflect changes
- [x] Code follows the project's coding conventions

## Screenshots / Recordings

<img width="846" height="360" alt="20260826-2203-08 3154428" src="https://github.com/user-attachments/assets/0b2357a5-d6bd-47ed-ae3d-bbbea0aac832" />

## Additional Notes

Uno target builds cleanly but wasn't run/visually verified. Worth a quick look in Visual Studio at the new glyph (`\ue8cb`) next to the existing ascending/descending icons before merging, to confirm it reads well at 10px.